### PR TITLE
Further renaming of the the rcgsheffield/iceberg_software git repo to rcgsheffield/sheffield_hpc

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
-.. image:: https://travis-ci.org/rcgsheffield/iceberg_software.svg?branch=master
-    :target: https://travis-ci.org/rcgsheffield/iceberg_software
+.. image:: https://travis-ci.org/rcgsheffield/sheffield_hpc.svg?branch=master
+    :target: https://travis-ci.org/rcgsheffield/sheffield_hpc
 
 Iceberg Documentation
 =====================

--- a/conf.py
+++ b/conf.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# iceberg Software documentation build configuration file, created by
+# sheffield_hpc documentation build configuration file, created by
 # sphinx-quickstart on Tue Mar 31 11:40:21 2015.
 #
 
@@ -80,7 +80,7 @@ html_theme_options = {'navbar_sidebarrel':False,
                       'navbar_title': ' ',
                       'navbar_links': [("RCG Home", "http://www.shef.ac.uk/cics/research", True),
                                        ("Documentation Home", "index"),
-                                       ("GitHub", "https://github.com/rcgsheffield/iceberg_software", True),
+                                       ("GitHub", "https://github.com/rcgsheffield/sheffield_hpc", True),
                                        ],
                       'globaltoc_depth': 1}
 

--- a/iceberg/software/apps/CASTEP.rst
+++ b/iceberg/software/apps/CASTEP.rst
@@ -181,10 +181,10 @@ The directory ``CASTEP-8.0`` was then deleted and the parallel version was insta
 
 Modulefiles
 -----------
-* `CASTEP 16.1-serial <https://github.com/rcgsheffield/iceberg_software/blob/master/software/modulefiles/apps/intel/15/castep/16.1-serial>`_
-* `CASTEP 16.1-parallel <https://github.com/rcgsheffield/iceberg_software/blob/master/software/modulefiles/apps/intel/15/castep/16.1-parallel>`_
-* `CASTEP 8.0-serial <https://github.com/rcgsheffield/iceberg_software/blob/master/software/modulefiles/apps/intel/15/castep/8.0-serial>`_
-* `CASTEP 8.0-parallel <https://github.com/rcgsheffield/iceberg_software/blob/master/software/modulefiles/apps/intel/15/castep/16.1-parallel>`_
+* `CASTEP 16.1-serial <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/apps/intel/15/castep/16.1-serial>`_
+* `CASTEP 16.1-parallel <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/apps/intel/15/castep/16.1-parallel>`_
+* `CASTEP 8.0-serial <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/apps/intel/15/castep/8.0-serial>`_
+* `CASTEP 8.0-parallel <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/apps/intel/15/castep/16.1-parallel>`_
 
 Testing
 -------

--- a/iceberg/software/apps/MOMFBD.rst
+++ b/iceberg/software/apps/MOMFBD.rst
@@ -21,4 +21,4 @@ The MOMFBD binaries can be added to your path with ::
 
 Installation notes
 ------------------
-MOMFBD was installed using gcc 5.2. Using `this script <https://github.com/rcgsheffield/iceberg_software/blob/master/software/install_scripts/apps/gcc/5.2/MOMFBD/install_momfbd.sh>`_ and is loaded by `this modulefle <https://github.com/rcgsheffield/iceberg_software/blob/master/software/modulefiles/apps/gcc/5.2/momfbd/2016.04.14>`_.
+MOMFBD was installed using gcc 5.2. Using `this script <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/apps/gcc/5.2/MOMFBD/install_momfbd.sh>`_ and is loaded by `this modulefle <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/apps/gcc/5.2/momfbd/2016.04.14>`_.

--- a/iceberg/software/apps/bcbio.rst
+++ b/iceberg/software/apps/bcbio.rst
@@ -63,9 +63,9 @@ These are primarily for system administrators.
 
 Version 0.9.6a was installed using gcc 5.2, R 3.2.1 and Anaconda Python 2.3. The install was performed in two parts.
 
-The first step was to run the SGE script below in batch mode. Note that the install often fails due to external services being flaky. See https://github.com/rcgsheffield/iceberg_software/issues/219 for details. Depending on the reason for the failure, it should be OK to simply restart the install. This particular install was done in one-shot...no restarts necessary.
+The first step was to run the SGE script below in batch mode. Note that the install often fails due to external services being flaky. See https://github.com/rcgsheffield/sheffield_hpc/issues/219 for details. Depending on the reason for the failure, it should be OK to simply restart the install. This particular install was done in one-shot...no restarts necessary.
 
-* `install_bcbio_0.96a <https://github.com/rcgsheffield/iceberg_software/blob/master/software/install_scripts/apps/gcc/5.2/bcbio/install_bcbio_0.96a.sge>`_
+* `install_bcbio_0.96a <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/apps/gcc/5.2/bcbio/install_bcbio_0.96a.sge>`_
 
 The output from this batch run can be found in `/usr/local/packages6/apps/gcc/5.2/bcbio/0.9.6a/install_output/`
 
@@ -97,7 +97,7 @@ As is usually the case for us, this stalled on the final STAR command. The exact
 
     STAR   --runMode genomeGenerate   --runThreadN 16   --genomeDir /usr/local/packages6/apps/gcc/5.2/bcbio/0.9.6a/genomes/Mmusculus/mm10/star   --genomeFastaFiles /usr/local/packages6/apps/gcc/5.2/bcbio/0.9.6a/genomes/Mmusculus/mm10/seq/mm10.fa      --genomeSAindexNbases 14   --genomeChrBinNbits 14
 
-This failed (see https://github.com/rcgsheffield/iceberg_software/issues/272). The fix was to add the line ::
+This failed (see https://github.com/rcgsheffield/sheffield_hpc/issues/272). The fix was to add the line ::
 
   index mm10 /usr/local/packages6/apps/gcc/5.2/bcbio/0.9.6a/genomes/Mmusculus/mm10/seq/mm10.fa
 
@@ -107,7 +107,7 @@ to the file ::
 
 Update: **14th March 2016**
 
-`Another issue <https://github.com/rcgsheffield/iceberg_software/issues/274>`_ required us to modify `/usr/local/packages6/apps/gcc/5.2/bcbio/0.9.6a/genomes/Mmusculus/mm10/seq/mm10-resources.yaml` so that it read ::
+`Another issue <https://github.com/rcgsheffield/sheffield_hpc/issues/274>`_ required us to modify `/usr/local/packages6/apps/gcc/5.2/bcbio/0.9.6a/genomes/Mmusculus/mm10/seq/mm10-resources.yaml` so that it read ::
 
   version: 16
 
@@ -140,8 +140,8 @@ Update: **14th March 2016**
 
 The development version was installed using gcc 5.2, R 3.2.1 and Anaconda Python 2.3.
 
-* `install_bcbio_devel.sge <https://github.com/rcgsheffield/iceberg_software/blob/master/software/install_scripts/apps/gcc/5.2/bcbio/install_bcbio_devel.sge>`_ This is a SGE submit script. The long running time of the installer made it better-suited to being run as a batch job.
-* `bcbio-devel modulefile <https://github.com/rcgsheffield/iceberg_software/blob/master/software/modulefiles/apps/gcc/5.2/bcbio/devel>`_ located on the system at ``/usr/local/modulefiles/apps/gcc/5.2/bcbio/devel``
+* `install_bcbio_devel.sge <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/apps/gcc/5.2/bcbio/install_bcbio_devel.sge>`_ This is a SGE submit script. The long running time of the installer made it better-suited to being run as a batch job.
+* `bcbio-devel modulefile <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/apps/gcc/5.2/bcbio/devel>`_ located on the system at ``/usr/local/modulefiles/apps/gcc/5.2/bcbio/devel``
 
 The first install attempt failed with the error ::
 
@@ -175,7 +175,7 @@ The GATK .jar file was obtained from https://www.broadinstitute.org/gatk/downloa
 Module files
 ------------
 
-* `0.9.6a <https://github.com/rcgsheffield/iceberg_software/blob/master/software/modulefiles/apps/gcc/5.2/bcbio/0.9.6a>`_
+* `0.9.6a <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/apps/gcc/5.2/bcbio/0.9.6a>`_
 
 Testing
 -------

--- a/iceberg/software/apps/bedtools.rst
+++ b/iceberg/software/apps/bedtools.rst
@@ -32,7 +32,7 @@ After that any of the bedtools commands can be run from the prompt.
 
 Installation notes
 ------------------
-bedtools was installed using gcc 5.2 with the script `install_bedtools.sh <https://github.com/rcgsheffield/iceberg_software/blob/master/software/install_scripts/apps/gcc/5.2/bedtools/install_bedtools.sh>`_
+bedtools was installed using gcc 5.2 with the script `install_bedtools.sh <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/apps/gcc/5.2/bedtools/install_bedtools.sh>`_
 
 
 Testing

--- a/iceberg/software/apps/bless.rst
+++ b/iceberg/software/apps/bless.rst
@@ -63,7 +63,7 @@ Remember that memory is allocated on a per-slot basis. You should ensure that yo
 
 Installation notes
 ------------------
-Various issues were encountered while attempting to install bless. See https://github.com/rcgsheffield/iceberg_software/issues/143 for details.
+Various issues were encountered while attempting to install bless. See https://github.com/rcgsheffield/sheffield_hpc/issues/143 for details.
 It was necessary to install gcc 4.9.2 in order to build bless. No other compiler worked!
 
 Here are the install steps ::
@@ -108,4 +108,4 @@ No test suite was found.
 Modulefile
 ----------
 * The module file is on the system at `/usr/local/modulefiles/apps/gcc/4.9.2/bless/1.02`
-* The module file is `on github <https://github.com/rcgsheffield/iceberg_software/blob/master/software/modulefiles/apps/gcc/4.9.2/bless/1.02>`_.
+* The module file is `on github <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/apps/gcc/4.9.2/bless/1.02>`_.

--- a/iceberg/software/apps/bwa.rst
+++ b/iceberg/software/apps/bwa.rst
@@ -92,9 +92,9 @@ The default version is controlled by the `.version` file at `/usr/local/modulefi
 *Version 0.7.12*
 
 * The module file is on the system at `/usr/local/modulefiles/apps/gcc/5.2/bwa/0.7.12`
-* On github: `0.7.12 <https://github.com/rcgsheffield/iceberg_software/blob/master/software/modulefiles/apps/gcc/5.2/bwa/0.7.12>`_.
+* On github: `0.7.12 <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/apps/gcc/5.2/bwa/0.7.12>`_.
 
 *Version 0.7.5a*
 
 * The module file is on the system at `/usr/local/modulefiles/apps/gcc/5.2/bwa/0.7.5a`
-* On github: `0.7.5a <https://github.com/rcgsheffield/iceberg_software/blob/master/software/modulefiles/apps/gcc/5.2/bwa/0.7.5a>`_.
+* On github: `0.7.5a <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/apps/gcc/5.2/bwa/0.7.5a>`_.

--- a/iceberg/software/apps/code_saturne_4.0.rst
+++ b/iceberg/software/apps/code_saturne_4.0.rst
@@ -112,9 +112,9 @@ Post Install Steps
 ------------------
 To make Code Saturne aware of the SGE system:
 
-* Created ``/usr/local/packages6/apps/gcc/4.4.7/code_saturne/4.0/etc/code_saturne.cfg``: See `code_saturne.cfg 4.0 <https://github.com/rcgsheffield/iceberg_software/blob/master/software/apps/assets/code_saturne/4.0/code_saturne.cfg>`_
+* Created ``/usr/local/packages6/apps/gcc/4.4.7/code_saturne/4.0/etc/code_saturne.cfg``: See `code_saturne.cfg 4.0 <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/apps/assets/code_saturne/4.0/code_saturne.cfg>`_
 
-* Modified ``/usr/local/packages6/apps/gcc/4.4.7/code_saturne/4.0/share/code_saturne/batch/batch.SGE``. See: `batch.SGE 4.0 <https://github.com/rcgsheffield/iceberg_software/blob/master/software/apps/assets/code_saturne/4.0/batch.SGE>`_
+* Modified ``/usr/local/packages6/apps/gcc/4.4.7/code_saturne/4.0/share/code_saturne/batch/batch.SGE``. See: `batch.SGE 4.0 <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/apps/assets/code_saturne/4.0/batch.SGE>`_
 
 Testing
 -------

--- a/iceberg/software/apps/ctffind.rst
+++ b/iceberg/software/apps/ctffind.rst
@@ -23,7 +23,7 @@ Installation notes
 These are primarily for system administrators.
 
 * ctffind was installed using the gcc 4.4.7 compiler
-* `install_ctffind.sh <https://github.com/rcgsheffield/iceberg_software/blob/master/software/install_scripts/apps/gcc/4.4.7/ctffind/3.140609/install_ctffind.sh>`_
+* `install_ctffind.sh <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/apps/gcc/4.4.7/ctffind/3.140609/install_ctffind.sh>`_
 
 
 Modulefile

--- a/iceberg/software/apps/ffmpeg.rst
+++ b/iceberg/software/apps/ffmpeg.rst
@@ -62,4 +62,4 @@ All tests passed.
 Modulefile
 ----------
 * The module file is on the system at `/usr/local/modulefiles/apps/gcc/5.2/ffmpeg/2.8.3`
-* The module file is `on github <https://github.com/rcgsheffield/iceberg_software/blob/master/software/modulefiles/apps/gcc/5.2/ffmpeg/2.8.3>`_.
+* The module file is `on github <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/apps/gcc/5.2/ffmpeg/2.8.3>`_.

--- a/iceberg/software/apps/freesurfer.rst
+++ b/iceberg/software/apps/freesurfer.rst
@@ -42,7 +42,7 @@ The following were tried ::
 
 Installation notes
 ------------------
-These are primarily for administrators of the system. The github issue for the original install request is at https://github.com/rcgsheffield/iceberg_software/issues/164
+These are primarily for administrators of the system. The github issue for the original install request is at https://github.com/rcgsheffield/sheffield_hpc/issues/164
 
 Freesurfer was installed as follows ::
 

--- a/iceberg/software/apps/gemini.rst
+++ b/iceberg/software/apps/gemini.rst
@@ -23,14 +23,14 @@ Installation notes
 These are primarily for system administrators.
 
 * gemini was installed using the gcc 4.4.7 compiler
-* `install_gemini.sh <https://github.com/rcgsheffield/iceberg_software/blob/master/software/install_scripts/apps/gcc/4.4.7/gemini/0.18/install_gemini.sh>`_
+* `install_gemini.sh <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/apps/gcc/4.4.7/gemini/0.18/install_gemini.sh>`_
 
 
 Testing
 -------
 The test script used was
 
-* `test_gemini.sh <https://github.com/rcgsheffield/iceberg_software/blob/master/software/test_scripts/apps/gcc/4.4.7/gemini/0.18/test_gemini.sh>`_
+* `test_gemini.sh <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/test_scripts/apps/gcc/4.4.7/gemini/0.18/test_gemini.sh>`_
 
 The full output from the test run is on the system at `/usr/local/packages6/apps/gcc/4.4.7/gemini/0.18/test_results/`
 

--- a/iceberg/software/apps/gromacs.rst
+++ b/iceberg/software/apps/gromacs.rst
@@ -34,4 +34,4 @@ Compilation Choices:
 * -DGMX_BUILD_OWN_FFTW=ON
 
 The script used to build gromacs can be found `here
-<https://github.com/rcgsheffield/iceberg_software/blob/master/software/install_scripts/apps/gromacs/install_gromacs_5.1.sh>`_.
+<https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/apps/gromacs/install_gromacs_5.1.sh>`_.

--- a/iceberg/software/apps/htop.rst
+++ b/iceberg/software/apps/htop.rst
@@ -40,4 +40,4 @@ No test suite was found.
 Modulefile
 ----------
 * The module file is on the system at `/usr/local/modulefiles/apps/gcc/4.4.7/htop/2.0`
-* The module file is `on github <https://github.com/rcgsheffield/iceberg_software/blob/master/software/modulefiles/apps/gcc/4.4.7/htop/2.0>`_.
+* The module file is `on github <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/apps/gcc/4.4.7/htop/2.0>`_.

--- a/iceberg/software/apps/imagej.rst
+++ b/iceberg/software/apps/imagej.rst
@@ -40,7 +40,7 @@ Links to documentation can be found at http://imagej.nih.gov/ij/download.html
 
 Installation notes
 ------------------
-Install version 1.49 using the `install_imagej.sh <https://github.com/rcgsheffield/iceberg_software/blob/master/software/install_scripts/apps/imagej/1.50g/install_imagej.sh>`_ script
+Install version 1.49 using the `install_imagej.sh <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/apps/imagej/1.50g/install_imagej.sh>`_ script
 
 Run the GUI and update to the latest version by clicking on `Help > Update ImageJ`
 
@@ -51,7 +51,7 @@ Modify the `imagej` script so that it reads ::
     java -Xmx512m -jar -Dplugins.dir=/usr/local/packages6/apps/binapps/imagej/1.50g/plugins/ /usr/local/packages6/apps/binapps/imagej/1.50g/ij.jar
 
 ImageJ's 3D plugin requires Java 3D which needs to be included in the JRE used by imagej.
-I attempted a module-controlled version of Java3D but the plugin refused to recognise it. See https://github.com/rcgsheffield/iceberg_software/issues/279 for details.
+I attempted a module-controlled version of Java3D but the plugin refused to recognise it. See https://github.com/rcgsheffield/sheffield_hpc/issues/279 for details.
 
 The plug-in will install Java3D within the JRE for you if you launch it and click **Plugins>3D>3D Viewer**
 

--- a/iceberg/software/apps/mathematica.rst
+++ b/iceberg/software/apps/mathematica.rst
@@ -198,5 +198,5 @@ Install the University network ``mathpass`` file at ``/usr/local/packages6/apps/
 
 Modulefiles
 -----------
-* The `10.3.1 module file  <https://github.com/rcgsheffield/iceberg_software/blob/master/software/modulefiles/apps/binapps/mathematica/10.3.1>`_.
-* The `10.2 module file  <https://github.com/rcgsheffield/iceberg_software/blob/master/software/modulefiles/apps/binapps/mathematica/10.2>`_.
+* The `10.3.1 module file  <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/apps/binapps/mathematica/10.3.1>`_.
+* The `10.2 module file  <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/apps/binapps/mathematica/10.2>`_.

--- a/iceberg/software/apps/octave.rst
+++ b/iceberg/software/apps/octave.rst
@@ -80,7 +80,7 @@ Octave was installed using gcc 5.2 and the following libraries:
 * :ref:`fltk` 1.3.3
 * :ref:`fftw` 3.3.4
 
-* Octave was installed using a SGE batch job. The install script is on `github <https://github.com/rcgsheffield/iceberg_software/blob/master/software/install_scripts/apps/gcc/5.2/octave/install_octave.sh>`_
+* Octave was installed using a SGE batch job. The install script is on `github <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/apps/gcc/5.2/octave/install_octave.sh>`_
 * The make log is on the system at `/usr/local/packages6/apps/gcc/5.2/octave/4.0/make_octave4.0.0.log`
 * The configure log is on the system at `/usr/local/packages6/apps/gcc/5.2/octave/4.0/configure_octave4.0.0.log`
 
@@ -276,4 +276,4 @@ For information, here is the relevant part of the Configure log that describes h
 Module File
 -----------
 
-The module file is `octave_4.0 <https://github.com/rcgsheffield/iceberg_software/blob/master/software/modulefiles/apps/gcc/5.2/octave/4.0>`_
+The module file is `octave_4.0 <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/apps/gcc/5.2/octave/4.0>`_

--- a/iceberg/software/apps/openfoam.rst
+++ b/iceberg/software/apps/openfoam.rst
@@ -31,6 +31,6 @@ Installation notes
 ------------------
 
 OpenFoam was compiled using the
-`install_openfoam.sh <https://github.com/rcgsheffield/iceberg_software/blob/master/software/install_scripts/apps/gcc/5.2/openfoam/install_openfoam.sh>`_ script, the module
+`install_openfoam.sh <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/apps/gcc/5.2/openfoam/install_openfoam.sh>`_ script, the module
 file is
-`3.0.0 <https://github.com/rcgsheffield/iceberg_software/blob/master/software/install_scripts/apps/gcc/5.2/openfoam/3.0.0>`_.
+`3.0.0 <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/apps/gcc/5.2/openfoam/3.0.0>`_.

--- a/iceberg/software/apps/phyluce.rst
+++ b/iceberg/software/apps/phyluce.rst
@@ -31,4 +31,4 @@ As root::
   $ source activate /usr/local/packages6/apps/binapps/conda/phyluce
   $ conda install -c https://conda.binstar.org/faircloth-lab phyluce
 
-This installs Phyluce as a conda environment in the /usr/local/packages6/apps/binapps/conda/phyluce folder, which is then loaded by the module file `phyluce/1.5.0 <https://github.com/rcgsheffield/iceberg_software/blob/master/software/modulefiles/apps/binapps/phyluce/1.5.0>`_, which is a modification of the anaconda module files.
+This installs Phyluce as a conda environment in the /usr/local/packages6/apps/binapps/conda/phyluce folder, which is then loaded by the module file `phyluce/1.5.0 <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/apps/binapps/phyluce/1.5.0>`_, which is a modification of the anaconda module files.

--- a/iceberg/software/apps/povray.rst
+++ b/iceberg/software/apps/povray.rst
@@ -39,7 +39,7 @@ Installation notes
 ------------------
 povray 3.7.0 was installed using gcc 5.2 using the following script 
 
-* `install_povray-3.7.sh <https://github.com/rcgsheffield/iceberg_software/blob/master/software/install_scripts/apps/gcc/5.2/povray/0.37/install_povray-3.7.sh>`_
+* `install_povray-3.7.sh <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/apps/gcc/5.2/povray/0.37/install_povray-3.7.sh>`_
 
 Testing
 -------
@@ -52,4 +52,4 @@ All tests passed.
 Modulefile
 ----------
 * The module file is on the system at `/usr/local/modulefiles/apps/gcc/5.2/povray/3.7`
-* The module file is `on github <https://github.com/rcgsheffield/iceberg_software/blob/master/software/modulefiles/apps/gcc/5.2/povray/3.7>`_.
+* The module file is `on github <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/apps/gcc/5.2/povray/3.7>`_.

--- a/iceberg/software/apps/r.rst
+++ b/iceberg/software/apps/r.rst
@@ -153,8 +153,8 @@ This was a scripted install. It was compiled from source with gcc 4.4.7 and with
 
 This build required several external modules including :ref:`xzutils`, :ref:`curl`, :ref:`bzip2` and :ref:`zlib`
 
-* `install_R_3.3.0.sh <https://github.com/rcgsheffield/iceberg_software/blob/master/software/install_scripts/apps/R/install_R_3.3.0.sh>`_ Downloads, compiles, tests and installs R 3.3.0 and the ``Rmath`` library.
-* `R 3.3.0 Modulefile <https://github.com/rcgsheffield/iceberg_software/blob/master/software/modulefiles/apps/R/3.3.0>`_ located on the system at ``/usr/local/modulefiles/apps/R/3.3.0``
+* `install_R_3.3.0.sh <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/apps/R/install_R_3.3.0.sh>`_ Downloads, compiles, tests and installs R 3.3.0 and the ``Rmath`` library.
+* `R 3.3.0 Modulefile <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/apps/R/3.3.0>`_ located on the system at ``/usr/local/modulefiles/apps/R/3.3.0``
 * Install log-files, including the output of the `make check` tests are available on the system at `/usr/local/packages6/R/3.3.0/install_logs`
 
 **Version 3.2.4**
@@ -165,8 +165,8 @@ This was a scripted install. It was compiled from source with gcc 4.4.7 and with
 
 This build made use of new versions of :ref:`xzutils` and :ref:`curl`
 
-* `install_R_3.2.4.sh <https://github.com/rcgsheffield/iceberg_software/blob/master/software/install_scripts/apps/R/install_R_3.2.4.sh>`_ Downloads, compiles, tests and installs R 3.2.4 and the ``Rmath`` library.
-* `R 3.2.4 Modulefile <https://github.com/rcgsheffield/iceberg_software/blob/master/software/modulefiles/apps/R/3.2.4>`_ located on the system at ``/usr/local/modulefiles/apps/R/3.2.4``
+* `install_R_3.2.4.sh <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/apps/R/install_R_3.2.4.sh>`_ Downloads, compiles, tests and installs R 3.2.4 and the ``Rmath`` library.
+* `R 3.2.4 Modulefile <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/apps/R/3.2.4>`_ located on the system at ``/usr/local/modulefiles/apps/R/3.2.4``
 * Install log-files, including the output of the `make check` tests are available on the system at `/usr/local/packages6/R/3.2.4/install_logs`
 
 **Version 3.2.3**
@@ -175,8 +175,8 @@ This build made use of new versions of :ref:`xzutils` and :ref:`curl`
 
 This was a scripted install. It was compiled from source with gcc 4.4.7 and with ``--enable-R-shlib`` enabled. You will need a large memory ``qrsh`` session in order to successfully run the build script. I used ``qrsh -l rmem=8G -l mem=16G``
 
-* `install_R_3.2.3.sh <https://github.com/rcgsheffield/iceberg_software/blob/master/software/install_scripts/apps/R/install_R_3.2.3.sh>`_ Downloads, compiles, tests and installs R 3.2.3 and the ``Rmath`` library.
-* `R 3.2.3 Modulefile <https://github.com/rcgsheffield/iceberg_software/blob/master/software/modulefiles/apps/R/3.2.3>`_ located on the system at ``/usr/local/modulefiles/apps/R/3.2.3``
+* `install_R_3.2.3.sh <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/apps/R/install_R_3.2.3.sh>`_ Downloads, compiles, tests and installs R 3.2.3 and the ``Rmath`` library.
+* `R 3.2.3 Modulefile <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/apps/R/3.2.3>`_ located on the system at ``/usr/local/modulefiles/apps/R/3.2.3``
 * Install log-files, including the output of the `make check` tests are available on the system at `/usr/local/packages6/R/3.2.3/install_logs`
 
 **Version 3.2.2**
@@ -185,16 +185,16 @@ This was a scripted install. It was compiled from source with gcc 4.4.7 and with
 
 This was a scripted install. It was compiled from source with gcc 4.4.7 and with ``--enable-R-shlib`` enabled. You will need a large memory ``qrsh`` session in order to successfully run the build script. I used ``qrsh -l rmem=8G -l mem=16G``
 
-* `install_R_3.2.2.sh <https://github.com/rcgsheffield/iceberg_software/blob/master/software/install_scripts/apps/R/install_R_3.2.2.sh>`_ Downloads, compiles and installs R 3.2.2 and the ``Rmath`` library.
-* `R 3.2.2 Modulefile <https://github.com/rcgsheffield/iceberg_software/blob/master/software/modulefiles/apps/R/3.2.2>`_ located on the system at ``/usr/local/modulefiles/apps/R/3.2.2``
+* `install_R_3.2.2.sh <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/apps/R/install_R_3.2.2.sh>`_ Downloads, compiles and installs R 3.2.2 and the ``Rmath`` library.
+* `R 3.2.2 Modulefile <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/apps/R/3.2.2>`_ located on the system at ``/usr/local/modulefiles/apps/R/3.2.2``
 * Install log-files were manually copied to ``/usr/local/packages6/R/3.2.2/install_logs`` on the system. This step should be included in the next version of the install script.
 
 **Version 3.2.1**
 
 This was a manual install. It was compiled from source with gcc 4.4.7 and with ``--enable-R-shlib`` enabled.
 
-* `Install notes <https://github.com/rcgsheffield/iceberg_software/blob/master/software/install_scripts/apps/R/R-3.2.1.md>`_
-* `R 3.2.1 Modulefile <https://github.com/rcgsheffield/iceberg_software/blob/master/software/modulefiles/apps/R/3.2.1>`_ located on the system at ``/usr/local/modulefiles/apps/R/3.2.1``
+* `Install notes <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/apps/R/R-3.2.1.md>`_
+* `R 3.2.1 Modulefile <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/apps/R/3.2.1>`_ located on the system at ``/usr/local/modulefiles/apps/R/3.2.1``
 
 **Older versions**
 

--- a/iceberg/software/apps/relion.rst
+++ b/iceberg/software/apps/relion.rst
@@ -25,7 +25,7 @@ These are primarily for system administrators.
 Install instructions: http://www2.mrc-lmb.cam.ac.uk/relion/index.php/Download_%26_install
 
 * RELION was installed using the gcc 4.4.7 compiler and Openmpi 1.8.8
-* `install_relion.sh <https://github.com/rcgsheffield/iceberg_software/blob/master/software/install_scripts/apps/gcc/4.4.7/relion/1.4/install_relion.sh>`_
+* `install_relion.sh <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/apps/gcc/4.4.7/relion/1.4/install_relion.sh>`_
 * Note - the environment variable RELION_QSUB_TEMPLATE points to an SGE qsub template, which needs customizing to work with our environment
 
 Modulefile

--- a/iceberg/software/apps/samtools.rst
+++ b/iceberg/software/apps/samtools.rst
@@ -84,4 +84,4 @@ The full log is on the system at `/usr/local/packages6/apps/gcc/5.2/samtools/1.2
 Modulefile
 ----------
 * The module file is on the system at `/usr/local/modulefiles/apps/gcc/5.2/samtools/1.2`
-* The module file is `on github <https://github.com/rcgsheffield/iceberg_software/blob/master/software/modulefiles/apps/gcc/5.2/samtools/1.2>`_.
+* The module file is `on github <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/apps/gcc/5.2/samtools/1.2>`_.

--- a/iceberg/software/apps/su2.rst
+++ b/iceberg/software/apps/su2.rst
@@ -24,4 +24,4 @@ Installation notes
 ------------------
 
 Su2 was compiled using the
-`install_su2.sh <https://github.com/rcgsheffield/iceberg_software/blob/master/software/install_scripts/apps/gcc/4.4.7/su2/install_su2.sh>`_ script. SU2 also has it's own version of CGNS which was compiled with the script `install_cgns.sh <https://github.com/rcgsheffield/iceberg_software/blob/master/software/install_scripts/apps/gcc/4.4.7/su2/install_cgns.sh>`_. The module file is `4.1.0 <https://github.com/rcgsheffield/iceberg_software/blob/master/software/modulefiles/apps/gcc/4.4.7/su2/4.1.0>`_.
+`install_su2.sh <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/apps/gcc/4.4.7/su2/install_su2.sh>`_ script. SU2 also has it's own version of CGNS which was compiled with the script `install_cgns.sh <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/apps/gcc/4.4.7/su2/install_cgns.sh>`_. The module file is `4.1.0 <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/apps/gcc/4.4.7/su2/4.1.0>`_.

--- a/iceberg/software/apps/tophat.rst
+++ b/iceberg/software/apps/tophat.rst
@@ -24,7 +24,7 @@ This command makes the tophat binary available to your session.
 
 Installation notes
 ------------------
-Tophat 2.1.0 was installed using gcc 4.8.2. Installs were attempted using gcc 5.2 and gcc 4.4.7 but both failed (see `this issue on github <https://github.com/rcgsheffield/iceberg_software/issues/153>`_ )
+Tophat 2.1.0 was installed using gcc 4.8.2. Installs were attempted using gcc 5.2 and gcc 4.4.7 but both failed (see `this issue on github <https://github.com/rcgsheffield/sheffield_hpc/issues/153>`_ )
 
 This install has dependencies on the following
 
@@ -63,9 +63,9 @@ Testing
 -------
 A test script was executed based on the documentation `on the tophat website <https://ccb.jhu.edu/software/tophat/tutorial.shtml>`_ (retrieved 29th October 2015). It only proves that the code can run without error, not that the result is correct.
 
-* `tophat_test.sh  <https://github.com/rcgsheffield/iceberg_software/blob/master/software/install_scripts/apps/tophat/tests/tophat_test.sh>`_
+* `tophat_test.sh  <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/apps/tophat/tests/tophat_test.sh>`_
 
 Modulefile
 ----------
 * The module file is on the system at `/usr/local/modulefiles/apps/gcc/4.8.2/tophat/2.1.0`
-* The module file is `on github <https://github.com/rcgsheffield/iceberg_software/blob/master/software/modulefiles/apps/gcc/4.8.2/tophat/2.1.0>`_.
+* The module file is `on github <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/apps/gcc/4.8.2/tophat/2.1.0>`_.

--- a/iceberg/software/apps/vcftools.rst
+++ b/iceberg/software/apps/vcftools.rst
@@ -29,6 +29,6 @@ Installation notes
 ------------------
 
 VCFtools was compiled using the
-`install_vcftools.sh <https://github.com/rcgsheffield/iceberg_software/blob/master/software/install_scripts/apps/gcc/5.2/vcftools/install_vcftools.sh>`_ script, the module
+`install_vcftools.sh <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/apps/gcc/5.2/vcftools/install_vcftools.sh>`_ script, the module
 file is
-`0.1.14 <https://github.com/rcgsheffield/iceberg_software/blob/master/software/install_scripts/apps/gcc/5.2/vcftools/0.1.14>`_.
+`0.1.14 <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/apps/gcc/5.2/vcftools/0.1.14>`_.

--- a/iceberg/software/compilers/gcc.rst
+++ b/iceberg/software/compilers/gcc.rst
@@ -55,12 +55,12 @@ These notes are primarily for system administrators
 
 * gcc version 5.2 was installed using :
 
-  * `install_gcc_5.2.sh <https://github.com/rcgsheffield/iceberg_software/blob/master/software/install_scripts/compilers/gcc/install_gcc_5.2.sh>`_
-  * `gcc 5.2 modulefile <https://github.com/rcgsheffield/iceberg_software/blob/master/software/modulefiles/compilers/gcc/5.2>`_ located on the system at ``/usr/local/modulefiles/compilers/gcc/5.2``
+  * `install_gcc_5.2.sh <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/compilers/gcc/install_gcc_5.2.sh>`_
+  * `gcc 5.2 modulefile <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/compilers/gcc/5.2>`_ located on the system at ``/usr/local/modulefiles/compilers/gcc/5.2``
 
 * gcc version 4.9.2 was installed using :
 
-  * `install_gcc_4.9.2.sh <https://github.com/rcgsheffield/iceberg_software/blob/master/software/install_scripts/compilers/gcc/install_gcc_5.9.2.sh>`_
-  * `gcc 4.9.2 modulefile <https://github.com/rcgsheffield/iceberg_software/blob/master/software/modulefiles/compilers/gcc/4.9.2>`_ located on the system at ``/usr/local/modulefiles/compilers/gcc/4.9.2``
+  * `install_gcc_4.9.2.sh <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/compilers/gcc/install_gcc_5.9.2.sh>`_
+  * `gcc 4.9.2 modulefile <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/compilers/gcc/4.9.2>`_ located on the system at ``/usr/local/modulefiles/compilers/gcc/4.9.2``
 
 * Installation notes for versions 4.8.2 and below are not available.

--- a/iceberg/software/compilers/git.rst
+++ b/iceberg/software/compilers/git.rst
@@ -24,5 +24,5 @@ Installation notes
 ------------------
 Version 2.5 of git was installed using gcc 5.2 using the following install script and module file:
 
-* `install_git_2.5.sh <https://github.com/rcgsheffield/iceberg_software/blob/master/software/install_scripts/apps/git/install_git_5.2.s://github.com/rcgsheffield/iceberg_software/blob/master/software/install_scripts/apps/git/install_git_2.5.sh>`_
-* `git 2.5 modulefile <https://github.com/rcgsheffield/iceberg_software/blob/master/software/modulefiles/apps/git/2.5>`_ located on the system at ``/usr/local/modulefiles/compilers/git/2.5``
+* `install_git_2.5.sh <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/apps/git/install_git_5.2.s://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/apps/git/install_git_2.5.sh>`_
+* `git 2.5 modulefile <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/apps/git/2.5>`_ located on the system at ``/usr/local/modulefiles/compilers/git/2.5``

--- a/iceberg/software/compilers/intel.rst
+++ b/iceberg/software/compilers/intel.rst
@@ -63,7 +63,7 @@ The following notes are primarily for system administrators.
   * The license file is at ``/usr/local/packages6/compilers/intel/license.lic``
   * The environment variable ``INTEL_LICENSE_FILE`` is set by the environment module and points to the license file location
   * Download the files ``l_ccompxe_2015.3.187.tgz`` (C/C++) and ``l_fcompxe_2015.3.187.tgz`` (Fortran) from Intel Portal.
-  * Put the above .tgz files in the same directory as `install_intel15.sh <https://github.com/rcgsheffield/iceberg_software/blob/master/software/install_scripts/compilers/intel/2015.3/install_intel15.sh>`_ and `silent_master.cfg <https://github.com/rcgsheffield/iceberg_software/blob/master/software/install_scripts/compilers/intel/2015.3/silent_master.cfg>`_
+  * Put the above .tgz files in the same directory as `install_intel15.sh <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/compilers/intel/2015.3/install_intel15.sh>`_ and `silent_master.cfg <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/compilers/intel/2015.3/silent_master.cfg>`_
   * Run ``install_intel15.sh``
   * To find what was required in the module file, I did ::
 
@@ -72,7 +72,7 @@ The following notes are primarily for system administrators.
      env > after_intel.env
      diff base.env after_intel.env
 
-  * The `module file <https://github.com/rcgsheffield/iceberg_software/blob/master/software/modulefiles/compilers/intel/15.0.3>`_ is on iceberg at ``/usr/local/modulefiles/compilers/intel/15.0.3``
+  * The `module file <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/compilers/intel/15.0.3>`_ is on iceberg at ``/usr/local/modulefiles/compilers/intel/15.0.3``
 
 version 14 and below
 ~~~~~~~~~~~~~~~~~~~~

--- a/iceberg/software/libs/cfitsio.rst
+++ b/iceberg/software/libs/cfitsio.rst
@@ -25,5 +25,5 @@ to the include directory.
 Installation notes
 ------------------
 This section is primarily for administrators of the system. CFITSIO 3.380 was compiled with gcc 5.2.
-The compilation used this `script <https://github.com/rcgsheffield/iceberg_software/blob/master/software/install_scripts/libs/gcc/>`_ and it is loaded with this `modulefile
+The compilation used this `script <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/libs/gcc/>`_ and it is loaded with this `modulefile
 <https://github.com/mikecroucher/iceberg_software/blob/master/software/modulefiles/libs/gcc/5.2/cfitsio/3.380>`_ .

--- a/iceberg/software/libs/cuda.rst
+++ b/iceberg/software/libs/cuda.rst
@@ -79,4 +79,4 @@ No install notes are available
 Module Files
 ------------
 * The module file is on the system at ``/usr/local/modulefiles/libs/cuda/7.5.18``
-* The module file is `on github <https://github.com/rcgsheffield/iceberg_software/blob/master/software/modulefiles/libs/binlibs/cuda/7.5.18>`_.
+* The module file is `on github <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/libs/binlibs/cuda/7.5.18>`_.

--- a/iceberg/software/libs/curl.rst
+++ b/iceberg/software/libs/curl.rst
@@ -46,5 +46,5 @@ This section is primarily for administrators of the system.
 
 Curl 7.47.1 was compiled with gcc 4.47
 
-* Install script: `install_curl_7.47.1.sh <https://github.com/rcgsheffield/iceberg_software/blob/master/software/install_scripts/libs/gcc/4.4.7/curl/nstall_curl_7.47.1.sh>`_
-* Module file: `7.47.1 <https://github.com/rcgsheffield/iceberg_software/blob/master/software/modulefiles/libs/gcc/4.4.7/curl/7.47.1>`_
+* Install script: `install_curl_7.47.1.sh <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/libs/gcc/4.4.7/curl/nstall_curl_7.47.1.sh>`_
+* Module file: `7.47.1 <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/libs/gcc/4.4.7/curl/7.47.1>`_

--- a/iceberg/software/libs/hdf5.rst
+++ b/iceberg/software/libs/hdf5.rst
@@ -66,8 +66,8 @@ This section is primarily for administrators of the system.
 
 **Version 1.8.16 built using GCC Compiler, with seperate ZLIB and SZIP**
 
-* `install_hdf5.sh   <https://github.com/rcgsheffield/iceberg_software/blob/master/software/install_scripts/libs/gcc/4.4.7/hdf5/install_hdf5.sh>`_ Install script
-* `1.8.16   <https://github.com/rcgsheffield/iceberg_software/blob/master/software/modulefiles/libs/gcc/hdf5/1.8.16>`_
+* `install_hdf5.sh   <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/libs/gcc/4.4.7/hdf5/install_hdf5.sh>`_ Install script
+* `1.8.16   <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/libs/gcc/hdf5/1.8.16>`_
 
 **Version 1.8.15-patch1 built using PGI Compiler**
 
@@ -76,7 +76,7 @@ Here are the build details for the module `libs/hdf5/pgi/1.8.15-patch1`
 Compiled using PGI 15.7 and OpenMPI 1.8.8
 
 * `install_pgi_hdf5_1.8.15-patch1.sh   <https://github.com/rcgsheffield/blob/master/software/install_scripts/libs/pgi/hdf5/install_pgi_hdf5_1.8.15-patch1.sh>`_ Install script
-* `Modulefile <https://github.com/rcgsheffield/iceberg_software/blob/master/software/modulefiles/libs/pgi/hdf5/1.8.15-patch1>`_ located on the system at ``/usr/local/modulefiles/libs/hdf5/pgi/1.8.15-patch1``
+* `Modulefile <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/libs/pgi/hdf5/1.8.15-patch1>`_ located on the system at ``/usr/local/modulefiles/libs/hdf5/pgi/1.8.15-patch1``
 
 **gcc versions**
 

--- a/iceberg/software/libs/nagfortran.rst
+++ b/iceberg/software/libs/nagfortran.rst
@@ -125,4 +125,4 @@ Module Files
 **fll6i25dcl**
 
 * The module file is on the system at ``/usr/local/modulefiles/libs/intel/15/NAG/fll6i25dcl``
-* The module file is `on github <https://github.com/rcgsheffield/iceberg_software/blob/master/software/modulefiles/libs/intel/15/NAG/fll6i25dcl>`_.
+* The module file is `on github <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/libs/intel/15/NAG/fll6i25dcl>`_.

--- a/iceberg/software/libs/netcdf-fortran.rst
+++ b/iceberg/software/libs/netcdf-fortran.rst
@@ -28,5 +28,5 @@ This section is primarily for administrators of the system.
 
 **Version 4.4.3**
 
-* `install_gcc_netcdf-fortran_4.4.3.sh  <https://github.com/rcgsheffield/iceberg_software/blob/master/software/install_scripts/libs/gcc/4.4.7/netcdf-fortran/install_gcc_netcdf-fortran_4.4.3.sh>`_ Install script
+* `install_gcc_netcdf-fortran_4.4.3.sh  <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/libs/gcc/4.4.7/netcdf-fortran/install_gcc_netcdf-fortran_4.4.3.sh>`_ Install script
 * `Modulefile <https://github.com/mikecroucher/iceberg_software/blob/master/software/modulefiles/libs/gcc/4.4.7/openmpi/1.10.1/netcdf-fortran/4.4.3>`_.

--- a/iceberg/software/libs/netcdf_pgi.rst
+++ b/iceberg/software/libs/netcdf_pgi.rst
@@ -29,6 +29,6 @@ This section is primarily for administrators of the system.
 
 Compiled using PGI 15.7, OpenMPI 1.8.8 and HDF5 1.8.15-patch1
 
-* `install_pgi_netcdf_4.3.3.1.sh  <https://github.com/rcgsheffield/iceberg_software/blob/master/software/install_scripts/libs/pgi/netcdf/install_pgi_netcdf_4.3.3.1.sh>`_ Install script
+* `install_pgi_netcdf_4.3.3.1.sh  <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/libs/pgi/netcdf/install_pgi_netcdf_4.3.3.1.sh>`_ Install script
 * Install logs are on the system at ``/usr/local/packages6/libs/pgi/netcdf/4.3.3.1/install_logs``
 * `Modulefile <https://github.com/mikecroucher/iceberg_software/blob/master/software/modulefiles/libs/pgi/netcdf/4.3.3.1>`_ located on the system at ``ls /usr/local/modulefiles/libs/pgi/netcdf/4.3.3.1``

--- a/iceberg/software/libs/scotch.rst
+++ b/iceberg/software/libs/scotch.rst
@@ -21,6 +21,6 @@ To make this library available, run the following module command ::
 
 Installation notes
 ------------------
-This section is primarily for administrators of the system. SCOTCH 6.0.4 was compiled with gcc 5.2 using the bash file `install_scotch.sh <https://github.com/rcgsheffield/iceberg_software/blob/master/software/install_scripts/libs/gcc/5.2/install_scotch.sh>`_
+This section is primarily for administrators of the system. SCOTCH 6.0.4 was compiled with gcc 5.2 using the bash file `install_scotch.sh <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/libs/gcc/5.2/install_scotch.sh>`_
 
 

--- a/iceberg/software/mpi/openmpi-gcc.rst
+++ b/iceberg/software/mpi/openmpi-gcc.rst
@@ -33,19 +33,19 @@ These are primarily for administrators of the system.
 
 Compiled using gcc 4.4.7.
 
-* `install_openMPI_1.10.1.sh  <https://github.com/rcgsheffield/iceberg_software/blob/master/software/install_scripts/mpi/gcc/openmpi/install_gcc_openMPI_1.10.1.sh>`_ Downloads, compiles and installs OpenMPI 1.10.0 using the system gcc.
-* `Modulefile 1.10.1 <https://github.com/rcgsheffield/iceberg_software/blob/master/software/modulefiles/mpi/gcc/openmpi/1.10.1>`_ located on the system at ``/usr/local/modulefiles/mpi/gcc/openmpi/1.10.1``
+* `install_openMPI_1.10.1.sh  <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/mpi/gcc/openmpi/install_gcc_openMPI_1.10.1.sh>`_ Downloads, compiles and installs OpenMPI 1.10.0 using the system gcc.
+* `Modulefile 1.10.1 <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/mpi/gcc/openmpi/1.10.1>`_ located on the system at ``/usr/local/modulefiles/mpi/gcc/openmpi/1.10.1``
 
 **Version 1.10.0**
 
 Compiled using gcc 4.4.7.
 
-* `install_openMPI_1.10.0.sh  <https://github.com/rcgsheffield/iceberg_software/blob/master/software/install_scripts/mpi/gcc/openmpi/install_gcc_openMPI_1.10.0.sh>`_ Downloads, compiles and installs OpenMPI 1.10.0 using the system gcc.
-* `Modulefile 1.10 <https://github.com/rcgsheffield/iceberg_software/blob/master/software/modulefiles/mpi/gcc/openmpi/1.10.0>`_ located on the system at ``/usr/local/modulefiles/mpi/gcc/openmpi/1.10.0``
+* `install_openMPI_1.10.0.sh  <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/mpi/gcc/openmpi/install_gcc_openMPI_1.10.0.sh>`_ Downloads, compiles and installs OpenMPI 1.10.0 using the system gcc.
+* `Modulefile 1.10 <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/mpi/gcc/openmpi/1.10.0>`_ located on the system at ``/usr/local/modulefiles/mpi/gcc/openmpi/1.10.0``
 
 **Version 1.8.8**
 
 Compiled using gcc 4.4.7.
 
-* `install_openMPI.sh  <https://github.com/rcgsheffield/iceberg_software/blob/master/software/install_scripts/mpi/gcc/openmpi/install_gcc_openMPI_1.8.8.sh>`_ Downloads, compiles and installs OpenMPI 1.8.8 using the system gcc.
-* `Modulefile <https://github.com/rcgsheffield/iceberg_software/blob/master/software/modulefiles/mpi/gcc/openmpi/1.8.8>`_ located on the system at ``/usr/local/modulefiles/mpi/gcc/openmpi/1.8.8``
+* `install_openMPI.sh  <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/mpi/gcc/openmpi/install_gcc_openMPI_1.8.8.sh>`_ Downloads, compiles and installs OpenMPI 1.8.8 using the system gcc.
+* `Modulefile <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/mpi/gcc/openmpi/1.8.8>`_ located on the system at ``/usr/local/modulefiles/mpi/gcc/openmpi/1.8.8``

--- a/iceberg/software/mpi/openmpi-pgi.rst
+++ b/iceberg/software/mpi/openmpi-pgi.rst
@@ -31,7 +31,7 @@ These are primarily for administrators of the system.
 
 Compiled using PGI 15.7.
 
-* `install_openMPI.sh  <https://github.com/rcgsheffield/iceberg_software/blob/master/software/install_scripts/mpi/pgi/openmpi/install_pgi_openMPI_1.8.8.sh>`_ Downloads, compiles and installs OpenMPI 1.8.8 using v15.7 of the PGI Compiler.
-* `Modulefile <https://github.com/rcgsheffield/iceberg_software/blob/master/software/modulefiles/mpi/pgi/openmpi/1.8.8>`_ located on the system at ``/usr/local/modulefiles/mpi/pgi/openmpi/1.8.8``
+* `install_openMPI.sh  <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/mpi/pgi/openmpi/install_pgi_openMPI_1.8.8.sh>`_ Downloads, compiles and installs OpenMPI 1.8.8 using v15.7 of the PGI Compiler.
+* `Modulefile <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/mpi/pgi/openmpi/1.8.8>`_ located on the system at ``/usr/local/modulefiles/mpi/pgi/openmpi/1.8.8``
 
 Installation notes for older versions are not available.

--- a/sharc/software/index.rst
+++ b/sharc/software/index.rst
@@ -4,7 +4,7 @@ Software on ShARC
 =================
 
 These pages list the software available on ShARC. If you notice an error or
-an omission, or wish to request new software please create an issue on our `github page <https://github.com/rcgsheffield/iceberg_software/issues>`_
+an omission, or wish to request new software please create an issue on our `github page <https://github.com/rcgsheffield/sheffield_hpc/issues>`_
 
 .. toctree::
     :hidden:

--- a/themes/tuos/layout.html
+++ b/themes/tuos/layout.html
@@ -6,7 +6,7 @@
 {% set bootswatch_css_custom = ['http://fonts.googleapis.com/css?family=Open+Sans:400,600,700'] + ['_static/iceberg.css'] %}
 
 {%- block content %}
-<a class="forkme" href="https://github.com/rcgsheffield/iceberg_software">
+<a class="forkme" href="https://github.com/rcgsheffield/sheffield_hpc">
 <img alt="Fork me on GitHub" src="{{ pathto('_static/img/forkme.png', 1) }}">
 </a>
 {{ super() }}


### PR DESCRIPTION
Git already does URL rewriting but this just makes the doc's source neater.

Also fixes the Travis CI status icon (see `README.rst`).