### PR TITLE
NAG compiler v6.0 and v6.1: add docs for ShARC

### DIFF
--- a/iceberg/software/compilers/nag.rst
+++ b/iceberg/software/compilers/nag.rst
@@ -61,38 +61,16 @@ Accept the license and answer the questions as follows ::
 
 Licensing
 ---------
-Add the license key to /usr/local/packages5/nag/license.lic
+Add the license key to ``/usr/local/packages5/nag/license.lic``
 
 The license key needs to be updated annually before 31st July.
 
-Point to this license file using the environment variable $NAG_KUSARI_FILE
-
-This is done in the environment module
+Point to this license file using the environment variable ``$NAG_KUSARI_FILE`` (this is done in the environment module).
 
 Module File
 -----------
-Module file location is ``/usr/local/modulefiles/compilers/NAG/6.0`` ::
 
-  #%Module1.0#####################################################################
-  ##
-  ## NAG Fortran Compiler 6.0 module file
-  ##
-
-  ## Module file logging
-  source /usr/local/etc/module_logging.tcl
-  ##
-
-  proc ModulesHelp { } {
-          puts stderr "Makes the NAG Fortran Compiler v6.0 available"
-  }
-
-  module-whatis   "Makes the NAG Fortran Compiler v6.0 available"
-
-  set NAGFOR_DIR /usr/local/packages6/compilers/NAG/6.0
-
-  prepend-path PATH $NAGFOR_DIR
-  prepend-path MANPATH $NAGFOR_DIR/man
-  setenv NAG_KUSARI_FILE /usr/local/packages5/nag/license.lic
+Install `this modulefile <https://github.com/rcgsheffield/sheffield_hpc/tree/master/iceberg/software/modulefiles/compilers/NAG/6.0>`__ as ``/usr/local/modulefiles/compilers/NAG/6.0``
 
 Testing
 -------

--- a/iceberg/software/compilers/nag.rst
+++ b/iceberg/software/compilers/nag.rst
@@ -93,3 +93,12 @@ Module file location is ``/usr/local/modulefiles/compilers/NAG/6.0`` ::
   prepend-path PATH $NAGFOR_DIR
   prepend-path MANPATH $NAGFOR_DIR/man
   setenv NAG_KUSARI_FILE /usr/local/packages5/nag/license.lic
+
+Testing
+-------
+
+Test the installation by compiling and building a sample Fortran 90 program ::
+
+        module load compilers/NAG/6.0
+        nagfor -o /tmp/f90_util /usr/local/packages6/compilers/NAG/6.0/lib/NAG_Fortran/f90_util.f90
+        /tmp/f90_util

--- a/iceberg/software/modulefiles/compilers/NAG/6.0
+++ b/iceberg/software/modulefiles/compilers/NAG/6.0
@@ -1,0 +1,20 @@
+#%Module1.0#####################################################################
+##
+## NAG Fortran Compiler 6.0 module file
+##
+
+## Module file logging
+source /usr/local/etc/module_logging.tcl
+
+proc ModulesHelp { } {
+      puts stderr "Makes the NAG Fortran Compiler v6.0 available"
+}
+
+module-whatis   "Makes the NAG Fortran Compiler v6.0 available"
+
+set NAGFOR_DIR /usr/local/packages6/compilers/NAG/6.0
+
+prepend-path PATH $NAGFOR_DIR
+prepend-path MANPATH $NAGFOR_DIR/man
+setenv NAG_KUSARI_FILE /usr/local/packages5/nag/license.lic
+

--- a/sharc/software/development/nag.rst
+++ b/sharc/software/development/nag.rst
@@ -75,29 +75,8 @@ Point to this license file using the environment variable ``$NAG_KUSARI_FILE`` (
 
 Module File
 -----------
-Module file location is ``/usr/local/modulefiles/dev/NAG/6.0`` ::
 
-        #%Module1.0#####################################################################
-        ##
-        ## NAG Fortran Compiler module file
-        ##
-
-        ## Module file logging
-        source /usr/local/etc/module_logging.tcl
-
-        proc ModulesHelp { } {
-                global nagvers
-                puts stderr "Makes the NAG Fortran Compiler vnagvers available"
-        }
-
-        set nagvers 6.0
-        set nagroot /usr/local/packages/dev/NAG/$nagvers
-
-        module-whatis   "Makes the NAG Fortran Compiler v$nagvers available"
-
-        prepend-path PATH $nagroot/bin
-        prepend-path MANPATH $nagroot/man
-        setenv NAG_KUSARI_FILE /usr/local/packages/dev/NAG/license.lic
+Install `this modulefile <https://github.com/rcgsheffield/sheffield_hpc/tree/master/sharc/software/modulefiles/dev/NAG/6.0>`__ as ``/usr/local/modulefiles/dev/NAG/6.0``
 
 Testing
 -------

--- a/sharc/software/development/nag.rst
+++ b/sharc/software/development/nag.rst
@@ -1,0 +1,109 @@
+NAG Fortran Compiler
+====================
+
+The NAG Fortran Compiler is robust, highly tested, and valued by developers all over the globe for its checking capabilities and detailed error reporting. The Compiler is available on Unix platforms as well as for Microsoft Windows and Apple Mac platforms. Release 6.0 has extensive support for both legacy and modern Fortran features, and also supports parallel programming with OpenMP.
+
+Making the NAG Compiler available
+---------------------------------
+
+After connecting to ShARC (see :ref:`ssh`),  start an interactive sesssion with the :code:`qsh` or :code:`qrsh` command. To make the NAG Fortran Compiler available, run the following module command ::
+
+        module load dev/NAG/6.0
+
+Compilation examples
+--------------------
+To compile the Fortran hello world example into an executable called ``hello`` using the NAG compiler ::
+
+        nagfor hello.f90 -o hello
+
+Detailed Documentation
+----------------------
+Once you've run the NAG Compiler module command, ``man`` documentation is available ::
+
+        man nagfor
+
+Online documentation:
+
+* `PDF version of the NAG Fortran Compiler Manual <http://www.nag.co.uk/nagware/np/r60_doc/np60_manual.pdf>`_
+* `NAG Fortran Compiler Documentation Index (NAG's Website) <http://www.nag.co.uk/nagware/np.asp>`_
+
+Installation Notes
+------------------
+
+The following notes are primarily for system sysadmins
+
+**Version 6.0**
+
+Run the following ::
+
+        nag_vers=6.0
+        media_dir="/usr/local/media/NAG/$nag_vers"
+        mkdir -p $media_dir
+        tarball=npl6a60na_amd64.tgz 
+        tarball_url=https://www.nag.co.uk/downloads/impl/$tarball
+
+        wget -c $tarball_url -P $media_dir
+
+        mkdir -m 2775 -p $prefix
+        chown -R $USER:app-admins $prefix
+
+        mkdir -p $tmp_dir
+        pushd $tmp_dir
+        tar -zxf $media_dir/$tarball
+        pushd NAG_Fortran-amd64/
+
+Run the interactive install script ::
+
+        ./INSTALL.sh
+
+Accept the license and answer the questions as follows:
+
+* **Install compiler binaries to where? [/usr/local/bin]?** ``/usr/local/packages/dev/NAG/6.0/bin/``
+* **Install compiler library files to where?** ``/usr/local/packages/dev/NAG/6.0/lib/NAG_Fortran``
+* **Install compiler man page to which directory?** ``/usr/local/packages/dev/NAG/6.0/man/man1``
+* **Suffix for compiler man page [1]** *leave as default*
+* **Install module man pages to which directory?** ``/usr/local/packages/dev/NAG/6.0/man/man3``
+* **Suffix for module man pages [3]?** *leave as default*
+
+Licensing
+---------
+Add the license key to ``/usr/local/packages/dev/NAG/license.lic``
+
+The license key needs to be updated annually before 31st July.
+
+Point to this license file using the environment variable ``$NAG_KUSARI_FILE`` (this is done in the environment module).
+
+Module File
+-----------
+Module file location is ``/usr/local/modulefiles/dev/NAG/6.0`` ::
+
+        #%Module1.0#####################################################################
+        ##
+        ## NAG Fortran Compiler module file
+        ##
+
+        ## Module file logging
+        source /usr/local/etc/module_logging.tcl
+
+        proc ModulesHelp { } {
+                global nagvers
+                puts stderr "Makes the NAG Fortran Compiler vnagvers available"
+        }
+
+        set nagvers 6.0
+        set nagroot /usr/local/packages/dev/NAG/$nagvers
+
+        module-whatis   "Makes the NAG Fortran Compiler v$nagvers available"
+
+        prepend-path PATH $nagroot/bin
+        prepend-path MANPATH $nagroot/man
+        setenv NAG_KUSARI_FILE /usr/local/packages/dev/NAG/license.lic
+
+Testing
+-------
+
+Test the installation by compiling and building a sample Fortran 90 program ::
+
+        module load dev/NAG/6.0
+        nagfor -o /tmp/f90_util /usr/local/packages/dev/NAG/6.0/lib/NAG_Fortran/f90_util.f90
+        /tmp/f90_util

--- a/sharc/software/development/nag.rst
+++ b/sharc/software/development/nag.rst
@@ -8,6 +8,7 @@ Making the NAG Compiler available
 
 After connecting to ShARC (see :ref:`ssh`),  start an interactive sesssion with the :code:`qsh` or :code:`qrsh` command. To make the NAG Fortran Compiler available, run the following module command ::
 
+        module load dev/NAG/6.1
         module load dev/NAG/6.0
 
 Compilation examples
@@ -32,9 +33,31 @@ Installation Notes
 
 The following notes are primarily for system sysadmins
 
+**Licensing**
+
+Add the license key(s) to ``/usr/local/packages/dev/NAG/license.lic``.
+
+The license key needs to be updated annually before 31st July.
+
+The NAG compiler environment modules (see below) set the environment variable ``$NAG_KUSARI_FILE`` to the path to this file.
+
+**Version 6.1**
+
+#. Perform an unattended install using `install_NAG_compiler_6.1.sh
+   <https://github.com/rcgsheffield/sheffield_hpc/tree/master/sharc/software/install_scripts/dev/NAG/install_NAG_compiler_6.1.sh>`__.
+   The software will be installed into ``/usr/local/packages/dev/NAG/6.1``.
+#. Install `this modulefile
+   <https://github.com/rcgsheffield/sheffield_hpc/tree/master/sharc/software/modulefiles/dev/NAG/6.1>`__
+   as ``/usr/local/modulefiles/dev/NAG/6.1``
+#. Test the installation by compiling and building a sample Fortran 90 program ::
+
+        module load dev/NAG/6.1
+        nagfor -o /tmp/f90_util /usr/local/packages/dev/NAG/6.1/lib/NAG_Fortran/f90_util.f90
+        /tmp/f90_util
+
 **Version 6.0**
 
-Run the following ::
+First, run the following ::
 
         nag_vers=6.0
         media_dir="/usr/local/media/NAG/$nag_vers"
@@ -52,7 +75,7 @@ Run the following ::
         tar -zxf $media_dir/$tarball
         pushd NAG_Fortran-amd64/
 
-Run the interactive install script ::
+Next, run the interactive install script ::
 
         ./INSTALL.sh
 
@@ -65,21 +88,7 @@ Accept the license and answer the questions as follows:
 * **Install module man pages to which directory?** ``/usr/local/packages/dev/NAG/6.0/man/man3``
 * **Suffix for module man pages [3]?** *leave as default*
 
-Licensing
----------
-Add the license key to ``/usr/local/packages/dev/NAG/license.lic``
-
-The license key needs to be updated annually before 31st July.
-
-Point to this license file using the environment variable ``$NAG_KUSARI_FILE`` (this is done in the environment module).
-
-Module File
------------
-
 Install `this modulefile <https://github.com/rcgsheffield/sheffield_hpc/tree/master/sharc/software/modulefiles/dev/NAG/6.0>`__ as ``/usr/local/modulefiles/dev/NAG/6.0``
-
-Testing
--------
 
 Test the installation by compiling and building a sample Fortran 90 program ::
 

--- a/sharc/software/install_scripts/dev/NAG/install_NAG_compiler_6.1.sh
+++ b/sharc/software/install_scripts/dev/NAG/install_NAG_compiler_6.1.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Install NAG Fortran compiler v6.1 on ShARC
+
+# Define variables
+nag_vers=6.1
+media_dir="/usr/local/media/NAG/$nag_vers"
+tarball=npl6a61na_amd64.tgz 
+tarball_url=https://www.nag.co.uk/downloads/impl/$tarball
+prefix=/usr/local/packages/dev/NAG/$nag_vers
+tmp_dir=/tmp/${USER}/NAG/$nag_vers/
+# Directory to contain binary materials:
+export INSTALL_TO_BINDIR=$prefix/bin
+# Directory to contain supporting library materials, which must
+# be different from the binaries directory:
+export INSTALL_TO_LIBDIR=$prefix/lib/NAG_Fortran
+# Directory prefix for preformatted man pages:
+export INSTALL_TO_CATMANDIR=$prefix/man/man
+# Directory prefix for unformatted man pages;
+export INSTALL_TO_MANDIR=$prefix/man/man
+
+# Create directories
+mkdir -p $media_dir
+
+mkdir -m 2775 -p $prefix
+chown -R $USER:app-admins $prefix
+
+mkdir -p $tmp_dir
+
+# Download and unpack 
+pushd $tmp_dir
+wget -c $tarball_url -P $media_dir
+tar -zxf $media_dir/$tarball
+
+# Unattended install
+pushd NAG_Fortran-amd64/
+sh INSTALLU.sh
+
+popd
+popd
+
+# Test using:
+#nagfor -o ~/f90_util /usr/local/packages/dev/NAG/6.1/lib/NAG_Fortran/f90_util.f90
+

--- a/sharc/software/modulefiles/dev/NAG/6.0
+++ b/sharc/software/modulefiles/dev/NAG/6.0
@@ -1,0 +1,21 @@
+#%Module1.0#####################################################################
+##
+## NAG Fortran Compiler module file
+##
+
+# Module file logging
+source /usr/local/etc/module_logging.tcl
+
+proc ModulesHelp { } {
+        global nagvers
+        puts stderr "Makes the NAG Fortran Compiler vnagvers available"
+}
+
+set nagvers 6.0
+set nagroot /usr/local/packages/dev/NAG/$nagvers
+
+module-whatis   "Makes the NAG Fortran Compiler v$nagvers available"
+
+prepend-path PATH $nagroot/bin
+prepend-path MANPATH $nagroot/man
+setenv NAG_KUSARI_FILE /usr/local/packages/dev/NAG/license.lic

--- a/sharc/software/modulefiles/dev/NAG/6.1
+++ b/sharc/software/modulefiles/dev/NAG/6.1
@@ -1,0 +1,21 @@
+%Module1.0#####################################################################
+#
+# NAG Fortran Compiler module file
+#
+
+# Module file logging
+source /usr/local/etc/module_logging.tcl
+
+proc ModulesHelp { } {
+        global nagvers
+        puts stderr "Makes the NAG Fortran Compiler vnagvers available"
+}
+
+set nagvers 6.1
+set nagroot /usr/local/packages/dev/NAG/$nagvers
+
+module-whatis   "Makes the NAG Fortran Compiler v$nagvers available"
+
+prepend-path PATH $nagroot/bin
+prepend-path MANPATH $nagroot/man
+setenv NAG_KUSARI_FILE /usr/local/packages/dev/NAG/license.lic


### PR DESCRIPTION
Plus testing example for ShARC and Iceberg.

Could also roll NAG compiler 6.1 docs + install script + modulefiles for ShARC and Iceberg into this PR when get a new license from NAG.