### PR TITLE
Remove run-time dependency of FFTW library on particular version of GCC

### DIFF
--- a/iceberg/software/libs/fftw.rst
+++ b/iceberg/software/libs/fftw.rst
@@ -62,6 +62,8 @@ Modulefile is on the system at ``/usr/local/modulefiles/libs/gcc/5.2/fftw/3.3.4`
 
   set FFTW_DIR /usr/local/packages6/libs/gcc/5.2/fftw/3.3.4
 
+  prepend-path CPATH $FFTW_DIR/include
   prepend-path LD_LIBRARY_PATH $FFTW_DIR/lib
-  prepend-path CPLUS_INCLUDE_PATH $FFTW_DIR/include
   prepend-path LIBRARY_PATH $FFTW_DIR/lib
+  prepend-path MANPATH $FFTW_DIR/share/man
+  prepend-path PATH $FFTW_DIR/bin

--- a/iceberg/software/libs/fftw.rst
+++ b/iceberg/software/libs/fftw.rst
@@ -54,17 +54,13 @@ Modulefile is on the system at ``/usr/local/modulefiles/libs/gcc/5.2/fftw/3.3.4`
 
   ## Module file logging
   source /usr/local/etc/module_logging.tcl
-  ##
-
-  module load compilers/gcc/5.2
 
   proc ModulesHelp { } {
           puts stderr "Makes the FFTW 3.3.4 library available"
   }
+  module-whatis   "Makes the FFTW 3.3.4 library available"
 
   set FFTW_DIR /usr/local/packages6/libs/gcc/5.2/fftw/3.3.4
-
-  module-whatis   "Makes the FFTW 3.3.4 library available"
 
   prepend-path LD_LIBRARY_PATH $FFTW_DIR/lib
   prepend-path CPLUS_INCLUDE_PATH $FFTW_DIR/include

--- a/iceberg/software/libs/fftw.rst
+++ b/iceberg/software/libs/fftw.rst
@@ -62,7 +62,7 @@ Modulefile is on the system at ``/usr/local/modulefiles/libs/gcc/5.2/fftw/3.3.4`
 
   set FFTW_DIR /usr/local/packages6/libs/gcc/5.2/fftw/3.3.4
 
-  prepend-path CPATH $FFTW_DIR/include
+  prepend-path CPLUS_INCLUDE_PATH $FFTW_DIR/include
   prepend-path LD_LIBRARY_PATH $FFTW_DIR/lib
   prepend-path LIBRARY_PATH $FFTW_DIR/lib
   prepend-path MANPATH $FFTW_DIR/share/man


### PR DESCRIPTION
At present the [`libs/gcc/5.2/fftw/3.3.4` modulefile has a run-time dependency on `compilers/gcc/5.2`](iceberg/software/libs/fftw.rst) when this is not necessary (as confirmed by running `ldd` on all binaries in the fftw installation directory).  This makes it more difficult to use fftw 3.3.4 with CUDA as the latter requires an older version of GCC.

The line `module load compilers/gcc/5.2` needs removing from the `libs/gcc/5.2/fftw/3.3.4` modulefile.

Also, I've made a few other refinements to the fftw modulefile:

* use `CPATH` instead of `CPLUS_INCLUDE_PATH` as fftw is a C library;
* set `MANPATH`
* set `PATH`
