### PR TITLE
Iceberg + FFTW + FLTK: add builds with CUDA-compatible GCC

### DIFF
--- a/iceberg/software/install_scripts/libs/gcc/4.9.2/fftw/3.3.5/install.sh
+++ b/iceberg/software/install_scripts/libs/gcc/4.9.2/fftw/3.3.5/install.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+fftw_vers=3.3.5
+fftw_tarball="fftw-${fftw_vers}.tar.gz"
+fftw_tarball_url="http://www.fftw.org/${fftw_tarball}"
+
+compiler=gcc
+compiler_vers=4.9.2
+
+prefix="/usr/local/packages6/libs/${compiler}/${compiler_vers}/fftw/${fftw_vers}/"
+
+modulefile="/usr/local/modulefiles/libs/${compiler}/${compiler_vers}/fftw/${fftw_vers}"
+
+workers=8
+
+# Signal handling for failure
+handle_error () {
+    errcode=$? # save the exit code as the first thing done in the trap function 
+    echo "error $errorcode" 
+    echo "the command executing at the
+    time of the error was" echo "$BASH_COMMAND" 
+    echo "on line ${BASH_LINENO[0]}"
+    # do some error handling, cleanup, logging, notification $BASH_COMMAND
+    # contains the command that was being executed at the time of the trap
+    # ${BASH_LINENO[0]} contains the line number in the script of that command
+    # exit the script or return to try again, etc.
+    exit $errcode  # or use some other value or do return instead 
+}
+trap handle_error ERR
+
+# Download and unpack tarball
+[[ -f $fftw_tarball ]] || wget $fftw_tarball_url
+if ! [[ -f .fftw_tarball_unpacked ]]; then
+    tar -zxf ${fftw_tarball}
+    touch .fftw_tarball_unpacked 
+fi
+
+# Create install and modulefile dirs
+for d in $prefix $(dirname $modulefile); do
+    mkdir -m 2775 -p $d
+done
+
+# Activate a compiler
+module purge
+module load compilers/${compiler}/${compiler_vers}
+
+# Build and install
+pushd fftw-${fftw_vers}
+./configure --prefix=${prefix} --enable-threads --enable-openmp --enable-shared
+make -j${workers}
+make check
+make install
+popd
+
+# Set permissions and ownership
+for d in $prefix $(dirname $modulefile); do
+    chmod -R g+w $d
+    chown -R ${USER}:app-admins $d
+done

--- a/iceberg/software/install_scripts/libs/gcc/4.9.2/fltk/1.3.3/install.sh
+++ b/iceberg/software/install_scripts/libs/gcc/4.9.2/fltk/1.3.3/install.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Install the the FLTK library v1.3.3 on Iceberg
+
+fltk_vers=1.3.3
+fltk_tarball="fltk-${fltk_vers}-source.tar.gz"
+fltk_tarball_url="http://fltk.org/pub/fltk/1.3.3/${fltk_tarball}"
+
+compiler=gcc
+compiler_vers=4.9.2
+
+prefix="/usr/local/packages6/libs/${compiler}/${compiler_vers}/fltk/${fltk_vers}/"
+
+build_dir="${TMPDIR-/tmp}/${USER}/fltk/${fltk_vers}"
+
+modulefile="/usr/local/modulefiles/libs/${compiler}/${compiler_vers}/fltk/${fltk_vers}"
+
+workers=8
+
+# Signal handling for failure
+handle_error () {
+    errcode=$? # save the exit code as the first thing done in the trap function 
+    echo "error $errorcode" 
+    echo "the command executing at the
+    time of the error was" echo "$BASH_COMMAND" 
+    echo "on line ${BASH_LINENO[0]}"
+    # do some error handling, cleanup, logging, notification $BASH_COMMAND
+    # contains the command that was being executed at the time of the trap
+    # ${BASH_LINENO[0]} contains the line number in the script of that command
+    # exit the script or return to try again, etc.
+    exit $errcode  # or use some other value or do return instead 
+}
+trap handle_error ERR
+
+mkdir -m 0700 -p $build_dir
+pushd $build_dir
+
+# Download and unpack tarball
+[[ -f $fltk_tarball ]] || wget $fltk_tarball_url
+if ! [[ -f .fltk_tarball_unpacked ]]; then
+    tar -zxf ${fltk_tarball}
+    touch .fltk_tarball_unpacked 
+fi
+
+# Create install and modulefile dirs
+for d in $prefix $(dirname $modulefile); do
+    mkdir -m 2775 -p $d
+done
+
+# Activate a compiler
+module purge
+module load compilers/${compiler}/${compiler_vers}
+
+# Build and install
+pushd fltk-${fltk_vers}
+
+#Fixes error relating to undefined _ZN18Fl_XFont_On_Demand5valueEv
+#Source https://groups.google.com/forum/#!topic/fltkgeneral/GT6i2KGCb3A
+sed -i 's/class Fl_XFont_On_Demand/class FL_EXPORT Fl_XFont_On_Demand/' FL/x.H
+
+./configure --prefix=${prefix} --enable-shared --enable-xft
+make -j${workers}
+make install
+popd
+
+# Set permissions and ownership
+for d in $prefix $(dirname $modulefile); do
+    chmod -R g+w $d
+    chown -R ${USER}:app-admins $d
+done

--- a/iceberg/software/libs/fftw.rst
+++ b/iceberg/software/libs/fftw.rst
@@ -5,31 +5,32 @@ fftw
 
 .. sidebar:: fftw
 
-   :Latest version: 3.3.4
+   :Latest version: 3.3.5
    :URL: http://www.fftw.org/
-   :Location: /usr/local/packages6/libs/gcc/5.2/fftw/3.3.4
 
 FFTW is a C subroutine library for computing the discrete Fourier transform (DFT) in one or more dimensions, of arbitrary input size, and of both real and complex data (as well as of even/odd data, i.e. the discrete cosine/sine transforms or DCT/DST).
 
 Usage
 -----
-To make this library available, run the following module command ::
+To make this library available, run one of the following module commands: ::
 
+        module load libs/gcc/4.9.2/fftw/3.3.5
         module load libs/gcc/5.2/fftw/3.3.4
+
+If you are using :ref:`cuda` then you will want to use version 3.3.5 as the build of version 3.3.4 is dependent on GCC 5.2, a version of GCC not supported by CUDA at this time.
 
 Installation notes
 ------------------
-This section is primarily for administrators of the system. FFTW 3.3.4 was compiled with gcc 5.2 ::
+This section is primarily for administrators of the system. 
 
-    module load compilers/gcc/5.2
-    mkdir -p /usr/local/packages6/libs/gcc/5.2/fftw/3.3.4
-    tar -xvzf fftw-3.3.4.tar.gz
-    cd fftw-3.3.4
-    ./configure --prefix=/usr/local/packages6/libs/gcc/5.2/fftw/3.3.4 --enable-threads --enable-openmp --enable-shared
-    make
-    make check
+**version 3.3.5**
 
-Result was lots of numerical output and ::
+This was compiled with GCC 4.9.2 (for compatibility with CUDA, which doesn't support GCC >= 5.0.0).  
+Threading (inc. OpenMP) and shared-library support were enabled and build-time.
+
+First, download, configure, build, test and install using :download:`this script </iceberg/software/install_scripts/libs/gcc/4.9.2/fftw/3.3.5/install.sh>`.
+
+During the testing stage you should see lots of numerical output plus: ::
 
   --------------------------------------------------------------
            FFTW transforms passed basic tests!
@@ -39,13 +40,35 @@ Result was lots of numerical output and ::
            FFTW threaded transforms passed basic tests!
   --------------------------------------------------------------
 
-Installed with ::
+Next, :download:`this modulefile </iceberg/software/modulefiles/libs/gcc/4.9.2/fftw/3.3.5>` as ``/usr/local/modulefiles/libs/gcc/4.9.2/fftw/3.3.5`` 
+
+**version 3.3.4**
+
+This was compiled with GCC 5.2: ::
+
+    module load compilers/gcc/5.2
+    mkdir -p /usr/local/packages6/libs/gcc/5.2/fftw/3.3.4
+    tar -xvzf fftw-3.3.4.tar.gz
+    cd fftw-3.3.4
+    ./configure --prefix=/usr/local/packages6/libs/gcc/5.2/fftw/3.3.4 --enable-threads --enable-openmp --enable-shared
+    make
+    make check
+
+The result was lots of numerical output and: ::
+
+  --------------------------------------------------------------
+           FFTW transforms passed basic tests!
+  --------------------------------------------------------------
+
+  --------------------------------------------------------------
+           FFTW threaded transforms passed basic tests!
+  --------------------------------------------------------------
+
+Installed with: ::
 
     make install
 
-Module file
-------------
-Modulefile is on the system at ``/usr/local/modulefiles/libs/gcc/5.2/fftw/3.3.4`` ::
+The modulefile is on the system at ``/usr/local/modulefiles/libs/gcc/5.2/fftw/3.3.4`` ::
 
   #%Module1.0#####################################################################
   ##

--- a/iceberg/software/libs/fftw.rst
+++ b/iceberg/software/libs/fftw.rst
@@ -17,7 +17,7 @@ To make this library available, run one of the following module commands: ::
         module load libs/gcc/4.9.2/fftw/3.3.5
         module load libs/gcc/5.2/fftw/3.3.4
 
-If you are using :ref:`cuda` then you will want to use version 3.3.5 as the build of version 3.3.4 is dependent on GCC 5.2, a version of GCC not supported by CUDA at this time.
+If you are using :ref:`cuda` then you will want to use version 3.3.5 as the build of version 3.3.4 is dependent on GCC 5.2, a version of GCC not supported by CUDA at this time. 
 
 Installation notes
 ------------------
@@ -26,7 +26,8 @@ This section is primarily for administrators of the system.
 **version 3.3.5**
 
 This was compiled with GCC 4.9.2 (for compatibility with CUDA, which doesn't support GCC >= 5.0.0).  
-Threading (inc. OpenMP) and shared-library support were enabled and build-time.
+Threading (inc. OpenMP) and shared-library support were enabled at build-time.  
+Vectorisation support was not explicitly enabled to allow the library to be used on nodes that do not support AVX/AVX2.
 
 First, download, configure, build, test and install using :download:`this script </iceberg/software/install_scripts/libs/gcc/4.9.2/fftw/3.3.5/install.sh>`.
 

--- a/iceberg/software/libs/fltk.rst
+++ b/iceberg/software/libs/fltk.rst
@@ -40,43 +40,41 @@ Next, :download:`this modulefile </iceberg/software/modulefiles/libs/gcc/4.9.2/f
 * Compiled with (and has a runtime dependency on) GCC 5.2
 * Installed using: ::
 
-  module load compilers/gcc/5.2
-  mkdir -p /usr/local/packages6/libs/gcc/5.2/fltk/1.3.3
-  #tar -xvzf ./fltk-1.3.3-source.tar.gz
-  cd fltk-1.3.3
+        module load compilers/gcc/5.2
+        mkdir -p /usr/local/packages6/libs/gcc/5.2/fltk/1.3.3
+        #tar -xvzf ./fltk-1.3.3-source.tar.gz
+        cd fltk-1.3.3
 
-  #Fixes error relating to undefined _ZN18Fl_XFont_On_Demand5valueEv
-  #Source https://groups.google.com/forum/#!topic/fltkgeneral/GT6i2KGCb3A
-  sed -i 's/class Fl_XFont_On_Demand/class FL_EXPORT Fl_XFont_On_Demand/' FL/x.H
+        #Fixes error relating to undefined _ZN18Fl_XFont_On_Demand5valueEv
+        #Source https://groups.google.com/forum/#!topic/fltkgeneral/GT6i2KGCb3A
+        sed -i 's/class Fl_XFont_On_Demand/class FL_EXPORT Fl_XFont_On_Demand/' FL/x.H
 
-  ./configure --prefix=/usr/local/packages6/libs/gcc/5.2/fltk/1.3.3 --enable-shared --enable-xft
-  make
-  make install
+        ./configure --prefix=/usr/local/packages6/libs/gcc/5.2/fltk/1.3.3 --enable-shared --enable-xft
+        make
+        make install
 
-Modulefile at ``/usr/local/modulefiles/libs/gcc/5.2/fltk/1.3.3``
+Modulefile at ``/usr/local/modulefiles/libs/gcc/5.2/fltk/1.3.3``: ::
 
-.. code-block:: none
+        #%Module1.0#####################################################################
+        ##
+        ## fltk 1.3.3 module file
+        ##
 
-  #%Module1.0#####################################################################
-  ##
-  ## fltk 1.3.3 module file
-  ##
+        ## Module file logging
+        source /usr/local/etc/module_logging.tcl
+        ##
 
-  ## Module file logging
-  source /usr/local/etc/module_logging.tcl
-  ##
+        module load compilers/gcc/5.2
 
-  module load compilers/gcc/5.2
+        proc ModulesHelp { } {
+                puts stderr "Makes the FLTK 1.3.3 library available"
+        }
 
-  proc ModulesHelp { } {
-          puts stderr "Makes the FLTK 1.3.3 library available"
-  }
+        set FLTK_DIR /usr/local/packages6/libs/gcc/5.2/fltk/1.3.3
 
-  set FLTK_DIR /usr/local/packages6/libs/gcc/5.2/fltk/1.3.3
+        module-whatis   "Makes the FLTK 1.3.3 library available"
 
-  module-whatis   "Makes the FLTK 1.3.3 library available"
-
-  prepend-path LD_LIBRARY_PATH $FLTK_DIR/lib
-  prepend-path CPLUS_INCLUDE_PATH $FLTK_DIR/include
-  prepend-path LIBRARY_PATH $FLTK_DIR/lib
-  prepend-path PATH $FLTK_DIR/bin
+        prepend-path LD_LIBRARY_PATH $FLTK_DIR/lib
+        prepend-path CPLUS_INCLUDE_PATH $FLTK_DIR/include
+        prepend-path LIBRARY_PATH $FLTK_DIR/lib
+        prepend-path PATH $FLTK_DIR/bin

--- a/iceberg/software/libs/fltk.rst
+++ b/iceberg/software/libs/fltk.rst
@@ -7,24 +7,38 @@ FLTK
 
    :Version: 1.3.3
    :URL: http://www.fltk.org/index.php
-   :Location: /usr/local/packages6/libs/gcc/5.2/fltk/1.3.3
 
-FLTK (pronounced "fulltick") is a cross-platform C++ GUI toolkit for UNIX®/Linux® (X11), Microsoft® Windows®, and MacOS® X. FLTK provides modern GUI functionality without the bloat and supports 3D graphics via OpenGL® and its built-in GLUT emulation.
+FLTK (pronounced "fulltick") is a cross-platform C++ GUI toolkit for UNIX/Linux (X11), Windows, and OS X. FLTK provides modern GUI functionality without the bloat and supports 3D graphics via OpenGL and its built-in GLUT emulation.
 
 Usage
 -----
-.. code-block:: none
+
+Run one of the following: ::
 
         module load libs/gcc/5.2/fltk/1.3.3
+        module load libs/gcc/4.9.2/fltk/1.3.3
+
+If you are using :ref:`cuda` then you will want to use the version that was built with (and has a runtime dependency on) GCC 4.9.2 as GCC 5.0 and later are not supported by CUDA at this time. 
 
 Installation notes
 ------------------
 This section is primarily for administrators of the system.
 
-* This is a pre-requisite for GNU Octave version 4.0
-* It was built with gcc 5.2
+**Version 1.3.3 (GCC 4.9.2)**
 
-.. code-block:: none
+* Compiled with (and has a runtime dependency on) GCC 4.9.2 (for compatibility with CUDA, which doesn't support GCC >= 5.0.0).  
+* Shared-library support and `X Font Library <https://www.freedesktop.org/wiki/Software/Xft/>`_ (Xft) support were enabled at build-time.  
+* A pre-requisite for Relion 2-beta.
+
+First, download, configure, build, test and install using :download:`this script </iceberg/software/install_scripts/libs/gcc/4.9.2/fltk/1.3.3/install.sh>`.
+
+Next, :download:`this modulefile </iceberg/software/modulefiles/libs/gcc/4.9.2/fltk/1.3.3>` as ``/usr/local/modulefiles/libs/gcc/4.9.2/fltk/1.3.3`` 
+
+**Version 1.3.3 (GCC 5.2)**
+
+* This is a pre-requisite for GNU Octave version 4.0
+* Compiled with (and has a runtime dependency on) GCC 5.2
+* Installed using: ::
 
   module load compilers/gcc/5.2
   mkdir -p /usr/local/packages6/libs/gcc/5.2/fltk/1.3.3
@@ -39,8 +53,6 @@ This section is primarily for administrators of the system.
   make
   make install
 
-Module File
------------
 Modulefile at ``/usr/local/modulefiles/libs/gcc/5.2/fltk/1.3.3``
 
 .. code-block:: none

--- a/iceberg/software/modulefiles/libs/gcc/4.9.2/fftw/3.3.5
+++ b/iceberg/software/modulefiles/libs/gcc/4.9.2/fftw/3.3.5
@@ -1,0 +1,25 @@
+#%Module1.0#####################################################################
+##
+## fftw 3.3.5 module file
+##
+
+## Module file logging
+source /usr/local/etc/module_logging.tcl
+
+set fftwvers 3.3.5
+set compiler gcc
+set compilervers 4.9.2
+
+proc ModulesHelp { } {
+        global fftwvers
+        puts stderr "Makes the FFTW $fftwvers library available"
+}
+module-whatis   "Makes the FFTW $fftwvers library available"
+
+set FFTW_DIR /usr/local/packages6/libs/$compiler/$compilervers/fftw/$fftwvers
+
+prepend-path CPATH $FFTW_DIR/include
+prepend-path LD_LIBRARY_PATH $FFTW_DIR/lib
+prepend-path LIBRARY_PATH $FFTW_DIR/lib
+prepend-path MANPATH $FFTW_DIR/share/man
+prepend-path PATH $FFTW_DIR/bin

--- a/iceberg/software/modulefiles/libs/gcc/4.9.2/fltk/1.3.3
+++ b/iceberg/software/modulefiles/libs/gcc/4.9.2/fltk/1.3.3
@@ -1,0 +1,28 @@
+#%Module1.0#####################################################################
+##
+## fltk 1.3.3 module file
+##
+
+## Module file logging
+source /usr/local/etc/module_logging.tcl
+##
+
+set fltkvers     1.3.3
+set compiler     gcc
+set compilervers 4.9.2
+
+module load compilers/$compiler/$compilervers
+
+proc ModulesHelp { } {
+    global fltkvers
+    puts stderr "Makes the FLTK $fltkvers library available"
+}
+
+set FLTK_DIR /usr/local/packages6/libs/$compiler/$compilervers/fltk/$fltkvers
+
+module-whatis   "Makes the FLTK $fltkvers library available"
+
+prepend-path LD_LIBRARY_PATH    $FLTK_DIR/lib
+prepend-path CPLUS_INCLUDE_PATH $FLTK_DIR/include
+prepend-path LIBRARY_PATH       $FLTK_DIR/lib
+prepend-path PATH               $FLTK_DIR/bin


### PR DESCRIPTION
Add a FFTW build that is a) a little newer and b) has a run-time dependency on a CUDA-compatible GCC (i.e. gcc < 5.0.0).

Also, Add a FLTK build that is has a run-time dependency on a CUDA-compatible GCC (i.e. gcc < 5.0.0).