### PR TITLE
ShARC OpenMPI + Intel compiler

### DIFF
--- a/sharc/software/install_scripts/mpi/openmpi/2.0.1/install_openMPI_2.0.1_intel_17.0.0.sh
+++ b/sharc/software/install_scripts/mpi/openmpi/2.0.1/install_openMPI_2.0.1_intel_17.0.0.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Install OpenMPI 2.0.1 built with Intel 2017 compilers on the ShARC cluster
+# Install OpenMPI 2.0.1 built with Intel 17.0.0 compilers on the ShARC cluster
 
 ##############################################################################
 # Error handling
@@ -31,9 +31,10 @@ module load dev/intel-compilers/17.0.0
 
 short_version=2.0
 version=${short_version}.1
-build_dir="/scratch/${USER}/openmpi_${version}"
-prefix="/usr/local/packages/mpi/openmpi/${version}/intel-2017"
-modulefile="/usr/local/modulefiles/mpi/openmpi/${version}/intel-2017"
+compiler=intel-17.0.0
+build_dir="${TMPDIR-/tmp}/${USER}/openmpi_${version}"
+prefix="/usr/local/packages/mpi/openmpi/${version}/${compiler}"
+modulefile="/usr/local/modulefiles/mpi/openmpi/${version}/${compiler}"
 filename="openmpi-${version}.tar.gz"
 baseurl="http://www.open-mpi.org/software/ompi/v${short_version}/downloads/"
 workers=16  # for building in parallel

--- a/sharc/software/install_scripts/mpi/openmpi/2.0.1/install_openMPI_2.0.1_intel_17.0.0.sh
+++ b/sharc/software/install_scripts/mpi/openmpi/2.0.1/install_openMPI_2.0.1_intel_17.0.0.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Install OpenMPI 2.0.1 built with Intel 2017 compilers on the ShARC cluster
+
+##############################################################################
+# Error handling
+##############################################################################
+
+handle_error () {
+    errcode=$? # save the exit code as the first thing done in the trap function 
+    echo "error $errorcode" 
+    echo "the command executing at the
+    time of the error was" echo "$BASH_COMMAND" 
+    echo "on line ${BASH_LINENO[0]}"
+    # do some error handling, cleanup, logging, notification $BASH_COMMAND
+    # contains the command that was being executed at the time of the trap
+    # ${BASH_LINENO[0]} contains the line number in the script of that command
+    # exit the script or return to try again, etc.
+    exit $errcode  # or use some other value or do return instead 
+} 
+trap handle_error ERR
+
+##############################################################################
+# Module loads
+##############################################################################
+
+module load dev/intel-compilers/17.0.0
+
+##############################################################################
+# Variable setup
+##############################################################################
+
+short_version=2.0
+version=${short_version}.1
+build_dir="/scratch/${USER}/openmpi_${version}"
+prefix="/usr/local/packages/mpi/openmpi/${version}/intel-2017"
+modulefile="/usr/local/modulefiles/mpi/openmpi/${version}/intel-2017"
+filename="openmpi-${version}.tar.gz"
+baseurl="http://www.open-mpi.org/software/ompi/v${short_version}/downloads/"
+workers=16  # for building in parallel
+
+##############################################################################
+# Create build, install and modulefile dirs
+##############################################################################
+
+[[ -d $build_dir ]] || mkdir -p $build_dir
+
+for d in $prefix $(dirname $modulefile); do 
+    mkdir -m 2775 -p $d
+    chown -R ${USER}:app-admins $d
+done
+
+##############################################################################
+# Download source
+##############################################################################
+
+cd $build_dir
+wget -c ${baseurl}/${filename}
+
+##############################################################################
+# Build and install
+##############################################################################
+
+tar -xzf openmpi-${version}.tar.gz
+cd openmpi-${version}
+
+./configure --prefix=${prefix} --with-psm2 CC=icc CXX=icpc FC=ifort
+make -j${workers}
+make check
+make install
+
+##############################################################################
+# Download and install examples
+##############################################################################
+
+pushd ${prefix}
+curl -L https://github.com/open-mpi/ompi/archive/v${short_version}.x.tar.gz | tar -zx
+mv ompi-${short_version}.x/examples .
+rm -r ompi-${short_version}.x 
+popd
+
+echo "Next, install modulefile as $modulefile."

--- a/sharc/software/modulefiles/mpi/openmpi/2.0.1/intel-17.0.0
+++ b/sharc/software/modulefiles/mpi/openmpi/2.0.1/intel-17.0.0
@@ -1,0 +1,33 @@
+#%Module1.0#####################################################################
+##
+## OpenMPI (+ Intel compilers) module file
+##
+
+## Module file logging
+source /usr/local/etc/module_logging.tcl
+##
+
+proc ModulesHelp { } {
+    global openmpiversion
+    global compiler
+
+    puts stderr "   Adds `openmpi-$openmpiversion' (+ Intel compilers) to your PATH environment variable and necessary libraries"
+}
+
+set openmpiversion   2.0.1
+set compilerversion  17.0.0
+set openmpiroot      /usr/local/packages/mpi/openmpi/$openmpiversion/intel-$compilerversion
+
+module-whatis   "Adds `openmpi-$openmpiversion' (+ Intel compilers) to your PATH environment variable and necessary libraries"
+
+#setenv OMPI_MCA_btl_tcp_if_include eth0
+#setenv OMPI_MCA_btl tcp,self
+
+module load dev/intel-compilers/$compilerversion
+
+setenv MPI_HOME $openmpiroot
+
+prepend-path PATH $openmpiroot/bin/
+prepend-path LD_LIBRARY_PATH $openmpiroot/lib/
+prepend-path MANPATH $openmpiroot/share/man/
+

--- a/sharc/software/parallel/openmpi-intel.rst
+++ b/sharc/software/parallel/openmpi-intel.rst
@@ -1,0 +1,61 @@
+OpenMPI (Intel version)
+=======================
+
+.. sidebar:: OpenMPI (intel version)
+
+   :Latest Version: 2.0.1
+   :Dependancies: Intel compilers
+   :URL: http://www.open-mpi.org/
+
+The Open MPI Project is an open source Message Passing Interface implementation that is developed and maintained by a consortium of academic, research, and industry partners. Open MPI is therefore able to combine the expertise, technologies, and resources from all across the High Performance Computing community in order to build the best MPI library available. Open MPI offers advantages for system and software vendors, application developers and computer science researchers.
+
+Versions
+--------
+
+You can load a specific version using ::
+
+   module load mpi/openmpi/2.0.1/intel-17.0.0
+
+See `here <https://mail-archive.com/announce@lists.open-mpi.org/msg00085.html>`__ for a brief guide to the new features in OpenMPI 2.x and `here <https://raw.githubusercontent.com/open-mpi/ompi/v2.x/NEWS>`__ for a detailed view of the changes between OpenMPI versions.
+
+Examples
+--------
+
+Example programs are available in the ``/usr/local/packages/mpi/openmpi/XXX/intel-17.0.0/examples/`` directory (where ``XXX`` is the version of OpenMPI you are using e.g. ``2.0.1``).  
+
+To compile and run these programs: copy that directory to your home directory, start an interactive MPI-aware session on a worker node, activate the version of OpenMPI you wish to use, compile the examples then run them.
+
+In more detail ::
+
+    # Connect to iceberg
+    ssh user@iceberg  
+
+    # Copy the examples to your home directory
+    cp -r /usr/local/packages/mpi/openmpi/2.0.1/intel-17.0.0/examples/ ~/openmpi_2.0.1_examples
+
+    # Start an interactive session from which we can run MPI processes using a core on each of four nodes
+    qrsh -pe mpi 4
+
+    # Compile all programs in the examples directory
+    cd ~/openmpi_2.0.1_examples
+    make
+
+    # Once compiled, run an example program on all (or a subset) of your MPI nodes using the mpirun utility
+    $ mpirun -np 4 hello_c
+    Hello, world, I am 0 of 4, (Open MPI v2.0.1, package: Open MPI user@sharc-node002.shef.ac.uk Distribution, ident: 2.0.1, repo rev: v2.0.0-257-gee86e07, Sep 02, 2016, 141)
+    Hello, world, I am 1 of 4, (Open MPI v2.0.1, package: Open MPI user@sharc-node002.shef.ac.uk Distribution, ident: 2.0.1, repo rev: v2.0.0-257-gee86e07, Sep 02, 2016, 141)
+    Hello, world, I am 2 of 4, (Open MPI v2.0.1, package: Open MPI user@sharc-node002.shef.ac.uk Distribution, ident: 2.0.1, repo rev: v2.0.0-257-gee86e07, Sep 02, 2016, 141)
+    Hello, world, I am 3 of 4, (Open MPI v2.0.1, package: Open MPI user@sharc-node002.shef.ac.uk Distribution, ident: 2.0.1, repo rev: v2.0.0-257-gee86e07, Sep 02, 2016, 141)
+
+
+Installation notes
+------------------
+
+These are primarily for administrators of the system.
+
+**Version 2.0.1**
+
+#. Ensure :ref:`Intel compilers 17.0.0 <sharc-intel-compilers>` are installed and licensed.
+#. Download, compile and install OpenMPI 2.0.1 using the `install_openMPI_2.0.1_intel-17.0.0.sh <https://github.com/rcgsheffield/sheffield_hpc/blob/master/sharc/software/install_scripts/mpi/openmpi/2.0.1/install_openMPI_2.0.1_intel_17.0.0.sh>`_ script.
+#. Install `this modulefile <https://github.com/rcgsheffield/sheffield_hpc/blob/master/sharc/software/modulefiles/mpi/openmpi/2.0.1/intel-17.0.0>`__ as ``/usr/local/modulefiles/mpi/openmpi/2.0.1/intel-17.0.0``
+#. Test by running some <Examples>_.


### PR DESCRIPTION
Docs, install script and modulefile for OpenMPI 2.0.1 built using the Intel 17.0.0 compiler.