### PR TITLE
Iceberg + Intel MKL: add dedicated module file and page for v11.2.3

### DIFF
--- a/iceberg/software/apps/intel_r.rst
+++ b/iceberg/software/apps/intel_r.rst
@@ -9,7 +9,7 @@ R (Intel Build)
    :URL: http://www.r-project.org/
    :Documentation: http://www.r-project.org/
 
-R is a statistical computing language. This version of R is built using the :ref:`Intel Compilers` and the Intel Math Kernel Library. This combination can result in significantly faster runtimes in certain circumstances.
+R is a statistical computing language. This version of R is built using the :ref:`Intel compilers <iceberg_intel_compilers>` and the Intel Math Kernel Library. This combination can result in significantly faster runtimes in certain circumstances.
 
 Most R extensions are written and tested for the gcc suite of compilers so it is recommended that you perform testing before switching to this version of R.
 

--- a/iceberg/software/apps/r.rst
+++ b/iceberg/software/apps/r.rst
@@ -127,7 +127,7 @@ For full details about the functions made available by the Rmath library, see se
 
 Accelerated version of R
 ------------------------
-There is an experimental, accelerated version of R installed on Iceberg that makes use of the :ref:`Intel Compilers` and the Intel MKL. See :ref:`Intel R` for details.
+There is an experimental, accelerated version of R installed on Iceberg that makes use of the :ref:`Intel compilers <iceberg_intel_compilers>` and the Intel MKL. See :ref:`Intel R` for details.
 
 Installation Notes
 ------------------

--- a/iceberg/software/compilers/intel.rst
+++ b/iceberg/software/compilers/intel.rst
@@ -1,4 +1,4 @@
-.. _`Intel Compilers`:
+.. _iceberg_intel_compilers:
 
 Intel Compilers
 ===============

--- a/iceberg/software/libs/intel-mkl.rst
+++ b/iceberg/software/libs/intel-mkl.rst
@@ -1,0 +1,34 @@
+.. _iceberg_intel_mkl:
+
+Intel Math Kernel Library
+=========================
+
+Intel's Math Kernel Library (MKL) provides highly optimized, threaded and
+vectorized functions to maximize performance on each processor family.  It
+utilises de-facto standard C and Fortran APIs for compatibility with BLAS,
+LAPACK and FFTW functions from other math libraries.
+
+Parallel Studio Composer Edition version
+----------------------------------------
+
+The MKL was installed along with the :ref:`Intel compilers <iceberg_intel_compilers>` as part of Intel
+Parallel Studio XE 2015 (Update 3).  The MKL can be used with or without other
+Parallel Studio packages (such as the Intel compilers).  
+
+To activate just the MKL: ::
+
+    module load libs/intel-mkl/11.2.3
+
+Installation Notes
+------------------
+
+The following notes are primarily for system administrators.
+
+**Intel MKL 11.2.3**
+
+Installed as part of :ref:`Intel Parallel Studio Composer Edition 2015 Update 3
+<iceberg_intel_compilers>`.
+
+:download:`This modulefile
+</iceberg/software/modulefiles/libs/intel-mkl/11.2.3>` was installed as
+``/usr/local/modulefiles/libs/intel-mkl/11.2.3``

--- a/iceberg/software/libs/nagfortran.rst
+++ b/iceberg/software/libs/nagfortran.rst
@@ -19,7 +19,7 @@ Use the following command to make Mark 25 of the serial (1 CPU core) version of 
 
     module load libs/intel/15/NAG/fll6i25dcl
 
-Once you have ensured that you have loaded the module for the :ref:`Intel Compilers` you can compile your NAG program using ::
+Once you have ensured that you have loaded the module for the :ref:`Intel compilers <iceberg_intel_compilers>` you can compile your NAG program using ::
 
     ifort your_code.f90 -lnag_mkl -o your_code.exe
 

--- a/iceberg/software/modulefiles/libs/intel-mkl/11.2.3
+++ b/iceberg/software/modulefiles/libs/intel-mkl/11.2.3
@@ -1,0 +1,33 @@
+#%Module1.0#####################################################################
+#
+# Intel Math Kernel Library (MKL) 2015.3.187 module file
+# 
+################################################################################
+
+# Module file logging
+source /usr/local/etc/module_logging.tcl
+
+set     mklvers      11.2.3
+
+proc ModulesHelp { } {
+        global mklvers
+
+        puts stderr "   Makes the `Intel Math Kernel Library (MLK) $mklvers' available for use"
+}
+
+module-whatis   "Makes the Intel Math Kernel Library (MLK) mklvers available for use"
+
+set     intelpsroot   /usr/local/packages6/compilers/intel/2015/composer_xe_2015.3.187/
+
+# Environment variables determined using
+# $ env2 -from bash -to modulecmd "/usr/local/packages6/compilers/intel/2015/composer_xe_2015.3.187/mkl/bin/mklvars.sh intel64" | sed -e "s#/usr/local/packages6/compilers/intel/2015/composer_xe_2015.3.187#\$intelpsroot#g" -e 's/[{}]//g'
+#
+append-path MIC_LD_LIBRARY_PATH $intelpsroot/compiler/lib/mic;
+append-path MIC_LD_LIBRARY_PATH $intelpsroot/mkl/lib/mic;
+append-path CPATH $intelpsroot/mkl/include;
+prepend-path LD_LIBRARY_PATH $intelpsroot/mkl/lib/intel64;
+prepend-path LD_LIBRARY_PATH $intelpsroot/compiler/lib/intel64;
+prepend-path MANPATH $intelpsroot/man/en_US;
+append-path LIBRARY_PATH $intelpsroot/compiler/lib/intel64;
+append-path LIBRARY_PATH $intelpsroot/mkl/lib/intel64;
+append-path NLSPATH $intelpsroot/mkl/lib/intel64/locale/%l_%t/%N;


### PR DESCRIPTION
Should make it easier to use GCC, apps/libs that depend on GCC for their C++ STL lib and the MKL in the same environment.

Version determined using [this useful table](https://software.intel.com/en-us/articles/which-version-of-the-intel-ipp-intel-mkl-and-intel-tbb-libraries-are-included-in-the-intel).

NB still need to install Intel Parallel Studio 2017 on Iceberg (#359)