### PR TITLE
Convert all absolute URLs to files in this repo to relative (:download:)

### DIFF
--- a/iceberg/software/apps/CASTEP.rst
+++ b/iceberg/software/apps/CASTEP.rst
@@ -181,10 +181,10 @@ The directory ``CASTEP-8.0`` was then deleted and the parallel version was insta
 
 Modulefiles
 -----------
-* `CASTEP 16.1-serial <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/apps/intel/15/castep/16.1-serial>`_
-* `CASTEP 16.1-parallel <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/apps/intel/15/castep/16.1-parallel>`_
-* `CASTEP 8.0-serial <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/apps/intel/15/castep/8.0-serial>`_
-* `CASTEP 8.0-parallel <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/apps/intel/15/castep/16.1-parallel>`_
+* :download:`CASTEP 16.1-serial </iceberg/software/modulefiles/apps/intel/15/castep/16.1-serial>`
+* :download:`CASTEP 16.1-parallel </iceberg/software/modulefiles/apps/intel/15/castep/16.1-parallel>`
+* :download:`CASTEP 8.0-serial </iceberg/software/modulefiles/apps/intel/15/castep/8.0-serial>`
+* :download:`CASTEP 8.0-parallel </iceberg/software/modulefiles/apps/intel/15/castep/16.1-parallel>`
 
 Testing
 -------

--- a/iceberg/software/apps/MOMFBD.rst
+++ b/iceberg/software/apps/MOMFBD.rst
@@ -15,10 +15,13 @@ data.
 Usage
 -----
 
-The MOMFBD binaries can be added to your path with ::
+The MOMFBD binaries can be added to your path with: ::
 
-    module load apps/gcc/5.2/MOMFBD
+        module load apps/gcc/5.2/MOMFBD
 
 Installation notes
 ------------------
-MOMFBD was installed using gcc 5.2. Using `this script <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/apps/gcc/5.2/MOMFBD/install_momfbd.sh>`_ and is loaded by `this modulefle <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/apps/gcc/5.2/momfbd/2016.04.14>`_.
+
+MOMFBD was installed using gcc 5.2. 
+Using :download:`this script </iceberg/software/install_scripts/apps/gcc/5.2/MOMFBD/install_momfbd.sh>` 
+and is loaded by :download:`this modulefle </iceberg/software/modulefiles/apps/gcc/5.2/momfbd/2016.04.14>`.

--- a/iceberg/software/apps/bcbio.rst
+++ b/iceberg/software/apps/bcbio.rst
@@ -65,7 +65,7 @@ Version 0.9.6a was installed using gcc 5.2, R 3.2.1 and Anaconda Python 2.3. The
 
 The first step was to run the SGE script below in batch mode. Note that the install often fails due to external services being flaky. See https://github.com/rcgsheffield/sheffield_hpc/issues/219 for details. Depending on the reason for the failure, it should be OK to simply restart the install. This particular install was done in one-shot...no restarts necessary.
 
-* `install_bcbio_0.96a <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/apps/gcc/5.2/bcbio/install_bcbio_0.96a.sge>`_
+* :download:`install_bcbio_0.96a </iceberg/software/install_scripts/apps/gcc/5.2/bcbio/install_bcbio_0.96a.sge>`
 
 The output from this batch run can be found in `/usr/local/packages6/apps/gcc/5.2/bcbio/0.9.6a/install_output/`
 
@@ -140,8 +140,8 @@ Update: **14th March 2016**
 
 The development version was installed using gcc 5.2, R 3.2.1 and Anaconda Python 2.3.
 
-* `install_bcbio_devel.sge <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/apps/gcc/5.2/bcbio/install_bcbio_devel.sge>`_ This is a SGE submit script. The long running time of the installer made it better-suited to being run as a batch job.
-* `bcbio-devel modulefile <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/apps/gcc/5.2/bcbio/devel>`_ located on the system at ``/usr/local/modulefiles/apps/gcc/5.2/bcbio/devel``
+* :download:`install_bcbio_devel.sge </iceberg/software/install_scripts/apps/gcc/5.2/bcbio/install_bcbio_devel.sge>` This is a SGE submit script. The long running time of the installer made it better-suited to being run as a batch job.
+* :download:`bcbio-devel modulefile </iceberg/software/modulefiles/apps/gcc/5.2/bcbio/devel>` located on the system at ``/usr/local/modulefiles/apps/gcc/5.2/bcbio/devel``
 
 The first install attempt failed with the error ::
 
@@ -175,7 +175,7 @@ The GATK .jar file was obtained from https://www.broadinstitute.org/gatk/downloa
 Module files
 ------------
 
-* `0.9.6a <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/apps/gcc/5.2/bcbio/0.9.6a>`_
+* :download:`0.9.6a </iceberg/software/modulefiles/apps/gcc/5.2/bcbio/0.9.6a>`
 
 Testing
 -------

--- a/iceberg/software/apps/bedtools.rst
+++ b/iceberg/software/apps/bedtools.rst
@@ -32,7 +32,7 @@ After that any of the bedtools commands can be run from the prompt.
 
 Installation notes
 ------------------
-bedtools was installed using gcc 5.2 with the script `install_bedtools.sh <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/apps/gcc/5.2/bedtools/install_bedtools.sh>`_
+bedtools was installed using gcc 5.2 with the script :download:`install_bedtools.sh </iceberg/software/install_scripts/apps/gcc/5.2/bedtools/install_bedtools.sh>`
 
 
 Testing

--- a/iceberg/software/apps/bless.rst
+++ b/iceberg/software/apps/bless.rst
@@ -107,5 +107,5 @@ No test suite was found.
 
 Modulefile
 ----------
-* The module file is on the system at `/usr/local/modulefiles/apps/gcc/4.9.2/bless/1.02`
-* The module file is `on github <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/apps/gcc/4.9.2/bless/1.02>`_.
+* The module file is on the system at ``/usr/local/modulefiles/apps/gcc/4.9.2/bless/1.02``
+* The module file is :download:`on github </iceberg/software/modulefiles/apps/gcc/4.9.2/bless/1.02>`.

--- a/iceberg/software/apps/bwa.rst
+++ b/iceberg/software/apps/bwa.rst
@@ -91,10 +91,10 @@ The default version is controlled by the `.version` file at `/usr/local/modulefi
 
 *Version 0.7.12*
 
-* The module file is on the system at `/usr/local/modulefiles/apps/gcc/5.2/bwa/0.7.12`
-* On github: `0.7.12 <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/apps/gcc/5.2/bwa/0.7.12>`_.
+* The module file is on the system at ``/usr/local/modulefiles/apps/gcc/5.2/bwa/0.7.12``
+* On github: :download:`0.7.12 </iceberg/software/modulefiles/apps/gcc/5.2/bwa/0.7.12>`.
 
 *Version 0.7.5a*
 
-* The module file is on the system at `/usr/local/modulefiles/apps/gcc/5.2/bwa/0.7.5a`
-* On github: `0.7.5a <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/apps/gcc/5.2/bwa/0.7.5a>`_.
+* The module file is on the system at ``/usr/local/modulefiles/apps/gcc/5.2/bwa/0.7.5a``
+* On github: :download:`0.7.5a </iceberg/software/modulefiles/apps/gcc/5.2/bwa/0.7.5a>`.

--- a/iceberg/software/apps/code_saturne_4.0.rst
+++ b/iceberg/software/apps/code_saturne_4.0.rst
@@ -112,8 +112,8 @@ Post Install Steps
 ------------------
 To make Code Saturne aware of the SGE system:
 
-* Created ``/usr/local/packages6/apps/gcc/4.4.7/code_saturne/4.0/etc/code_saturne.cfg``: See `code_saturne.cfg 4.0 <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/apps/assets/code_saturne/4.0/code_saturne.cfg>`_
-* Modified ``/usr/local/packages6/apps/gcc/4.4.7/code_saturne/4.0/share/code_saturne/batch/batch.SGE``. See: `batch.SGE 4.0 <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/apps/assets/code_saturne/4.0/batch.SGE>`_
+* Created ``/usr/local/packages6/apps/gcc/4.4.7/code_saturne/4.0/etc/code_saturne.cfg``: See :download:`code_saturne.cfg 4.0 </iceberg/software/apps/assets/code_saturne/4.0/code_saturne.cfg>`
+* Modified ``/usr/local/packages6/apps/gcc/4.4.7/code_saturne/4.0/share/code_saturne/batch/batch.SGE``. See: :download:`batch.SGE 4.0 </iceberg/software/apps/assets/code_saturne/4.0/batch.SGE>`
 
 Testing
 -------

--- a/iceberg/software/apps/ffmpeg.rst
+++ b/iceberg/software/apps/ffmpeg.rst
@@ -62,4 +62,4 @@ All tests passed.
 Modulefile
 ----------
 * The module file is on the system at `/usr/local/modulefiles/apps/gcc/5.2/ffmpeg/2.8.3`
-* The module file is `on github <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/apps/gcc/5.2/ffmpeg/2.8.3>`_.
+* The module file is :download:`on github </iceberg/software/modulefiles/apps/gcc/5.2/ffmpeg/2.8.3>`.

--- a/iceberg/software/apps/gemini.rst
+++ b/iceberg/software/apps/gemini.rst
@@ -10,50 +10,50 @@ GEMINI (GEnome MINIng) is a flexible framework for exploring genetic variation i
 
 Making gemini available
 -----------------------
-The following module command makes the latest version of gemini available to your session ::
+The following module command makes the latest version of gemini available to your session: ::
 
-      module load apps/gcc/4.4.7/gemini
+        module load apps/gcc/4.4.7/gemini
 
-Alternatively, you can make a specific version available ::
+Alternatively, you can make a specific version available: ::
 
-      module load apps/gcc/4.4.7/gemini/0.18
+        module load apps/gcc/4.4.7/gemini/0.18
 
 Installation notes
 ------------------
 These are primarily for system administrators.
 
 * gemini was installed using the gcc 4.4.7 compiler
-* `install_gemini.sh <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/apps/gcc/4.4.7/gemini/0.18/install_gemini.sh>`_
+* :download:`install_gemini.sh </iceberg/software/install_scripts/apps/gcc/4.4.7/gemini/0.18/install_gemini.sh>`
 
 
 Testing
 -------
 The test script used was
 
-* `test_gemini.sh <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/test_scripts/apps/gcc/4.4.7/gemini/0.18/test_gemini.sh>`_
+* :download:`test_gemini.sh </iceberg/software/test_scripts/apps/gcc/4.4.7/gemini/0.18/test_gemini.sh>`
 
-The full output from the test run is on the system at `/usr/local/packages6/apps/gcc/4.4.7/gemini/0.18/test_results/`
+The full output from the test run is on the system at ``/usr/local/packages6/apps/gcc/4.4.7/gemini/0.18/test_results/``
 
-There was one failure ::
+There was one failure: ::
 
-      effstring.t02...\c
-  ok
-      effstring.t03...\c
-  15d14
-  < gene	impact	impact_severity	biotype	is_exonic	is_coding	is_lof
-  64a64
-  > gene	impact	impact_severity	biotype	is_exonic	is_coding	is_lof
-  fail
-  updated 10 variants
-       annotate-tool.t1 ... ok
-  updated 10 variants
-       annotate-tool.t2 ... ok
+          effstring.t02...\c
+      ok
+          effstring.t03...\c
+      15d14
+      < gene	impact	impact_severity	biotype	is_exonic	is_coding	is_lof
+      64a64
+      > gene	impact	impact_severity	biotype	is_exonic	is_coding	is_lof
+      fail
+      updated 10 variants
+           annotate-tool.t1 ... ok
+      updated 10 variants
+           annotate-tool.t2 ... ok
 
 This was reported to the developers who `indicated that it was nothing to worry about <https://github.com/arq5x/gemini/issues/621>`_
 
 Modulefile
 ----------
-The module file is on the system at `/usr/local/modulefiles/apps/gcc/4.4.7/gemini/0.18`
+The module file is on the system at ``/usr/local/modulefiles/apps/gcc/4.4.7/gemini/0.18``
 
 The contents of the module file is ::
 

--- a/iceberg/software/apps/gromacs.rst
+++ b/iceberg/software/apps/gromacs.rst
@@ -12,12 +12,10 @@ GROMACS
 
 Interactive Usage
 -----------------
-After connecting to iceberg (see :ref:`ssh`),  start an interactive session with the :code:`qsh` or :code:`qrsh` command. To make GROMACS available in this session, run one of the following command:
-
-.. code-block:: none
+After connecting to iceberg (see :ref:`ssh`),  start an interactive session with the ``qsh`` or ``qrsh`` command. 
+To make GROMACS available in this session, run one of the following command: ::
 
       source /usr/local/packages6/apps/intel/15/gromacs/5.1/bin/GMXRC
-
 
 Installation notes
 -------------------
@@ -28,10 +26,10 @@ Version 5.1
 Compilation Choices:
 
 * Use latest intel compilers
-* -DGMX_MPI=on
-* -DCMAKE_PREFIX_PATH=/usr/local/packages6/apps/intel/15/gromcas
-* -DGMX_FFT_LIBRARY="fftw3"
-* -DGMX_BUILD_OWN_FFTW=ON
+* ``-DGMX_MPI=on``
+* ``-DCMAKE_PREFIX_PATH=/usr/local/packages6/apps/intel/15/gromcas``
+* ``-DGMX_FFT_LIBRARY="fftw3"``
+* ``-DGMX_BUILD_OWN_FFTW=ON``
 
-The script used to build gromacs can be found `here
-<https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/apps/gromacs/install_gromacs_5.1.sh>`_.
+The script used to build gromacs can be found :download:`here
+</iceberg/software/install_scripts/apps/gromacs/install_gromacs_5.1.sh>`.

--- a/iceberg/software/apps/htop.rst
+++ b/iceberg/software/apps/htop.rst
@@ -39,5 +39,5 @@ No test suite was found.
 
 Modulefile
 ----------
-* The module file is on the system at `/usr/local/modulefiles/apps/gcc/4.4.7/htop/2.0`
-* The module file is `on github <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/apps/gcc/4.4.7/htop/2.0>`_.
+* The module file is on the system at ``/usr/local/modulefiles/apps/gcc/4.4.7/htop/2.0``
+* The module file is :download:`on github </iceberg/software/modulefiles/apps/gcc/4.4.7/htop/2.0>`.

--- a/iceberg/software/apps/imagej.rst
+++ b/iceberg/software/apps/imagej.rst
@@ -10,7 +10,7 @@ ImageJ is a public domain, Java-based image processing program developed at the 
 
 Interactive Usage
 -----------------
-After connecting to Iceberg (see :ref:`ssh`),  start an interactive session with the `qrshx` command.
+After connecting to Iceberg (see :ref:`ssh`),  start an interactive session with the ``qrshx`` command.
 
 The latest version of ImageJ (currently 1.50g) is made available with the command ::
 
@@ -21,15 +21,15 @@ Alternatively, you can load a specific version with ::
         module load apps/binapps/imagej/1.50g
 
 This module command also changes the environment to use Java 1.8 and Java 3D 1.5.2
-An environment variable called `IMAGEJ_DIR` is created by the module command that contains the path to the requested version of ImageJ.
+An environment variable called ``IMAGEJ_DIR`` is created by the module command that contains the path to the requested version of ImageJ.
 
 You can start ImageJ, with default settings, with the command ::
 
-   imagej
+        imagej
 
-This starts imagej with 512Mb of Java heap space. To request more, you need to run the Java .jar file directly and use the `-Xmx` Java flag. For example, to request 1 Gigabyte ::
+This starts imagej with 512Mb of Java heap space. To request more, you need to run the Java .jar file directly and use the ``-Xmx`` Java flag. For example, to request 1 Gigabyte ::
 
-    java -Xmx1G -Dplugins.dir=$IMAGEJ_DIR/plugins/ -jar $IMAGEJ_DIR/ij.jar
+        java -Xmx1G -Dplugins.dir=$IMAGEJ_DIR/plugins/ -jar $IMAGEJ_DIR/ij.jar
 
 You will need to ensure that you've requested enough virtual memory from the scheduler to support the above request.
 For more details, please refer to the Virtual Memory section of our :ref:`Java-iceberg` documentation.
@@ -40,15 +40,15 @@ Links to documentation can be found at http://imagej.nih.gov/ij/download.html
 
 Installation notes
 ------------------
-Install version 1.49 using the `install_imagej.sh <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/apps/imagej/1.50g/install_imagej.sh>`_ script
+Install version 1.49 using the :download:`install_imagej.sh </iceberg/software/install_scripts/apps/imagej/1.50g/install_imagej.sh>` script
 
 Run the GUI and update to the latest version by clicking on `Help > Update ImageJ`
 
-Rename the `run` script to `imagej` since `run` is too generic.
+Rename the ``run`` script to ``imagej`` since ``run`` is too generic.
 
-Modify the `imagej` script so that it reads ::
+Modify the ``imagej`` script so that it reads: ::
 
-    java -Xmx512m -jar -Dplugins.dir=/usr/local/packages6/apps/binapps/imagej/1.50g/plugins/ /usr/local/packages6/apps/binapps/imagej/1.50g/ij.jar
+        java -Xmx512m -jar -Dplugins.dir=/usr/local/packages6/apps/binapps/imagej/1.50g/plugins/ /usr/local/packages6/apps/binapps/imagej/1.50g/ij.jar
 
 ImageJ's 3D plugin requires Java 3D which needs to be included in the JRE used by imagej.
 I attempted a module-controlled version of Java3D but the plugin refused to recognise it. See https://github.com/rcgsheffield/sheffield_hpc/issues/279 for details.
@@ -57,31 +57,31 @@ The plug-in will install Java3D within the JRE for you if you launch it and clic
 
 Modulefile
 ----------
-* The module file is on the system at `/usr/local/modulefiles/apps/binapps/imagej/1.50g`
+* The module file is on the system at ``/usr/local/modulefiles/apps/binapps/imagej/1.50g``
 
-Its contents are ::
+Its contents are: ::
 
-  #%Module1.0#####################################################################
-  ##
-  ## ImageJ 1.50g modulefile
-  ##
+        #%Module1.0#####################################################################
+        ##
+        ## ImageJ 1.50g modulefile
+        ##
 
-  ## Module file logging
-  source /usr/local/etc/module_logging.tcl
-  ##
+        ## Module file logging
+        source /usr/local/etc/module_logging.tcl
+        ##
 
-  module load apps/java/1.8u71
+        module load apps/java/1.8u71
 
-  proc ModulesHelp { } {
-        puts stderr "Makes ImageJ 1.50g available"
-  }
+        proc ModulesHelp { } {
+              puts stderr "Makes ImageJ 1.50g available"
+        }
 
 
-  set version 1.50g
-  set IMAGEJ_DIR /usr/local/packages6/apps/binapps/imagej/$version
+        set version 1.50g
+        set IMAGEJ_DIR /usr/local/packages6/apps/binapps/imagej/$version
 
-  module-whatis   "Makes ImageJ 1.50g available"
+        module-whatis   "Makes ImageJ 1.50g available"
 
-  prepend-path PATH $IMAGEJ_DIR
-  prepend-path CLASSPATH $IMAGEJ_DIR/
-  prepend-path IMAGEJ_DIR $IMAGEJ_DIR
+        prepend-path PATH $IMAGEJ_DIR
+        prepend-path CLASSPATH $IMAGEJ_DIR/
+        prepend-path IMAGEJ_DIR $IMAGEJ_DIR

--- a/iceberg/software/apps/mathematica.rst
+++ b/iceberg/software/apps/mathematica.rst
@@ -198,5 +198,5 @@ Install the University network ``mathpass`` file at ``/usr/local/packages6/apps/
 
 Modulefiles
 -----------
-* The `10.3.1 module file  <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/apps/binapps/mathematica/10.3.1>`_.
-* The `10.2 module file  <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/apps/binapps/mathematica/10.2>`_.
+* The :download:`10.3.1 module file </iceberg/software/modulefiles/apps/binapps/mathematica/10.3.1>`.
+* The :download:`10.2 module file  </iceberg/software/modulefiles/apps/binapps/mathematica/10.2>`.

--- a/iceberg/software/apps/octave.rst
+++ b/iceberg/software/apps/octave.rst
@@ -80,8 +80,8 @@ Octave was installed using gcc 5.2 and the following libraries:
 * :ref:`fltk` 1.3.3
 * :ref:`fftw` 3.3.4
 
-* Octave was installed using a SGE batch job. The install script is on `github <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/apps/gcc/5.2/octave/install_octave.sh>`_
-* The make log is on the system at `/usr/local/packages6/apps/gcc/5.2/octave/4.0/make_octave4.0.0.log`
+* Octave was installed using a SGE batch job. The install script is on :download:`github </iceberg/software/install_scripts/apps/gcc/5.2/octave/install_octave.sh>`
+* The make log is on the system at ``/usr/local/packages6/apps/gcc/5.2/octave/4.0/make_octave4.0.0.log``
 * The configure log is on the system at `/usr/local/packages6/apps/gcc/5.2/octave/4.0/configure_octave4.0.0.log`
 
 For full functionality, Octave requires a large number of additional libraries to be installed. We have currently not installed all of these but will do so should they be required.
@@ -276,4 +276,4 @@ For information, here is the relevant part of the Configure log that describes h
 Module File
 -----------
 
-The module file is `octave_4.0 <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/apps/gcc/5.2/octave/4.0>`_
+The module file is :download:`octave_4.0 </iceberg/software/modulefiles/apps/gcc/5.2/octave/4.0>`

--- a/iceberg/software/apps/openfoam.rst
+++ b/iceberg/software/apps/openfoam.rst
@@ -31,6 +31,6 @@ Installation notes
 ------------------
 
 OpenFoam was compiled using the
-`install_openfoam.sh <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/apps/gcc/5.2/openfoam/install_openfoam.sh>`_ script, the module
+:download:`install_openfoam.sh </iceberg/software/install_scripts/apps/gcc/5.2/openfoam/install_openfoam.sh>` script, the module
 file is
-`3.0.0 <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/apps/gcc/5.2/openfoam/3.0.0>`_.
+`3.0.0 </iceberg/software/install_scripts/apps/gcc/5.2/openfoam/3.0.0>`.

--- a/iceberg/software/apps/phyluce.rst
+++ b/iceberg/software/apps/phyluce.rst
@@ -17,18 +17,19 @@ Phyluce can be activated using the module file::
 
     module load apps/binapps/phyluce/1.5.0
 
-
 Phyluce makes use of the ``apps/python/conda`` module, therefore this module will be loaded by loading Phyluce.
 As Phyluce is a Python package your default Python interpreter will be changed by loading Phyluce.
 
 Installation notes
 ------------------
 
-As root::
+As root: ::
 
-  $ module load apps/python/conda
-  $ conda create -p /usr/local/packages6/apps/binapps/conda/phyluce python=2
-  $ source activate /usr/local/packages6/apps/binapps/conda/phyluce
-  $ conda install -c https://conda.binstar.org/faircloth-lab phyluce
+      $ module load apps/python/conda
+      $ conda create -p /usr/local/packages6/apps/binapps/conda/phyluce python=2
+      $ source activate /usr/local/packages6/apps/binapps/conda/phyluce
+      $ conda install -c https://conda.binstar.org/faircloth-lab phyluce
 
-This installs Phyluce as a conda environment in the /usr/local/packages6/apps/binapps/conda/phyluce folder, which is then loaded by the module file `phyluce/1.5.0 <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/apps/binapps/phyluce/1.5.0>`_, which is a modification of the anaconda module files.
+This installs Phyluce as a conda environment in the ``/usr/local/packages6/apps/binapps/conda/phyluce`` folder, 
+which is then loaded by the module file :download:`phyluce/1.5.0 </iceberg/software/modulefiles/apps/binapps/phyluce/1.5.0>`, 
+which is a modification of the anaconda module files.

--- a/iceberg/software/apps/povray.rst
+++ b/iceberg/software/apps/povray.rst
@@ -39,7 +39,7 @@ Installation notes
 ------------------
 povray 3.7.0 was installed using gcc 5.2 using the following script 
 
-* `install_povray-3.7.sh <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/apps/gcc/5.2/povray/0.37/install_povray-3.7.sh>`_
+* `install_povray-3.7.sh <https://github.com/rcgsheffield/sheffield_hpc/blob/master/iceberg/software/install_scripts/apps/gcc/5.2/povray/0.37/install_povray-3.7.sh>`_
 
 Testing
 -------
@@ -51,5 +51,5 @@ All tests passed.
 
 Modulefile
 ----------
-* The module file is on the system at `/usr/local/modulefiles/apps/gcc/5.2/povray/3.7`
-* The module file is `on github <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/apps/gcc/5.2/povray/3.7>`_.
+* The module file is on the system at ``/usr/local/modulefiles/apps/gcc/5.2/povray/3.7``
+* The module file is :download:`on github </iceberg/software/modulefiles/apps/gcc/5.2/povray/3.7>`.

--- a/iceberg/software/apps/r.rst
+++ b/iceberg/software/apps/r.rst
@@ -153,8 +153,8 @@ This was a scripted install. It was compiled from source with gcc 4.4.7 and with
 
 This build required several external modules including :ref:`xzutils`, :ref:`curl`, :ref:`bzip2` and :ref:`zlib`
 
-* `install_R_3.3.0.sh <https://raw.githubusercontent.com/rcgsheffield/sheffield_hpc/master/iceberg/software/install_scripts/apps/R/install_R_3.3.0.sh>`_ Downloads, compiles, tests and installs R 3.3.0 and the ``Rmath`` library.
-* `R 3.3.0 Modulefile <https://raw.githubusercontent.com/rcgsheffield/sheffield_hpc/master/iceberg/software/modulefiles/apps/R/3.3.9>`_ located on the system at ``/usr/local/modulefiles/apps/R/3.3.0``
+* :download:`install_R_3.3.0.sh </iceberg/software/install_scripts/apps/R/install_R_3.3.0.sh>` Downloads, compiles, tests and installs R 3.3.0 and the ``Rmath`` library.
+* :download:`R 3.3.0 Modulefile </iceberg/software/modulefiles/apps/R/3.3.0>` located on the system at ``/usr/local/modulefiles/apps/R/3.3.0``
 * Install log-files, including the output of the `make check` tests are available on the system at `/usr/local/packages6/R/3.3.0/install_logs`
 
 **Version 3.2.4**
@@ -165,8 +165,8 @@ This was a scripted install. It was compiled from source with gcc 4.4.7 and with
 
 This build made use of new versions of :ref:`xzutils` and :ref:`curl`
 
-* `install_R_3.2.4.sh <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/iceberg/install_scripts/apps/R/install_R_3.2.4.sh>`_ Downloads, compiles, tests and installs R 3.2.4 and the ``Rmath`` library.
-* `R 3.2.4 Modulefile <https://raw.githubusercontent.com/rcgsheffield/sheffield_hpc/master/iceberg/software/modulefiles/apps/R/3.2.4>`_ located on the system at ``/usr/local/modulefiles/apps/R/3.2.4``
+* :download:`install_R_3.2.4.sh </iceberg/software/install_scripts/apps/R/install_R_3.2.4.sh>` Downloads, compiles, tests and installs R 3.2.4 and the ``Rmath`` library.
+* :download:`R 3.2.4 Modulefile </iceberg/software/modulefiles/apps/R/3.2.4>` located on the system at ``/usr/local/modulefiles/apps/R/3.2.4``
 * Install log-files, including the output of the `make check` tests are available on the system at `/usr/local/packages6/R/3.2.4/install_logs`
 
 **Version 3.2.3**
@@ -175,8 +175,8 @@ This build made use of new versions of :ref:`xzutils` and :ref:`curl`
 
 This was a scripted install. It was compiled from source with gcc 4.4.7 and with ``--enable-R-shlib`` enabled. You will need a large memory ``qrsh`` session in order to successfully run the build script. I used ``qrsh -l rmem=8G -l mem=16G``
 
-* `install_R_3.2.3.sh <https://raw.githubusercontent.com/rcgsheffield/sheffield_hpc/master/iceberg/software/install_scripts/apps/R/install_R_3.2.3.sh>`_ Downloads, compiles, tests and installs R 3.2.3 and the ``Rmath`` library.
-* `R 3.2.3 Modulefile <https://raw.githubusercontent.com/rcgsheffield/sheffield_hpc/master/iceberg/software/modulefiles/apps/R/3.2.3>`_ located on the system at ``/usr/local/modulefiles/apps/R/3.2.3``
+* :download:`install_R_3.2.3.sh </iceberg/software/install_scripts/apps/R/install_R_3.2.3.sh>` Downloads, compiles, tests and installs R 3.2.3 and the ``Rmath`` library.
+* :download:`R 3.2.3 Modulefile </iceberg/software/modulefiles/apps/R/3.2.3>` located on the system at ``/usr/local/modulefiles/apps/R/3.2.3``
 * Install log-files, including the output of the `make check` tests are available on the system at `/usr/local/packages6/R/3.2.3/install_logs`
 
 **Version 3.2.2**
@@ -185,16 +185,16 @@ This was a scripted install. It was compiled from source with gcc 4.4.7 and with
 
 This was a scripted install. It was compiled from source with gcc 4.4.7 and with ``--enable-R-shlib`` enabled. You will need a large memory ``qrsh`` session in order to successfully run the build script. I used ``qrsh -l rmem=8G -l mem=16G``
 
-* `install_R_3.2.2.sh <https://raw.githubusercontent.com/rcgsheffield/sheffield_hpc/master/iceberg/software/install_scripts/apps/R/install_R_3.2.2.sh>`_ Downloads, compiles and installs R 3.2.2 and the ``Rmath`` library.
-* `R 3.2.2 Modulefile <https://raw.githubusercontent.com/rcgsheffield/sheffield_hpc/master/iceberg/software/modulefiles/apps/R/3.2.2>`_ located on the system at ``/usr/local/modulefiles/apps/R/3.2.2``
+* :download:`install_R_3.2.2.sh </iceberg/software/install_scripts/apps/R/install_R_3.2.2.sh>` Downloads, compiles and installs R 3.2.2 and the ``Rmath`` library.
+* :download:`R 3.2.2 Modulefile </iceberg/software/modulefiles/apps/R/3.2.2>` located on the system at ``/usr/local/modulefiles/apps/R/3.2.2``
 * Install log-files were manually copied to ``/usr/local/packages6/R/3.2.2/install_logs`` on the system. This step should be included in the next version of the install script.
 
 **Version 3.2.1**
 
 This was a manual install. It was compiled from source with gcc 4.4.7 and with ``--enable-R-shlib`` enabled.
 
-* `Install notes <https://github.com/rcgsheffield/sheffield_hpc/blob/master/iceberg/software/install_scripts/apps/R/R-3.2.1.md>`_
-* `R 3.2.1 Modulefile <https://raw.githubusercontent.com/rcgsheffield/sheffield_hpc/master/iceberg/software/modulefiles/apps/R/3.2.1>`_ located on the system at ``/usr/local/modulefiles/apps/R/3.2.1``
+* :download:`Install notes </iceberg/software/install_scripts/apps/R/R-3.2.1.md>`
+* :download:`R 3.2.1 Modulefile </iceberg/software/modulefiles/apps/R/3.2.1>` located on the system at ``/usr/local/modulefiles/apps/R/3.2.1``
 
 **Older versions**
 

--- a/iceberg/software/apps/relion.rst
+++ b/iceberg/software/apps/relion.rst
@@ -25,7 +25,7 @@ These are primarily for system administrators.
 Install instructions: http://www2.mrc-lmb.cam.ac.uk/relion/index.php/Download_%26_install
 
 * RELION was installed using the gcc 4.4.7 compiler and Openmpi 1.8.8
-* `install_relion.sh <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/apps/gcc/4.4.7/relion/1.4/install_relion.sh>`_
+* :download:`install_relion.sh </iceberg/software/install_scripts/apps/gcc/4.4.7/relion/1.4/install_relion.sh>`
 * Note - the environment variable RELION_QSUB_TEMPLATE points to an SGE qsub template, which needs customizing to work with our environment
 
 Modulefile

--- a/iceberg/software/apps/samtools.rst
+++ b/iceberg/software/apps/samtools.rst
@@ -32,7 +32,7 @@ This section is primarily for system administrators.
 
 **Version 1.3.1**
 
-`This install script <https://github.com/rcgsheffield/sheffield_hpc/blob/master/iceberg/software/install_scripts/apps/samtools/install_samtools_1.3.1.sh>`_:
+:download:`This install script </iceberg/software/install_scripts/apps/samtools/install_samtools_1.3.1.sh>`:
 
 #. Built Samtools plus the bundled **HTSlib**, **HTSlib utilities** such as ``bgzip`` plus various useful plugins.  Compiled using `GCC <gcc_iceberg>`_ 6.2.
 #. Ran all tests using ``make tests``; a summary of the results is shown below; for full results see ``/usr/local/packages6/apps/gcc/6.2/samtools/1.3.1/tests.log`` ::
@@ -69,7 +69,7 @@ This section is primarily for system administrators.
 
 #. Installed Samtools to ``/usr/local/packages6/apps/gcc/6.2/samtools/1.3.1``
 
-Next, `this modulefile <https://github.com/rcgsheffield/sheffield_hpc/blob/master/iceberg/software/modulefiles/apps/gcc/6.2/samtools/1.3.1>`__ was installed as ``/usr/local/modulefiles/apps/gcc/6.2/samtools/1.3.1``
+Next, :download:`this modulefile </iceberg/software/modulefiles/apps/gcc/6.2/samtools/1.3.1>` was installed as ``/usr/local/modulefiles/apps/gcc/6.2/samtools/1.3.1``
 
 **Version 1.2**
 
@@ -120,4 +120,4 @@ The summary of the test output was ::
 
 The full log is on the system at `/usr/local/packages6/apps/gcc/5.2/samtools/1.2/make_tests.log`
 
-`This modulefile <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/apps/gcc/5.2/samtools/1.2>`__ was installed as ``/usr/local/modulefiles/apps/gcc/5.2/samtools/1.2``
+:download:`This modulefile </iceberg/software/modulefiles/apps/gcc/5.2/samtools/1.2>` was installed as ``/usr/local/modulefiles/apps/gcc/5.2/samtools/1.2``

--- a/iceberg/software/apps/su2.rst
+++ b/iceberg/software/apps/su2.rst
@@ -23,5 +23,8 @@ SU2 can be activated using the module file::
 Installation notes
 ------------------
 
-Su2 was compiled using the
-`install_su2.sh <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/apps/gcc/4.4.7/su2/install_su2.sh>`_ script. SU2 also has it's own version of CGNS which was compiled with the script `install_cgns.sh <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/apps/gcc/4.4.7/su2/install_cgns.sh>`_. The module file is `4.1.0 <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/apps/gcc/4.4.7/su2/4.1.0>`_.
+Su2 was compiled using the :download:`install_su2.sh </iceberg/software/install_scripts/apps/gcc/4.4.7/su2/install_su2.sh>` script. 
+
+SU2 also has it's own version of CGNS which was compiled with the script :download:`install_cgns.sh </iceberg/software/install_scripts/apps/gcc/4.4.7/su2/install_cgns.sh>`.
+
+The module file is :download:`4.1.0 </iceberg/software/modulefiles/apps/gcc/4.4.7/su2/4.1.0>`.

--- a/iceberg/software/apps/tophat.rst
+++ b/iceberg/software/apps/tophat.rst
@@ -63,9 +63,9 @@ Testing
 -------
 A test script was executed based on the documentation `on the tophat website <https://ccb.jhu.edu/software/tophat/tutorial.shtml>`_ (retrieved 29th October 2015). It only proves that the code can run without error, not that the result is correct.
 
-* `tophat_test.sh  <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/apps/tophat/tests/tophat_test.sh>`_
+* :download:`tophat_test.sh </iceberg/software/install_scripts/apps/tophat/tests/tophat_test.sh>`
 
 Modulefile
 ----------
-* The module file is on the system at `/usr/local/modulefiles/apps/gcc/4.8.2/tophat/2.1.0`
-* The module file is `on github <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/apps/gcc/4.8.2/tophat/2.1.0>`_.
+* The module file is on the system at ``/usr/local/modulefiles/apps/gcc/4.8.2/tophat/2.1.0``
+* The module file is :download:`on github </iceberg/software/modulefiles/apps/gcc/4.8.2/tophat/2.1.0>`

--- a/iceberg/software/apps/vcftools.rst
+++ b/iceberg/software/apps/vcftools.rst
@@ -29,6 +29,6 @@ Installation notes
 ------------------
 
 VCFtools was compiled using the
-`install_vcftools.sh <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/apps/gcc/5.2/vcftools/install_vcftools.sh>`_ script, the module
+:download:`install_vcftools.sh </iceberg/software/install_scripts/apps/gcc/5.2/vcftools/install_vcftools.sh>` script, the module
 file is
-`0.1.14 <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/apps/gcc/5.2/vcftools/0.1.14>`_.
+:download:`0.1.14 </iceberg/software/install_scripts/apps/gcc/5.2/vcftools/0.1.14>`.

--- a/iceberg/software/compilers/gcc.rst
+++ b/iceberg/software/compilers/gcc.rst
@@ -43,24 +43,24 @@ These notes are primarily for system administrators
 
 * gcc version 6.2 was installed using :
 
-  * `install_gcc_6.2.sh <https://github.com/mikecroucher/HPC_Installers/compilers/gcc/6.2/sheffield/iceberg/install_gcc_6.2.sh>`_
-  * `gcc 6.2 modulefile <https://github.com/mikecroucher/HPC_Installers/compilers/gcc/6.2/sheffield/iceberg/6.2>`_ located on the system at ``/usr/local/modulefiles/compilers/gcc/6.2``
+  * :download:`install_gcc_6.2.sh </iceberg/software/install_scripts/compilers/gcc/install_gcc_6.2.sh>`
+  * :download:`gcc 6.2 modulefile </iceberg/software/modulefiles/compilers/gcc/6.2>` located on the system at ``/usr/local/modulefiles/compilers/gcc/6.2``
 
 * gcc version 5.4 was installed using :
 
-  * `install_gcc_5.4.sh <https://github.com/mikecroucher/HPC_Installers/compilers/gcc/5.4/sheffield/iceberg/install_gcc_5.4.sh>`_
-  * `gcc 5.4 modulefile <https://github.com/mikecroucher/HPC_Installers/compilers/gcc/5.4/sheffield/iceberg/5.4>`_ located on the system at ``/usr/local/modulefiles/compilers/gcc/5.4``
+  * :download:`install_gcc_5.4.sh </iceberg/software/install_scripts/compilers/gcc/install_gcc_5.4.sh>`
+  * :download:`gcc 5.4 modulefile </iceberg/software/modulefiles/compilers/gcc/5.4>` located on the system at ``/usr/local/modulefiles/compilers/gcc/5.4``
 
 * Installation notes for version 5.3 are not available.
 
 * gcc version 5.2 was installed using :
 
-  * `install_gcc_5.2.sh <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/compilers/gcc/install_gcc_5.2.sh>`_
-  * `gcc 5.2 modulefile <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/compilers/gcc/5.2>`_ located on the system at ``/usr/local/modulefiles/compilers/gcc/5.2``
+  * :download:`install_gcc_5.2.sh </iceberg/software/install_scripts/compilers/gcc/install_gcc_5.2.sh>`
+  * :download:`gcc 5.2 modulefile </iceberg/software/modulefiles/compilers/gcc/5.2>` located on the system at ``/usr/local/modulefiles/compilers/gcc/5.2``
 
 * gcc version 4.9.2 was installed using :
 
-  * `install_gcc_4.9.2.sh <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/compilers/gcc/install_gcc_5.9.2.sh>`_
-  * `gcc 4.9.2 modulefile <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/compilers/gcc/4.9.2>`_ located on the system at ``/usr/local/modulefiles/compilers/gcc/4.9.2``
+  * :download:`install_gcc_4.9.2.sh </iceberg/software/install_scripts/compilers/gcc/install_gcc_4.9.2.sh>`
+  * :download:`gcc 4.9.2 modulefile </iceberg/software/modulefiles/compilers/gcc/4.9.2>` located on the system at ``/usr/local/modulefiles/compilers/gcc/4.9.2``
 
 * Installation notes for versions 4.8.2 and below are not available.

--- a/iceberg/software/compilers/git.rst
+++ b/iceberg/software/compilers/git.rst
@@ -24,5 +24,5 @@ Installation notes
 ------------------
 Version 2.5 of git was installed using gcc 5.2 using the following install script and module file:
 
-* `install_git_2.5.sh <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/apps/git/install_git_5.2.s://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/apps/git/install_git_2.5.sh>`_
-* `git 2.5 modulefile <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/apps/git/2.5>`_ located on the system at ``/usr/local/modulefiles/compilers/git/2.5``
+* :download:`install_git_2.5.sh </iceberg/software/install_scripts/apps/git/install_git_2.5.sh>`
+* :download:`git 2.5 modulefile </iceberg/software/modulefiles/apps/git/2.5>` located on the system at ``/usr/local/modulefiles/compilers/git/2.5``

--- a/iceberg/software/install_scripts/compilers/gcc/install_gcc_5.4.sh
+++ b/iceberg/software/install_scripts/compilers/gcc/install_gcc_5.4.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Install script used to install gcc 5.4 on iceberg
+# This does both the download and the install
+
+###############
+# Set variables
+###############
+export GVER=5.4.0
+# Directory to store downloaded tarball and build logs
+export MEDIA_DIR="/usr/local/media/gcc/${GVER}"
+export TMPDIR="${TMPDIR:-/tmp}"
+# Store unpacked source files
+export SOURCE_DIR="${TMPDIR}/${USER}/gcc/${GVER}/source"
+export TARBALL_FNAME="gcc-${GVER}.tar.gz"
+export SOURCE_URL="ftp://ftp.mirrorservice.org/sites/sourceware.org/pub/gcc/releases/gcc-${GVER}/${TARBALL_FNAME}"
+# Build in this dir
+export BUILD_DIR="${TMPDIR}/${USER}/gcc/${GVER}/build"
+export APPLICATION_ROOT=/usr/local/packages6
+export INSTALL_ROOT_DIR="${APPLICATION_ROOT}/compilers/gcc"
+# Install in this dir
+export INSTALL_DIR="${INSTALL_ROOT_DIR}/${GVER}"
+workers=4
+
+################
+# Error handling
+################
+handle_error () {
+    errcode=$? # save the exit code as the first thing done in the trap function 
+    echo "error $errorcode" 
+    echo "the command executing at the
+    time of the error was" echo "$BASH_COMMAND" 
+    echo "on line ${BASH_LINENO[0]}"
+    # do some error handling, cleanup, logging, notification $BASH_COMMAND
+    # contains the command that was being executed at the time of the trap
+    # ${BASH_LINENO[0]} contains the line number in the script of that command
+    # exit the script or return to try again, etc.
+    exit $errcode  # or use some other value or do return instead 
+}
+trap handle_error ERR
+
+##############
+# Download gcc
+##############
+mkdir -p ${MEDIA_DIR}
+if [[ ! -e ${MEDIA_DIR}/${TARBALL_FNAME} ]]; then
+    wget -P ${MEDIA_DIR} ${SOURCE_URL}
+fi
+
+##############
+# Untar source
+##############
+mkdir -p $SOURCE_DIR
+cd ${SOURCE_DIR}
+if [[ -e ./gcc-$GVER/untar_complete ]]; then
+    echo "Directory already untarred. Moving on"
+else
+    echo "Untarring gcc"
+    tar xzf ${MEDIA_DIR}/${TARBALL_FNAME}
+    touch ./gcc-$GVER/untar_complete
+fi
+
+###################
+# Download pre-reqs
+###################
+cd $SOURCE_DIR/gcc-${GVER}
+$SOURCE_DIR/gcc-${GVER}/contrib/download_prerequisites 2>&1 | tee ${MEDIA_DIR}/download_prereqs-gcc${GVER}.log
+
+########################
+# Configure in build dir
+########################
+mkdir -p $BUILD_DIR
+cd $BUILD_DIR
+$SOURCE_DIR/gcc-${GVER}/configure --prefix=$INSTALL_DIR --enable-languages=c,c++,fortran --disable-multilib 2>&1 | tee ${MEDIA_DIR}/configure-gcc${GVER}.log
+
+######################################
+# Compile, install and set permissions
+######################################
+mkdir -p $INSTALL_DIR
+make -j ${workers} 2>&1 | tee ${MEDIA_DIR}/make-gcc${GVER}-$(date +%s).log
+make install 2>&1 | tee ${MEDIA_DIR}/make-install-gcc${GVER}-$(date +%s).log
+chown -R ${USER}:app-admins ${INSTALL_DIR}
+chmod -R g+w ${INSTALL_DIR}

--- a/iceberg/software/install_scripts/compilers/gcc/install_gcc_6.2.sh
+++ b/iceberg/software/install_scripts/compilers/gcc/install_gcc_6.2.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+#Install script used to install gcc 6.2 on iceberg
+#This does both the download and the install
+
+# Set some env variables for convenience
+export INSTALL_ROOT_DIR=/usr/local/packages6/compilers/gcc
+export GVER=6.2.0
+export INSTALL_DIR=$INSTALL_ROOT_DIR/$GVER
+export SOURCE_DIR=/scratch/${USER}/gcc/${GVER}/source
+export BUILD_DIR=/scratch/${USER}/gcc/${GVER}/build
+workers=4
+
+handle_error () {
+    errcode=$? # save the exit code as the first thing done in the trap function 
+    echo "error $errorcode" 
+    echo "the command executing at the
+    time of the error was" echo "$BASH_COMMAND" 
+    echo "on line ${BASH_LINENO[0]}"
+    # do some error handling, cleanup, logging, notification $BASH_COMMAND
+    # contains the command that was being executed at the time of the trap
+    # ${BASH_LINENO[0]} contains the line number in the script of that command
+    # exit the script or return to try again, etc.
+    exit $errcode  # or use some other value or do return instead 
+}
+trap handle_error ERR
+
+
+# Make directories and set permissions on the install dir
+mkdir -p $INSTALL_DIR
+chown -R ${USER}:app-admins ${INSTALL_DIR}
+chmod -R g+w ${INSTALL_DIR}
+
+mkdir -p $SOURCE_DIR
+mkdir -p $BUILD_DIR
+
+# Download gcc
+cd $SOURCE_DIR
+[[ -e gcc-$GVER.tar.gz ]] || wget ftp://ftp.mirrorservice.org/sites/sourceware.org/pub/gcc/releases/gcc-${GVER}/gcc-${GVER}.tar.gz
+
+# Untar source
+if [[ -e ./gcc-$GVER/untar_complete ]]; then
+    echo "Directory already untarred. Moving on"
+else
+    echo "Untarring gcc"
+    time tar xzf ./gcc-$GVER.tar.gz
+    touch ./gcc-$GVER/untar_complete
+fi
+
+# Download pre-reqs
+cd $SOURCE_DIR/gcc-${GVER}
+$SOURCE_DIR/gcc-${GVER}/contrib/download_prerequisites
+
+#Enter build dir and configure
+cd $BUILD_DIR
+$SOURCE_DIR/gcc-${GVER}/configure --prefix=$INSTALL_DIR --enable-languages=c,c++,fortran,go --disable-multilib 2>&1 | tee config-gcc${GVER}.log
+
+# Run compilation on 4 cores (optional) - it takes for ever otherwise
+make -j ${workers} 2>&1 | tee make-gcc${GVER}.log
+make install 2>&1 | tee make-install-gcc${GVER}.log
+

--- a/iceberg/software/libs/cfitsio.rst
+++ b/iceberg/software/libs/cfitsio.rst
@@ -25,5 +25,5 @@ to the include directory.
 Installation notes
 ------------------
 This section is primarily for administrators of the system. CFITSIO 3.380 was compiled with gcc 5.2.
-The compilation used this `script <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/libs/gcc/>`_ and it is loaded with this `modulefile
-<https://github.com/mikecroucher/iceberg_software/blob/master/software/modulefiles/libs/gcc/5.2/cfitsio/3.380>`_ .
+The compilation used this :download:`script </iceberg/software/install_scripts/libs/gcc/5.2/install_cfitsio.sh>` 
+and it is loaded with this :download:`modulefile </iceberg/software/modulefiles/libs/gcc/5.2/cfitsio/3.380>`.

--- a/iceberg/software/libs/cuda.rst
+++ b/iceberg/software/libs/cuda.rst
@@ -93,7 +93,7 @@ These are primarily for system administrators
                             --samples --samplespath=/usr/local/packages6/libs/binlibs/CUDA/8.0.44/samples \
                             --no-opengl-libs -silent
 
-#. `This modulefile <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/libs/binlibs/cuda/8.0.44>`__ was installed as ``/usr/local/modulefiles/libs/cuda/8.0.44``
+#. :download:`This modulefile </iceberg/software/modulefiles/libs/binlibs/cuda/8.0.44>` was installed as ``/usr/local/modulefiles/libs/cuda/8.0.44``
 
 **CUDA 7.5.18**
 
@@ -106,7 +106,7 @@ These are primarily for system administrators
                             --samples --samplespath=/usr/local/packages6/libs/binlibs/CUDA/7.5.18/samples \
                             --no-opengl-libs  -silent
 
-#. `This modulefile <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/libs/binlibs/cuda/7.5.18>`__ was installed as ``/usr/local/modulefiles/libs/cuda/7.5.18``
+#. :download:`This modulefile </iceberg/software/modulefiles/libs/binlibs/cuda/7.5.18>` was installed as ``/usr/local/modulefiles/libs/cuda/7.5.18``
 
 **Previous versions**
 

--- a/iceberg/software/libs/curl.rst
+++ b/iceberg/software/libs/curl.rst
@@ -46,5 +46,5 @@ This section is primarily for administrators of the system.
 
 Curl 7.47.1 was compiled with gcc 4.47
 
-* Install script: `install_curl_7.47.1.sh <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/libs/gcc/4.4.7/curl/nstall_curl_7.47.1.sh>`_
-* Module file: `7.47.1 <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/libs/gcc/4.4.7/curl/7.47.1>`_
+* Install script: :download:`install_curl_7.47.1.sh </iceberg/software/install_scripts/libs/gcc/4.4.7/curl/install_curl_7.47.1.sh>`
+* Module file: :download:`7.47.1 </iceberg/software/modulefiles/libs/gcc/4.4.7/curl/7.47.1>`

--- a/iceberg/software/libs/hdf5.rst
+++ b/iceberg/software/libs/hdf5.rst
@@ -66,8 +66,8 @@ This section is primarily for administrators of the system.
 
 **Version 1.8.16 built using GCC Compiler, with seperate ZLIB and SZIP**
 
-* `install_hdf5.sh   <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/libs/gcc/4.4.7/hdf5/install_hdf5.sh>`_ Install script
-* `1.8.16   <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/libs/gcc/hdf5/1.8.16>`_
+* :download:`install_hdf5.sh </iceberg/software/install_scripts/libs/gcc/4.4.7/hdf5/install_hdf5.sh>` Install script
+* :download:`1.8.16 </iceberg/software/modulefiles/libs/gcc/hdf5/1.8.16>`
 
 **Version 1.8.15-patch1 built using PGI Compiler**
 
@@ -75,8 +75,8 @@ Here are the build details for the module `libs/hdf5/pgi/1.8.15-patch1`
 
 Compiled using PGI 15.7 and OpenMPI 1.8.8
 
-* `install_pgi_hdf5_1.8.15-patch1.sh   <https://github.com/rcgsheffield/blob/master/software/install_scripts/libs/pgi/hdf5/install_pgi_hdf5_1.8.15-patch1.sh>`_ Install script
-* `Modulefile <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/libs/pgi/hdf5/1.8.15-patch1>`_ located on the system at ``/usr/local/modulefiles/libs/hdf5/pgi/1.8.15-patch1``
+* :download:`install_pgi_hdf5_1.8.15-patch1.sh </iceberg/software/install_scripts/libs/pgi/hdf5/install_pgi_hdf5_1.8.15-patch1.sh>` Install script
+* :download:`Modulefile </iceberg/software/modulefiles/libs/pgi/hdf5/1.8.15-patch1>` located on the system at ``/usr/local/modulefiles/libs/hdf5/pgi/1.8.15-patch1``
 
 **gcc versions**
 

--- a/iceberg/software/libs/nagfortran.rst
+++ b/iceberg/software/libs/nagfortran.rst
@@ -144,7 +144,7 @@ Module Files
 **fll6i25dcl**
 
 * The module file is on the system at ``/usr/local/modulefiles/libs/intel/15/NAG/fll6i25dcl``
-* The module file is `on github <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/libs/intel/15/NAG/fll6i25dcl>`_.
+* The module file is :download:`on github </iceberg/software/modulefiles/libs/intel/15/NAG/fll6i25dcl>`.
 
 **fll6a24dpl**
 

--- a/iceberg/software/libs/netcdf-fortran.rst
+++ b/iceberg/software/libs/netcdf-fortran.rst
@@ -28,5 +28,5 @@ This section is primarily for administrators of the system.
 
 **Version 4.4.3**
 
-* `install_gcc_netcdf-fortran_4.4.3.sh  <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/libs/gcc/4.4.7/netcdf-fortran/install_gcc_netcdf-fortran_4.4.3.sh>`_ Install script
-* `Modulefile <https://github.com/mikecroucher/iceberg_software/blob/master/software/modulefiles/libs/gcc/4.4.7/openmpi/1.10.1/netcdf-fortran/4.4.3>`_.
+* :download:`install_gcc_netcdf-fortran_4.4.3.sh </iceberg/software/install_scripts/libs/gcc/4.4.7/netcdf-fortran/install_gcc_netcdf-fortran_4.4.3.sh>` Install script
+* :download:`Modulefile </iceberg/software/modulefiles/libs/gcc/4.4.7/openmpi/1.10.1/netcdf-fortran/4.4.3>`.

--- a/iceberg/software/libs/netcdf_pgi.rst
+++ b/iceberg/software/libs/netcdf_pgi.rst
@@ -29,6 +29,6 @@ This section is primarily for administrators of the system.
 
 Compiled using PGI 15.7, OpenMPI 1.8.8 and HDF5 1.8.15-patch1
 
-* `install_pgi_netcdf_4.3.3.1.sh  <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/libs/pgi/netcdf/install_pgi_netcdf_4.3.3.1.sh>`_ Install script
+* :download:`install_pgi_netcdf_4.3.3.1.sh </iceberg/software/install_scripts/libs/pgi/netcdf/install_pgi_netcdf_4.3.3.1.sh>` Install script
 * Install logs are on the system at ``/usr/local/packages6/libs/pgi/netcdf/4.3.3.1/install_logs``
-* `Modulefile <https://github.com/mikecroucher/iceberg_software/blob/master/software/modulefiles/libs/pgi/netcdf/4.3.3.1>`_ located on the system at ``ls /usr/local/modulefiles/libs/pgi/netcdf/4.3.3.1``
+* :download:`Modulefile </iceberg/software/modulefiles/libs/pgi/netcdf/4.3.3.1>` located on the system at ``ls /usr/local/modulefiles/libs/pgi/netcdf/4.3.3.1``

--- a/iceberg/software/libs/scotch.rst
+++ b/iceberg/software/libs/scotch.rst
@@ -21,6 +21,4 @@ To make this library available, run the following module command ::
 
 Installation notes
 ------------------
-This section is primarily for administrators of the system. SCOTCH 6.0.4 was compiled with gcc 5.2 using the bash file `install_scotch.sh <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/libs/gcc/5.2/install_scotch.sh>`_
-
-
+This section is primarily for administrators of the system. SCOTCH 6.0.4 was compiled with gcc 5.2 using the bash file :download:`install_scotch.sh </iceberg/software/install_scripts/libs/gcc/5.2/install_scotch.sh>`

--- a/iceberg/software/modulefiles/compilers/gcc/5.4
+++ b/iceberg/software/modulefiles/compilers/gcc/5.4
@@ -1,0 +1,30 @@
+#%Module1.0#####################################################################
+##
+## gcc 5.4
+
+## Module file logging
+source /usr/local/etc/module_logging.tcl
+##
+
+set     app gcc
+set     version 5.4.0
+module-whatis   "loads the necessary `$app-$version' library paths"
+
+set BASEPATH /usr/local/packages6/compilers/$app/$version
+
+setenv GCCDIR $BASEPATH
+
+prepend-path PATH 		$BASEPATH/bin
+prepend-path LD_LIBRARY_PATH	$BASEPATH/lib:$BASEPATH/lib64
+prepend-path MANPATH		$BASEPATH/man
+
+prepend-path --delim " " CPPFLAGS " -I$BASEPATH/include"
+prepend-path --delim " " CFLAGS   " -I$BASEPATH/include"
+prepend-path --delim " " LDFLAGS  " -L$BASEPATH/lib -L$BASEPATH/lib64"
+
+setenv  CC      gcc
+setenv  CXX     g++
+setenv  F77     gfortran
+setenv  F90     gfortran
+setenv  F95     gfortran
+setenv  FC      gfortran

--- a/iceberg/software/modulefiles/compilers/gcc/6.2
+++ b/iceberg/software/modulefiles/compilers/gcc/6.2
@@ -1,0 +1,30 @@
+#%Module1.0#####################################################################
+##
+## gcc 6.2
+
+## Module file logging
+source /usr/local/etc/module_logging.tcl
+##
+
+set     app gcc
+set     version 6.2.0
+module-whatis   "loads the necessary `$app-$version' library paths"
+
+set BASEPATH /usr/local/packages6/compilers/$app/$version
+
+setenv GCCDIR $BASEPATH
+
+prepend-path PATH 		$BASEPATH/bin
+prepend-path LD_LIBRARY_PATH	$BASEPATH/lib:$BASEPATH/lib64
+prepend-path MANPATH		$BASEPATH/man
+
+prepend-path --delim " " CPPFLAGS " -I$BASEPATH/include"
+prepend-path --delim " " CFLAGS   " -I$BASEPATH/include"
+prepend-path --delim " " LDFLAGS  " -L$BASEPATH/lib -L$BASEPATH/lib64"
+
+setenv  CC      gcc
+setenv  CXX     g++
+setenv  F77     gfortran
+setenv  F90     gfortran
+setenv  F95     gfortran
+setenv  FC      gfortran

--- a/iceberg/software/mpi/openmpi-gcc.rst
+++ b/iceberg/software/mpi/openmpi-gcc.rst
@@ -33,19 +33,19 @@ These are primarily for administrators of the system.
 
 Compiled using gcc 4.4.7.
 
-* `install_openMPI_1.10.1.sh  <https://github.com/rcgsheffield/sheffield_hpc/blob/master/iceberg/software/install_scripts/mpi/gcc/openmpi/install_gcc_openMPI_1.10.1.sh>`_ Downloads, compiles and installs OpenMPI 1.10.0 using the system gcc.
-* `Modulefile 1.10.1 <https://github.com/rcgsheffield/sheffield_hpc/blob/master/iceberg/software/modulefiles/mpi/gcc/openmpi/1.10.1>`_ located on the system at ``/usr/local/modulefiles/mpi/gcc/openmpi/1.10.1``
+* :download:`install_openMPI_1.10.1.sh </iceberg/software/install_scripts/mpi/gcc/openmpi/install_gcc_openMPI_1.10.1.sh>` Downloads, compiles and installs OpenMPI 1.10.0 using the system gcc.
+* :download:`Modulefile 1.10.1 </iceberg/software/modulefiles/mpi/gcc/openmpi/1.10.1>` located on the system at ``/usr/local/modulefiles/mpi/gcc/openmpi/1.10.1``
 
 **Version 1.10.0**
 
 Compiled using gcc 4.4.7.
 
-* `install_openMPI_1.10.0.sh  <https://github.com/rcgsheffield/sheffield_hpc/blob/master/iceberg/software/install_scripts/mpi/gcc/openmpi/install_gcc_openMPI_1.10.0.sh>`_ Downloads, compiles and installs OpenMPI 1.10.0 using the system gcc.
-* `Modulefile 1.10 <https://github.com/rcgsheffield/sheffield_hpc/blob/master/iceberg/software/modulefiles/mpi/gcc/openmpi/1.10.0>`_ located on the system at ``/usr/local/modulefiles/mpi/gcc/openmpi/1.10.0``
+* :download:`install_openMPI_1.10.0.sh  </iceberg/software/install_scripts/mpi/gcc/openmpi/install_gcc_openMPI_1.10.0.sh>` Downloads, compiles and installs OpenMPI 1.10.0 using the system gcc.
+* :download:`Modulefile 1.10 </iceberg/software/modulefiles/mpi/gcc/openmpi/1.10.0>` located on the system at ``/usr/local/modulefiles/mpi/gcc/openmpi/1.10.0``
 
 **Version 1.8.8**
 
 Compiled using gcc 4.4.7.
 
-* `install_openMPI.sh  <https://github.com/rcgsheffield/sheffield_hpc/blob/master/iceberg/software/install_scripts/mpi/gcc/openmpi/install_gcc_openMPI_1.8.8.sh>`_ Downloads, compiles and installs OpenMPI 1.8.8 using the system gcc.
-* `Modulefile <https://github.com/rcgsheffield/sheffield_hpc/blob/master/iceberg/software/modulefiles/mpi/gcc/openmpi/1.8.8>`_ located on the system at ``/usr/local/modulefiles/mpi/gcc/openmpi/1.8.8``
+* :download:`install_openMPI.sh  </iceberg/software/install_scripts/mpi/gcc/openmpi/install_gcc_openMPI_1.8.8.sh>` Downloads, compiles and installs OpenMPI 1.8.8 using the system gcc.
+* :download:`Modulefile </iceberg/software/modulefiles/mpi/gcc/openmpi/1.8.8>` located on the system at ``/usr/local/modulefiles/mpi/gcc/openmpi/1.8.8``

--- a/iceberg/software/mpi/openmpi-pgi.rst
+++ b/iceberg/software/mpi/openmpi-pgi.rst
@@ -31,7 +31,7 @@ These are primarily for administrators of the system.
 
 Compiled using PGI 15.7.
 
-* `install_openMPI.sh  <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/install_scripts/mpi/pgi/openmpi/install_pgi_openMPI_1.8.8.sh>`_ Downloads, compiles and installs OpenMPI 1.8.8 using v15.7 of the PGI Compiler.
-* `Modulefile <https://github.com/rcgsheffield/sheffield_hpc/blob/master/software/modulefiles/mpi/pgi/openmpi/1.8.8>`_ located on the system at ``/usr/local/modulefiles/mpi/pgi/openmpi/1.8.8``
+* :download:`install_openMPI.sh </iceberg/software/install_scripts/mpi/pgi/openmpi/install_pgi_openMPI_1.8.8.sh>` downloads, compiles and installs OpenMPI 1.8.8 using v15.7 of the PGI Compiler.
+* :download:`Modulefile </iceberg/software/modulefiles/mpi/pgi/openmpi/1.8.8>` located on the system at ``/usr/local/modulefiles/mpi/pgi/openmpi/1.8.8``
 
 Installation notes for older versions are not available.

--- a/sharc/software/apps/R.rst
+++ b/sharc/software/apps/R.rst
@@ -116,8 +116,8 @@ These notes are primarily for administrators of the system.
 
 * `What's new in R version 3.3.2 <https://stat.ethz.ch/pipermail/r-announce/2016/000608.html>`_
 
-This was a scripted install. It was compiled from source with gcc 4.8.5 and with `--enable-R-shlib` enabled. It was run in batch mode.
+This was a scripted install. It was compiled from source with gcc 4.8.5 and with ``--enable-R-shlib`` enabled. It was run in batch mode.
 
-* `install_r_3.3.2_gcc4.8.5.sh <https://raw.githubusercontent.com/rcgsheffield/sheffield_hpc/master/sharc/software/install_scripts/apps/R/3.3.2/gcc-4.8.5/install_r_3.3.2_gcc4.8.5.sh>`_ Downloads, compiles, tests and installs R 3.3.2 and the ``Rmath`` library.
-* `R 3.3.2 Modulefile <https://raw.githubusercontent.com/rcgsheffield/sheffield_hpc/master/sharc/software/modulefiles/apps/R/gcc-4.8.5>`_ located on the system at ``/usr/local/modulefiles/apps/R/3.3.2/``
+* :download:`install_r_3.3.2_gcc4.8.5.sh </sharc/software/install_scripts/apps/R/3.3.2/gcc-4.8.5/install_r_3.3.2_gcc4.8.5.sh>` Downloads, compiles, tests and installs R 3.3.2 and the ``Rmath`` library.
+* :download:`R 3.3.2 Modulefile </sharc/software/modulefiles/apps/R/gcc-4.8.5>` located on the system at ``/usr/local/modulefiles/apps/R/3.3.2/``
 * Install log-files, including the output of the `make check` tests are available on the system at `/usr/local/packages/apps/R/3.3.2/gcc-4.8.5/install_logs/`

--- a/sharc/software/apps/java.rst
+++ b/sharc/software/apps/java.rst
@@ -52,7 +52,7 @@ These are primarily for administrators of the system.
 
 #. Download *Java SE Development Kit 8u102* `from Oracle <http://www.oracle.com/technetwork/java/javase/downloads>`_.  Select the tarball (``jdk-8u102-linux-x64.tar.gz``) for Linux and the *x64* CPU architecture family.
 #. Save this file to ``/usr/local/media/java/1.8.0_102/``.
-#. Install Java using `this script <https://github.com/rcgsheffield/sheffield_hpc/tree/master/sharc/software/install_scripts/apps/java/jdk1.8.0_102/binary/install.sh>`__. 
-#. Install `this modulefile <https://github.com/rcgsheffield/sheffield_hpc/tree/master/sharc/software/modulefiles/apps/java/jdk1.8.0_102/binary>`__ as ``/usr/local/modulefiles/apps/java/jdk1.8.0_102/binary``
+#. Install Java using :download:`this script </sharc/software/install_scripts/apps/java/jdk1.8.0_102/binary/install.sh>`. 
+#. Install :download:`this modulefile </sharc/software/modulefiles/apps/java/jdk1.8.0_102/binary>` as ``/usr/local/modulefiles/apps/java/jdk1.8.0_102/binary``
 	
 	

--- a/sharc/software/development/gcc.rst
+++ b/sharc/software/development/gcc.rst
@@ -36,10 +36,10 @@ These notes are primarily for system administrators
 
 * gcc version 6.2 was installed using :
 
-* `this script <https://github.com/rcgsheffield/sheffield_hpc/tree/master/sharc/software/install_scripts/dev/gcc/6.2/install.sh>`__
-* `gcc 6.2 modulefile <https://github.com/rcgsheffield/sheffield_hpc/tree/master/sharc/software/modulefiles/dev/gcc/6.2>`__ saved as `/usr/local/modulefiles/dev/gcc/6.2``
+* :download:`this script </sharc/software/install_scripts/dev/gcc/6.2/install.sh>`
+* :download:`gcc 6.2 modulefile </sharc/software/modulefiles/dev/gcc/6.2>` saved as `/usr/local/modulefiles/dev/gcc/6.2``
 
 * gcc version 5.4 was installed using :
 
-* `this script <https://github.com/rcgsheffield/sheffield_hpc/tree/master/sharc/software/install_scripts/dev/gcc/5.4/install.sh>`__
-* `this modulefile <https://github.com/rcgsheffield/sheffield_hpc/tree/master/sharc/software/modulefiles/dev/gcc/5.4>`__, saved as ``/usr/local/modulefiles/dev/gcc/5.4``
+* :download:`this script </sharc/software/install_scripts/dev/gcc/5.4/install.sh>`
+* :download:`this modulefile </sharc/software/modulefiles/dev/gcc/5.4>`, saved as ``/usr/local/modulefiles/dev/gcc/5.4``

--- a/sharc/software/development/intel_compilers.rst
+++ b/sharc/software/development/intel_compilers.rst
@@ -66,4 +66,4 @@ The following notes are primarily for system administrators.
 
 Installed as part of :ref:`Parallel Studio Composer Edition 2017 <sharc-intel-parallel-studio>`.
 
-`This modulefile <https://github.com/rcgsheffield/sheffield_hpc/tree/master/sharc/software/modulefiles/dev/intel-compilers/17.0.0>`__ was installed as ``/usr/local/modulefiles/dev/intel-compilers/17.0.0``.
+:download:`This modulefile </sharc/software/modulefiles/dev/intel-compilers/17.0.0>` was installed as ``/usr/local/modulefiles/dev/intel-compilers/17.0.0``.

--- a/sharc/software/development/intel_parallel_studio.rst
+++ b/sharc/software/development/intel_parallel_studio.rst
@@ -43,8 +43,8 @@ The following notes are primarily for system administrators.
    only readable by the ``app-admins`` group.
 #. Ensure details of the Intel license server are in the file
    ``/usr/local/packages/dev/intel-pe-xe-ce/license.lic``
-#. Run `this script
-   <https://github.com/rcgsheffield/sheffield_hpc/tree/master/sharc/software/install_scripts/dev/intel-ps-xe-ce/2017.0/install.sh>`__.
+#. Run :download:`this script
+   </sharc/software/install_scripts/dev/intel-ps-xe-ce/2017.0/install.sh>`.
    This installs Parallel Studio into
    ``/usr/local/packages/dev/intel-pe-xe-ce/2017.0/binary/``.  Products are
    activated using the aforementioned license file during the installation
@@ -56,11 +56,11 @@ The following notes are primarily for system administrators.
    modulefile for all Parallel Studio software and other modulefiles for
    specific products.  
 
-    * The `Compilers modulefile <https://github.com/rcgsheffield/sheffield_hpc/tree/master/sharc/software/modulefiles/dev/intel-compilers/17.0.0>`__ should be installed as ``/usr/local/modulefiles/dev/intel-compilers/17.0.0``.
-    * The `DAAL modulefile <https://github.com/rcgsheffield/sheffield_hpc/tree/master/sharc/software/modulefiles/libs/intel-daal/2017.0>`__ should be installed as ``/usr/local/modulefiles/libs/intel-daal/2017.0/binary``.
-    * The `IPP modulefile <https://github.com/rcgsheffield/sheffield_hpc/tree/master/sharc/software/modulefiles/libs/intel-ipp/2017.0>`__ should be installed as ``/usr/local/modulefiles/libs/intel-ipp/2017.0/binary``.
-    * The `MKL modulefile <https://github.com/rcgsheffield/sheffield_hpc/tree/master/sharc/software/modulefiles/libs/intel-mkl/2017.0>`__ should be installed as ``/usr/local/modulefiles/libs/intel-mkl/2017.0/binary``.
-    * The `TBB modulefile <https://github.com/rcgsheffield/sheffield_hpc/tree/master/sharc/software/modulefiles/libs/intel-tbb/2017.0>`__ should be installed as ``/usr/local/modulefiles/libs/intel-tbb/2017.0/binary``.
+    * The :download:`Compilers modulefile </sharc/software/modulefiles/dev/intel-compilers/17.0.0>` should be installed as ``/usr/local/modulefiles/dev/intel-compilers/17.0.0``.
+    * The :download:`DAAL modulefile </sharc/software/modulefiles/libs/intel-daal/2017.0/binary>` should be installed as ``/usr/local/modulefiles/libs/intel-daal/2017.0/binary``.
+    * The :download:`IPP modulefile </sharc/software/modulefiles/libs/intel-ipp/2017.0/binary>` should be installed as ``/usr/local/modulefiles/libs/intel-ipp/2017.0/binary``.
+    * The :download:`MKL modulefile </sharc/software/modulefiles/libs/intel-mkl/2017.0/binary>` should be installed as ``/usr/local/modulefiles/libs/intel-mkl/2017.0/binary``.
+    * The :download:`TBB modulefile </sharc/software/modulefiles/libs/intel-tbb/2017.0/binary>` should be installed as ``/usr/local/modulefiles/libs/intel-tbb/2017.0/binary``.
     * See the (TCL) modulefiles for details of how they were derived from Intel-supplied environment-manipulating shell scripts.
 
 #. Check that licensing is working by activating the Intel Compilers modulefile

--- a/sharc/software/libs/intel_daal.rst
+++ b/sharc/software/libs/intel_daal.rst
@@ -11,7 +11,7 @@ Parallel Studio Composer Edition version
 DAAL can be used with and without :ref:`other Parallel Studio packages <sharc-intel-parallel-studio>`.
 To access it: ::
 
-    module load libs/intel-daal/2017.0/binary
+        module load libs/intel-daal/2017.0/binary
 
 Licensing and availability
 --------------------------
@@ -27,4 +27,4 @@ The following notes are primarily for system administrators.
 
 Installed as part of :ref:`Parallel Studio Composer Edition 2017 <sharc-intel-parallel-studio>`.
 
-`This modulefile <https://github.com/rcgsheffield/sheffield_hpc/tree/master/sharc/software/modulefiles/libs/intel-daal/2017.0>`__ was installed as ``/usr/local/modulefiles/libs/intel-daal/2017.0/binary``.
+:download:`This modulefile </sharc/software/modulefiles/libs/intel-daal/2017.0/binary>` was installed as ``/usr/local/modulefiles/libs/intel-daal/2017.0/binary``.

--- a/sharc/software/libs/intel_ipp.rst
+++ b/sharc/software/libs/intel_ipp.rst
@@ -11,7 +11,7 @@ Parallel Studio Composer Edition version
 IPP can be used with and without :ref:`other Parallel Studio packages <sharc-intel-parallel-studio>`.
 To access it: ::
 
-    module load libs/intel-ipp/2017.0/binary
+        module load libs/intel-ipp/2017.0/binary
 
 Licensing and availability
 --------------------------
@@ -27,4 +27,4 @@ The following notes are primarily for system administrators.
 
 Installed as part of :ref:`Parallel Studio Composer Edition 2017 <sharc-intel-parallel-studio>`.
 
-`This modulefile <https://github.com/rcgsheffield/sheffield_hpc/tree/master/sharc/software/modulefiles/libs/intel-ipp/2017.0>`__ was installed as ``/usr/local/modulefiles/libs/intel-ipp/2017.0/binary``.
+:download:`This modulefile </sharc/software/modulefiles/libs/intel-ipp/2017.0/binary>` was installed as ``/usr/local/modulefiles/libs/intel-ipp/2017.0/binary``.

--- a/sharc/software/libs/intel_mkl.rst
+++ b/sharc/software/libs/intel_mkl.rst
@@ -84,4 +84,4 @@ The following notes are primarily for system administrators.
 
 Installed as part of :ref:`Parallel Studio Composer Edition 2017 <sharc-intel-parallel-studio>`.
 
-`This modulefile <https://github.com/rcgsheffield/sheffield_hpc/tree/master/sharc/software/modulefiles/libs/intel-mkl/2017.0>`__ was installed as ``/usr/local/modulefiles/libs/intel-mkl/2017.0/binary``.
+:download:`This modulefile </sharc/software/modulefiles/libs/intel-mkl/2017.0/binary>` was installed as ``/usr/local/modulefiles/libs/intel-mkl/2017.0/binary``.

--- a/sharc/software/parallel/openmpi-gcc.rst
+++ b/sharc/software/parallel/openmpi-gcc.rst
@@ -57,14 +57,14 @@ These are primarily for administrators of the system.
 **Version 2.0.1**
 
 1. Enable :ref:`GCC <gcc_sharc>` 6.2.0.
-2. Download, compile and install OpenMPI 2.0.1 using the `this script <https://github.com/rcgsheffield/sheffield_hpc/tree/master/sharc/software/install_scripts/mpi/openmpi/2.0.1/gcc-6.2/install.sh>`__.
-3. Install `this modulefile <https://github.com/rcgsheffield/sheffield_hpc/tree/master/sharc/software/modulefiles/mpi/openmpi/2.0.1/sheffield/sharc/gcc-6.2>`__ as ``/usr/local/modulefiles/mpi/openmpi/2.0.1/gcc-6.2``
+2. Download, compile and install OpenMPI 2.0.1 using the :download:`this script </sharc/software/install_scripts/mpi/openmpi/2.0.1/gcc-6.2/install.sh>`.
+3. Install :download:`this modulefile </sharc/software/modulefiles/mpi/openmpi/2.0.1/sheffield/sharc/gcc-6.2>` as ``/usr/local/modulefiles/mpi/openmpi/2.0.1/gcc-6.2``
 
 **Version 1.10.4**
 
 1. Enable :ref:`GCC <gcc_sharc>` 6.2.0.
-2. Download, compile and install OpenMPI 1.10.4 using `this script <https://github.com/rcgsheffield/sheffield_hpc/tree/master/sharc/software/install_scripts/mpi/openmpi/1.10.4/gcc-6.2/install.sh>`__.
-3. Install `this modulefile <https://github.com/rcgsheffield/sheffield_hpc/tree/master/sharc/software/modulefiles/mpi/openmpi/1.10.4/sheffield/sharc/gcc-6.2>`__ as ``/usr/local/modulefiles/mpi/openmpi/1.10.4/gcc-6.2``
+2. Download, compile and install OpenMPI 1.10.4 using :download:`this script </sharc/software/install_scripts/mpi/openmpi/1.10.4/gcc-6.2/install.sh>`.
+3. Install :download:`this modulefile </sharc/software/modulefiles/mpi/openmpi/1.10.4/sheffield/sharc/gcc-6.2>` as ``/usr/local/modulefiles/mpi/openmpi/1.10.4/gcc-6.2``
 
 	
 	

--- a/sharc/software/parallel/openmpi-intel.rst
+++ b/sharc/software/parallel/openmpi-intel.rst
@@ -56,6 +56,6 @@ These are primarily for administrators of the system.
 **Version 2.0.1**
 
 #. Ensure :ref:`Intel compilers 17.0.0 <sharc-intel-compilers>` are installed and licensed.
-#. Download, compile and install OpenMPI 2.0.1 using `this script <https://github.com/rcgsheffield/sheffield_hpc/blob/master/sharc/software/install_scripts/mpi/openmpi/2.0.1/intel-17.0.0/install.sh>`__.
-#. Install `this modulefile <https://github.com/rcgsheffield/sheffield_hpc/blob/master/sharc/software/modulefiles/mpi/openmpi/2.0.1/intel-17.0.0>`__ as ``/usr/local/modulefiles/mpi/openmpi/2.0.1/intel-17.0.0``
+#. Download, compile and install OpenMPI 2.0.1 using :download:`this script </sharc/software/install_scripts/mpi/openmpi/2.0.1/intel-17.0.0/install.sh>`.
+#. Install :download:`this modulefile </sharc/software/modulefiles/mpi/openmpi/2.0.1/intel-17.0.0>` as ``/usr/local/modulefiles/mpi/openmpi/2.0.1/intel-17.0.0``
 #. Test by running some <Examples>_.


### PR DESCRIPTION
* Converted all absolute URLs to install scripts / modulefiles that reside in this repo to relative URLs (using Sphinx's `:download:` role; see #375)
* Fixed a number of incorrect paths to install scripts and modulefiles.