### PR TITLE
Intel libs: minor fixes to modulefiles

### DIFF
--- a/iceberg/software/modulefiles/libs/binlibs/intel-daal/2017.0
+++ b/iceberg/software/modulefiles/libs/binlibs/intel-daal/2017.0
@@ -16,9 +16,8 @@ proc ModulesHelp { } {
 module-whatis   "Makes the `Intel Data Analytics Accelleration Library (DAAL)' available for use"
 
 # module variables
-#
-set     version      2017.0
-set     intelpsroot     /usr/local/packages6/compilers/intel-ps-xe-ce/$version/binary/
+set version     2017.0
+set intelpsroot /usr/local/packages6/compilers/intel-ps-xe-ce/$version/binary/
 
 # Variables determined using
 # env2 -from bash -to modulecmd "/usr/local/packages6/compilers/intel-ps-xe-ce/2017.0/binary/compilers_and_libraries_2017.0.098/linux/daal/bin/daalvars.sh intel64" | sed -e "s#/usr/local/packages6/compilers/intel-ps-xe-ce/2017.0/binary#\$intelpsroot#g" -e 's/[{}]//g'

--- a/iceberg/software/modulefiles/libs/binlibs/intel-ipp/2017.0
+++ b/iceberg/software/modulefiles/libs/binlibs/intel-ipp/2017.0
@@ -16,9 +16,8 @@ proc ModulesHelp { } {
 module-whatis   "Makes the `Intel Integrated Performance Primitives (IPP)' available for use"
 
 # module variables
-#
-set     version      2017.0
-set     intelpsroot     /usr/local/packages6/compilers/intel-ps-xe-ce/$version/binary/
+set version     2017.0
+set intelpsroot /usr/local/packages6/compilers/intel-ps-xe-ce/$version/binary/
 
 # Variables determined using
 # env2 -from bash -to modulecmd "/usr/local/packages6/compilers/intel-ps-xe-ce/2017.0/binary/compilers_and_libraries_2017.0.098/linux/ipp/bin/ippvars.sh intel64" | sed -e "s#/usr/local/packages6/compilers/intel-ps-xe-ce/2017.0/binary#\$intelpsroot#g" -e 's/[{}]//g'

--- a/iceberg/software/modulefiles/libs/binlibs/intel-mkl/11.2.3
+++ b/iceberg/software/modulefiles/libs/binlibs/intel-mkl/11.2.3
@@ -31,3 +31,5 @@ prepend-path MANPATH $intelpsroot/man/en_US;
 append-path LIBRARY_PATH $intelpsroot/compiler/lib/intel64;
 append-path LIBRARY_PATH $intelpsroot/mkl/lib/intel64;
 append-path NLSPATH $intelpsroot/mkl/lib/intel64/locale/%l_%t/%N;
+
+setenv MKLROOT $intelpsroot/mkl

--- a/iceberg/software/modulefiles/libs/binlibs/intel-mkl/2017.0
+++ b/iceberg/software/modulefiles/libs/binlibs/intel-mkl/2017.0
@@ -16,9 +16,8 @@ proc ModulesHelp { } {
 module-whatis   "Makes the `Intel Math Kernel Library (MLK) available for use"
 
 # module variables
-#
-set     version      2017.0
-set     intelpsroot    /usr/local/packages6/libs/intel-mkl/$version/binary
+set version     2017.0
+set intelpsroot /usr/local/packages6/compilers/intel-ps-xe-ce/$version/binary
 
 # Variables determined using
 # env2 -from bash -to modulecmd "/usr/local/packages6/compilers/intel-ps-xe-ce/2017.0/binary/compilers_and_libraries_2017.0.098/linux/mkl/bin/mklvars.sh intel64" | sed -e "s#/usr/local/packages6/compilers/intel-ps-xe-ce/2017.0/binary#\$intelpsroot#g" -e 's/[{}]//g'
@@ -32,6 +31,8 @@ prepend-path CPATH $intelpsroot/compilers_and_libraries_2017.0.098/linux/mkl/inc
 prepend-path LD_LIBRARY_PATH $intelpsroot/compilers_and_libraries_2017.0.098/linux/mkl/lib/intel64;
 prepend-path LD_LIBRARY_PATH $intelpsroot/compilers_and_libraries_2017.0.098/linux/compiler/lib/intel64;
 prepend-path NLSPATH $intelpsroot/compilers_and_libraries_2017.0.098/linux/mkl/lib/intel64/locale/%l_%t/%N;
+
+setenv MKLROOT $intelpsroot/compilers_and_libraries_2017.0.098/linux/mkl
 
 # License file (points at license server)
 setenv INTEL_LICENSE_FILE /usr/local/packages6/compilers/intel/license.lic

--- a/iceberg/software/modulefiles/libs/binlibs/intel-tbb/2017.0
+++ b/iceberg/software/modulefiles/libs/binlibs/intel-tbb/2017.0
@@ -16,9 +16,8 @@ proc ModulesHelp { } {
 module-whatis   "Makes `Intel Threading Building Blocks (TBB)' available for use"
 
 # module variables
-#
-set     version      2017.0
-set     intelpsroot    /usr/local/packages6/libs/intel-tbb/$version/binary
+set version     2017.0
+set intelpsroot /usr/local/packages6/compilers/intel-ps-xe-ce/$version/binary
 
 # Variables determined using
 # env2 -from bash -to modulecmd "/usr/local/packages6/compilers/intel-ps-xe-ce/2017.0/binary/compilers_and_libraries_2017.0.098/linux/tbb/bin/tbbvars.sh intel64" | sed -e "s#/usr/local/packages6/compilers/intel-ps-xe-ce/2017.0/binary#\$intelpsroot#g" -e 's/[{}]//g'

--- a/sharc/software/modulefiles/libs/intel-mkl/2017.0/binary
+++ b/sharc/software/modulefiles/libs/intel-mkl/2017.0/binary
@@ -33,6 +33,8 @@ prepend-path LD_LIBRARY_PATH $intelpsroot/compilers_and_libraries_2017.0.098/lin
 prepend-path LD_LIBRARY_PATH $intelpsroot/compilers_and_libraries_2017.0.098/linux/compiler/lib/intel64;
 prepend-path NLSPATH $intelpsroot/compilers_and_libraries_2017.0.098/linux/mkl/lib/intel64/locale/%l_%t/%N;
 
+setenv MKLROOT $intelpsroot/compilers_and_libraries_2017.0.098/linux/mkl
+
 # License file (points at license server)
 setenv INTEL_LICENSE_FILE /usr/local/packages/dev/intel-ps-xe-ce/license.lic
 


### PR DESCRIPTION
Minor fixes to Intel modulefiles (DAAL, IPP, TBB, MKL), inc. ensuring that `MKLROOT` is defined (required by CASTEP).