### PR TITLE
ShARC + Intel 2015: add install script, modulefiles and docs

### DIFF
--- a/sharc/software/development/intel_compilers.rst
+++ b/sharc/software/development/intel_compilers.rst
@@ -5,41 +5,47 @@ Intel Compilers
 
 Intel Compilers help create C, C++ and Fortran applications that can take full advantage of the advanced hardware capabilities available in Intel processors and co-processors. They also simplify that development by providing high level parallel models and built-in features like explicit vectorization and optimization reports.
 
-Parallel Studio Composer Edition 2017 versions
-----------------------------------------------
+Versions
+--------
 
-These versions of the Intel compilers were installed as part of :ref:`Intel Parallel Studio <sharc-intel-parallel-studio>` but can be used with or without the other Parallel Studio components.
+The Intel compilers were installed as part of :ref:`Intel Parallel Studio <sharc-intel-parallel-studio>` but can be used with or without the other Parallel Studio components.
 
-After connecting to the ShARC cluster (see :ref:`ssh`),  start an interactive session with the :code:`qsh` or :code:`qrsh` command then run ::
+After connecting to the ShARC cluster (see :ref:`ssh`),  start an interactive session with the :code:`qsh` or :code:`qrsh` command then activate a specific version of the compilers using one of: ::
 
-    dev/intel-compilers/17.0.0/binary
+        module load dev/intel-compilers/17.0.0/binary
+        module load dev/intel-compilers/15.0.7/binary
 
 Compilation examples
 --------------------
-**C**
 
-To compile the C hello world example into an executable called ``hello`` using the Intel C compiler ::
+C
+^
 
-    icc hello.c -o hello
 
-**C++**
+To compile the C hello world example into an executable called ``hello`` using the Intel C compiler: ::
 
-To compile the C++ hello world example into an executable called ``hello`` using the Intel C++ compiler ::
+        icc hello.c -o hello
+
+C++
+^^^
+
+To compile the C++ hello world example into an executable called ``hello`` using the Intel C++ compiler: ::
 
       icpc hello.cpp -o hello
 
-**Fortran**
+Fortran
+^^^^^^^
 
-To compile the Fortran hello world example into an executable called ``hello`` using the Intel Fortran compiler ::
+To compile the Fortran hello world example into an executable called ``hello`` using the Intel Fortran compiler: ::
 
       ifort hello.f90 -o hello
 
 Detailed Documentation
 ----------------------
-Once you have loaded the module on Iceberg, ``man`` pages are available for Intel compiler products ::
+Once you have loaded the module on Iceberg, ``man`` pages are available for Intel compiler products: ::
 
-    man ifort
-    man icc
+        man ifort
+        man icc
 
 The following links are to Intel's website:
 
@@ -62,8 +68,16 @@ Installation Notes
 
 The following notes are primarily for system administrators.
 
-**Intel Compilers 2017**
+Intel Compilers 17.0.0
+^^^^^^^^^^^^^^^^^^^^^^
 
 Installed as part of :ref:`Parallel Studio Composer Edition 2017 <sharc-intel-parallel-studio>`.
 
 :download:`This modulefile </sharc/software/modulefiles/dev/intel-compilers/17.0.0>` was installed as ``/usr/local/modulefiles/dev/intel-compilers/17.0.0``.
+
+Intel Compilers 15.0.7
+^^^^^^^^^^^^^^^^^^^^^^
+
+Installed as part of :ref:`Parallel Studio Composer Edition 2015.7 <sharc-intel-parallel-studio>`.
+
+:download:`This modulefile </sharc/software/modulefiles/dev/intel-compilers/15.0.7>` was installed as ``/usr/local/modulefiles/dev/intel-compilers/15.0.7``.

--- a/sharc/software/development/intel_parallel_studio.rst
+++ b/sharc/software/development/intel_parallel_studio.rst
@@ -3,16 +3,13 @@
 Intel Parallel Studio
 =====================
 
-Intel Parallel Studio XE is a software development suite that helps boost application performance by taking advantage of the ever-increasing processor core count and vector register width available in Intel Xeon processors and other compatible processors.  
+Intel Parallel Studio XE Composer Edition is a software development suite that helps boost application performance by taking advantage of the ever-increasing processor core count and vector register width available in Intel Xeon processors and other compatible processors.  
 Its core components are compilers and libraries for fast linear algebra, data transformation and parallelisation.
 
-Composer Edition 2017
----------------------
-
-This includes:
+The suite includes:
 
 * :ref:`Intel C++ and Fortran compilers <sharc-intel-compilers>`: these help create C, C++ and Fortran applications that "can take full advantage of the advanced hardware capabilities available in Intel processors and co-processors. They also simplify that development by providing high level parallel models and built-in features like explicit vectorization and optimization reports".
-* :ref:`Data Analytics Acceleration Library (DAAL) <sharc-intel-daal>`: functions for data analysis (characterization, summarization, and transformation) and Machine Learning (regression, classification, and more).
+* :ref:`Data Analytics Acceleration Library (DAAL) <sharc-intel-daal>`: functions for data analysis (characterization, summarization, and transformation) and Machine Learning (regression, classification, and more). Only available in the 2017 version of Parallel Studio.
 * :ref:`Math Kernel Library (MKL) <sharc-intel-mkl>`: This library provides highly optimized, threaded and vectorized functions to maximize performance on each processor family. Utilizes de facto standard C and Fortran APIs for compatibility with BLAS, LAPACK and FFTW functions from other math libraries.
 * :ref:`Integrated Performance Primitives (IPP) <sharc-intel-ipp>`: "high-quality, production-ready, low-level building blocks for image processing, signal processing, and data processing (data compression/decompression and cryptography) applications."
 * :ref:`Threading Building Blocks (TBB) <sharc-intel-tbb>`: lets you write "parallel C++ programs that take full advantage of multicore performance, that are portable and composable, and that have future-proof scalability."
@@ -36,7 +33,8 @@ Installation Notes
 
 The following notes are primarily for system administrators.
 
-**Parallel Studio XE Composer Edition 2017.0**
+Parallel Studio XE Composer Edition 2017.0
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 #. Download ``parallel_studio_xe_2017_composer_edition.tgz`` from the Intel
    Portal, save in ``/usr/local/media/protected/intel/2017.0/`` then make it
@@ -68,3 +66,34 @@ The following notes are primarily for system administrators.
    <https://en.wikipedia.org/wiki/%22Hello,_World!%22_program>`_ using the
    ``icc`` compiler.
 
+Parallel Studio XE Composer Edition 2015.7
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+#. Download ``l_compxe_2015.7.235.tgz`` from the Intel
+   Portal, save in ``/usr/local/media/protected/intel/2015.7/`` then make it
+   only readable by the ``app-admins`` group.
+#. Ensure details of the Intel license server are in the file
+   ``/usr/local/packages/dev/intel-pe-xe-ce/license.lic``
+#. Run :download:`this script
+   </sharc/software/install_scripts/dev/intel-ps-xe-ce/2015.7/install.sh>`.
+   This installs Parallel Studio into
+   ``/usr/local/packages/dev/intel-pe-xe-ce/2015.7/binary/``.  Products are
+   activated using the aforementioned license file during the installation
+   process.
+#. Install several modulefiles to locations under ``/usr/local/modulefiles``.
+   These modulefiles set the ``INTEL_LICENSE_FILE`` environment variable to the
+   location of the aforementioned license file and set other environment
+   variables required by the different Parallel Studio products.  There is one
+   modulefile for all Parallel Studio software and other modulefiles for
+   specific products.  
+
+    * The :download:`Compilers modulefile </sharc/software/modulefiles/dev/intel-compilers/15.0.7>` should be installed as ``/usr/local/modulefiles/dev/intel-compilers/15.0.7``.
+    * The :download:`IPP modulefile </sharc/software/modulefiles/libs/intel-ipp/2015.7/binary>` should be installed as ``/usr/local/modulefiles/libs/intel-ipp/2015.7/binary``.
+    * The :download:`MKL modulefile </sharc/software/modulefiles/libs/intel-mkl/2015.7/binary>` should be installed as ``/usr/local/modulefiles/libs/intel-mkl/2015.7/binary``.
+    * The :download:`TBB modulefile </sharc/software/modulefiles/libs/intel-tbb/2015.7/binary>` should be installed as ``/usr/local/modulefiles/libs/intel-tbb/2015.7/binary``.
+    * See the (TCL) modulefiles for details of how they were derived from Intel-supplied environment-manipulating shell scripts.
+
+#. Check that licensing is working by activating the Intel Compilers modulefile
+   then try compiling `a trivial C program
+   <https://en.wikipedia.org/wiki/%22Hello,_World!%22_program>`_ using the
+   ``icc`` compiler.

--- a/sharc/software/install_scripts/dev/intel-ps-xe-ce/2015.7/install.sh
+++ b/sharc/software/install_scripts/dev/intel-ps-xe-ce/2015.7/install.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+# Install 'Intel Parallel Studio XE 2015 Composer Edition' on sharc
+
+###############
+# Set variables
+###############
+export SHORT_VERS=2015
+export VERS="${SHORT_VERS}.7"
+export COMP_VERS=15.0.7  # compilers versioned differently
+# Directory containing tarball to store downloaded tarball and build logs
+export MEDIA_DIR="/usr/local/media/protected/intel/${VERS}"
+export TMPDIR="${TMPDIR:-/tmp}"
+# Store unpacked source files
+export SOURCE_DIR="${TMPDIR}/${USER}/intel/${VERS}"
+export TARBALL_FNAME="parallel_studio_xe_${SHORT_VERS}_composer_edition.tgz"
+export TARBALL_FNAME="l_compxe_${VERS}.235.tgz"
+export APPLICATION_ROOT="/usr/local/packages"
+export INSTALL_ROOT_DIR="${APPLICATION_ROOT}/dev/intel-ps-xe-ce"
+# Install in this dir
+export INSTALL_DIR="${INSTALL_ROOT_DIR}/${VERS}/binary"
+# License file (contains details of license server)
+export LIC_FPATH="/usr/local/packages/dev/intel-ps-xe-ce/license.lic"
+
+# Mapping from modulefile sources to destinations
+declare -A modfile_dests_map
+MODFILE_DEST_ROOT="/usr/local/modulefiles/"
+modfile_dests_map["compilers"]="${MODFILE_DEST_ROOT}/dev/intel-compilers/${COMP_VERS}/binary"
+modfile_dests_map["ipp"]="${MODFILE_DEST_ROOT}/libs/intel-ipp/${VERS}/binary"
+modfile_dests_map["mkl"]="${MODFILE_DEST_ROOT}/libs/intel-mkl/${VERS}/binary"
+modfile_dests_map["tbb"]="${MODFILE_DEST_ROOT}/libs/intel-tbb/${VERS}/binary"
+
+################
+# Error handling
+################
+handle_error () {
+    errcode=$? # save the exit code as the first thing done in the trap function 
+    echo "error $errorcode" 
+    echo "the command executing at the
+    time of the error was" echo "$BASH_COMMAND" 
+    echo "on line ${BASH_LINENO[0]}"
+    # do some error handling, cleanup, logging, notification $BASH_COMMAND
+    # contains the command that was being executed at the time of the trap
+    # ${BASH_LINENO[0]} contains the line number in the script of that command
+    # exit the script or return to try again, etc.
+    exit $errcode  # or use some other value or do return instead 
+}
+trap handle_error ERR
+
+##################
+# Make directories
+##################
+mkdir -m 0700 -p $SOURCE_DIR
+
+mkdir -m 2775 -p $INSTALL_DIR
+chown -R ${USER}:app-admins ${INSTALL_DIR} 
+
+for modfile_src in ${!modfile_dests_map[@]}; do
+    modfile_dest=${modfile_dests_map[${modfile_src}]}
+    mkdir -m 2775 -p $(dirname $modfile_dest)
+    chown -R ${USER}:app-admins $(dirname $modfile_dest)
+done
+
+##############
+# Untar source
+##############
+cd ${SOURCE_DIR}
+if [[ -e ./.untar_complete ]]; then
+    echo "Directory already untarred. Moving on"
+else
+    echo "Untarring Intel Parallel Studio"
+   tar xzf ${MEDIA_DIR}/${TARBALL_FNAME}
+    touch ./.untar_complete
+fi
+extracted_dir=$(basename $TARBALL_FNAME .tgz)
+cd $extracted_dir
+
+###########
+# Configure
+###########
+sed -e "s:.*ACCEPT_EULA=.*:ACCEPT_EULA=accept:" \
+    -e "s:.*CONTINUE_WITH_OPTIONAL_ERROR=.*:CONTINUE_WITH_OPTIONAL_ERROR=yes:" \
+    -e "s:.*PSET_INSTALL_DIR=.*:PSET_INSTALL_DIR=${INSTALL_DIR}:" \
+    -e "s:.*ACTIVATION_LICENSE_FILE=.*:ACTIVATION_LICENSE_FILE=${LIC_FPATH}:" \
+    -e "s:.*PSET_MODE=.*:PSET_MODE=install:" \
+    -e "s:.*ACTIVATION_TYPE=.*:ACTIVATION_TYPE=license_server:" \
+    -e "s:.*SIGNING_ENABLED=.*:SIGNING_ENABLED=no:" \
+    silent.cfg > silent.cfg.custom
+
+#########
+# Install
+#########
+# Try to install but if an install previously failed then
+# try to repair the install instead
+./install.sh --silent silent.cfg.custom --user-mode --tmp-dir ${TMPDIR} || \
+    sed -i -e "s:.*PSET_MODE=.*:PSET_MODE=repair:" silent.cfg.custom && \
+    ./install.sh --silent silent.cfg.custom --user-mode --tmp-dir ${TMPDIR} 
+
+#################
+# Set permissions
+#################
+chown -R ${USER}:app-admins ${INSTALL_DIR} 
+chmod -R g+w ${INSTALL_DIR} 
+
+#######################################################
+# Prompt to install modulefiles in particular locations
+#######################################################
+for modfile_src in ${!modfile_dests_map[@]}; do
+    echo "To do: install modulefile to ${modfile_dests_map[${modfile_src}]}"
+done
+

--- a/sharc/software/install_scripts/mpi/openmpi/1.10.4/intel-15.0.7/install.sh
+++ b/sharc/software/install_scripts/mpi/openmpi/1.10.4/intel-15.0.7/install.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Install OpenMPI 1.10.4 built with Intel 15.0.7 compilers on the ShARC cluster
+
+##############################################################################
+# Error handling
+##############################################################################
+
+handle_error () {
+    errcode=$? # save the exit code as the first thing done in the trap function 
+    echo "error $errorcode" 
+    echo "the command executing at the
+    time of the error was" echo "$BASH_COMMAND" 
+    echo "on line ${BASH_LINENO[0]}"
+    # do some error handling, cleanup, logging, notification $BASH_COMMAND
+    # contains the command that was being executed at the time of the trap
+    # ${BASH_LINENO[0]} contains the line number in the script of that command
+    # exit the script or return to try again, etc.
+    exit $errcode  # or use some other value or do return instead 
+} 
+trap handle_error ERR
+
+##############################################################################
+# Module loads
+##############################################################################
+
+module load dev/intel-compilers/15.0.7
+
+##############################################################################
+# Variable setup
+##############################################################################
+
+short_version=1.10
+version=${short_version}.4
+compiler=intel-15.0.7
+build_dir="${TMPDIR-/tmp}/${USER}/openmpi_${version}"
+prefix="/usr/local/packages/mpi/openmpi/${version}/${compiler}"
+modulefile="/usr/local/modulefiles/mpi/openmpi/${version}/${compiler}"
+filename="openmpi-${version}.tar.gz"
+baseurl="http://www.open-mpi.org/software/ompi/v${short_version}/downloads/"
+workers=16  # for building in parallel
+
+##############################################################################
+# Create build, install and modulefile dirs
+##############################################################################
+
+[[ -d $build_dir ]] || mkdir -p $build_dir
+
+for d in $prefix $(dirname $modulefile); do 
+    mkdir -m 2775 -p $d
+    chown -R ${USER}:app-admins $d
+done
+
+##############################################################################
+# Download source
+##############################################################################
+
+cd $build_dir
+wget -c ${baseurl}/${filename}
+
+##############################################################################
+# Build and install
+##############################################################################
+
+tar -xzf openmpi-${version}.tar.gz
+cd openmpi-${version}
+
+./configure --prefix=${prefix} --with-psm2 CC=icc CXX=icpc FC=ifort
+make -j${workers}
+make check
+make install
+
+##############################################################################
+# Download and install examples
+##############################################################################
+
+pushd ${prefix}
+curl -L https://github.com/open-mpi/ompi/archive/v${short_version}.tar.gz | tar -zx
+mv ompi-${short_version}/examples .
+rm -r ompi-${short_version} 
+popd
+
+echo "Next, install modulefile as $modulefile."

--- a/sharc/software/install_scripts/mpi/openmpi/1.10.4/intel-15.0.7/install.sh
+++ b/sharc/software/install_scripts/mpi/openmpi/1.10.4/intel-15.0.7/install.sh
@@ -6,16 +6,11 @@
 ##############################################################################
 
 handle_error () {
-    errcode=$? # save the exit code as the first thing done in the trap function 
-    echo "error $errorcode" 
-    echo "the command executing at the
-    time of the error was" echo "$BASH_COMMAND" 
-    echo "on line ${BASH_LINENO[0]}"
-    # do some error handling, cleanup, logging, notification $BASH_COMMAND
-    # contains the command that was being executed at the time of the trap
-    # ${BASH_LINENO[0]} contains the line number in the script of that command
-    # exit the script or return to try again, etc.
-    exit $errcode  # or use some other value or do return instead 
+    errcode=$?
+    echo "Error code: $errorcode" 
+    echo "Error command: " echo "$BASH_COMMAND" 
+    echo "Error on line: ${BASH_LINENO[0]}"
+    exit $errcode 
 } 
 trap handle_error ERR
 
@@ -23,6 +18,7 @@ trap handle_error ERR
 # Module loads
 ##############################################################################
 
+module purge
 module load dev/intel-compilers/15.0.7
 
 ##############################################################################
@@ -37,7 +33,7 @@ prefix="/usr/local/packages/mpi/openmpi/${version}/${compiler}"
 modulefile="/usr/local/modulefiles/mpi/openmpi/${version}/${compiler}"
 filename="openmpi-${version}.tar.gz"
 baseurl="http://www.open-mpi.org/software/ompi/v${short_version}/downloads/"
-workers=16  # for building in parallel
+mca_conf="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/openmpi-mca-params.conf"
 
 ##############################################################################
 # Create build, install and modulefile dirs
@@ -65,9 +61,14 @@ tar -xzf openmpi-${version}.tar.gz
 cd openmpi-${version}
 
 ./configure --prefix=${prefix} --with-psm2 CC=icc CXX=icpc FC=ifort
-make -j${workers}
+make 
 make check
 make install
+
+##############################################################################
+# Configure default settings
+##############################################################################
+cp ${mca_conf} ${prefix}/etc/openmpi-mca-params.conf
 
 ##############################################################################
 # Download and install examples

--- a/sharc/software/install_scripts/mpi/openmpi/1.10.4/intel-15.0.7/openmpi-mca-params.conf
+++ b/sharc/software/install_scripts/mpi/openmpi/1.10.4/intel-15.0.7/openmpi-mca-params.conf
@@ -1,0 +1,62 @@
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart, 
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
+# $COPYRIGHT$
+# 
+# Additional copyrights may follow
+# 
+# $HEADER$
+#
+
+# This is the default system-wide MCA parameters defaults file.
+# Specifically, the MCA parameter "mca_param_files" defaults to a
+# value of
+# "$HOME/.openmpi/mca-params.conf:$sysconf/openmpi-mca-params.conf"
+# (this file is the latter of the two).  So if the default value of
+# mca_param_files is not changed, this file is used to set system-wide
+# MCA parameters.  This file can therefore be used to set system-wide
+# default MCA parameters for all users.  Of course, users can override
+# these values if they want, but this file is an excellent location
+# for setting system-specific MCA parameters for those users who don't
+# know / care enough to investigate the proper values for them.
+
+# Note that this file is only applicable where it is visible (in a
+# filesystem sense).  Specifically, MPI processes each read this file
+# during their startup to determine what default values for MCA
+# parameters should be used.  mpirun does not bundle up the values in
+# this file from the node where it was run and send them to all nodes;
+# the default value decisions are effectively distributed.  Hence,
+# these values are only applicable on nodes that "see" this file.  If
+# $sysconf is a directory on a local disk, it is likely that changes
+# to this file will need to be propagated to other nodes.  If $sysconf
+# is a directory that is shared via a networked filesystem, changes to
+# this file will be visible to all nodes that share this $sysconf.
+
+# The format is straightforward: one per line, mca_param_name =
+# rvalue.  Quoting is ignored (so if you use quotes or escape
+# characters, they'll be included as part of the value).  For example:
+
+# Disable run-time MPI parameter checking
+#   mpi_param_check = 0
+
+# Note that the value "~/" will be expanded to the current user's home
+# directory.  For example:
+
+# Change component loading path
+#   component_path = /usr/local/lib/openmpi:~/my_openmpi_components
+
+# See "ompi_info --param all all" for a full listing of Open MPI MCA
+# parameters available and their default values.
+
+mtl = psm2 
+btl = ^tcp,openib
+oob_tcp_if_include = p3p1.321

--- a/sharc/software/install_scripts/mpi/openmpi/2.0.1/intel-15.0.7/install.sh
+++ b/sharc/software/install_scripts/mpi/openmpi/2.0.1/intel-15.0.7/install.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Install OpenMPI 2.0.1 built with Intel 15.0.7 compilers on the ShARC cluster
+
+##############################################################################
+# Error handling
+##############################################################################
+
+handle_error () {
+    errcode=$? # save the exit code as the first thing done in the trap function 
+    echo "error $errorcode" 
+    echo "the command executing at the
+    time of the error was" echo "$BASH_COMMAND" 
+    echo "on line ${BASH_LINENO[0]}"
+    # do some error handling, cleanup, logging, notification $BASH_COMMAND
+    # contains the command that was being executed at the time of the trap
+    # ${BASH_LINENO[0]} contains the line number in the script of that command
+    # exit the script or return to try again, etc.
+    exit $errcode  # or use some other value or do return instead 
+} 
+trap handle_error ERR
+
+##############################################################################
+# Module loads
+##############################################################################
+
+module load dev/intel-compilers/15.0.7
+
+##############################################################################
+# Variable setup
+##############################################################################
+
+short_version=2.0
+version=${short_version}.1
+compiler=intel-15.0.7
+build_dir="${TMPDIR-/tmp}/${USER}/openmpi_${version}"
+prefix="/usr/local/packages/mpi/openmpi/${version}/${compiler}"
+modulefile="/usr/local/modulefiles/mpi/openmpi/${version}/${compiler}"
+filename="openmpi-${version}.tar.gz"
+baseurl="http://www.open-mpi.org/software/ompi/v${short_version}/downloads/"
+workers=16  # for building in parallel
+
+##############################################################################
+# Create build, install and modulefile dirs
+##############################################################################
+
+[[ -d $build_dir ]] || mkdir -p $build_dir
+
+for d in $prefix $(dirname $modulefile); do 
+    mkdir -m 2775 -p $d
+    chown -R ${USER}:app-admins $d
+done
+
+##############################################################################
+# Download source
+##############################################################################
+
+cd $build_dir
+wget -c ${baseurl}/${filename}
+
+##############################################################################
+# Build and install
+##############################################################################
+
+tar -xzf openmpi-${version}.tar.gz
+cd openmpi-${version}
+
+./configure --prefix=${prefix} --with-psm2 CC=icc CXX=icpc FC=ifort
+make -j${workers}
+make check
+make install
+
+##############################################################################
+# Download and install examples
+##############################################################################
+
+pushd ${prefix}
+curl -L https://github.com/open-mpi/ompi/archive/v${short_version}.x.tar.gz | tar -zx
+mv ompi-${short_version}.x/examples .
+rm -r ompi-${short_version}.x 
+popd
+
+echo "Next, install modulefile as $modulefile."

--- a/sharc/software/install_scripts/mpi/openmpi/2.0.1/intel-15.0.7/install.sh
+++ b/sharc/software/install_scripts/mpi/openmpi/2.0.1/intel-15.0.7/install.sh
@@ -6,16 +6,11 @@
 ##############################################################################
 
 handle_error () {
-    errcode=$? # save the exit code as the first thing done in the trap function 
-    echo "error $errorcode" 
-    echo "the command executing at the
-    time of the error was" echo "$BASH_COMMAND" 
-    echo "on line ${BASH_LINENO[0]}"
-    # do some error handling, cleanup, logging, notification $BASH_COMMAND
-    # contains the command that was being executed at the time of the trap
-    # ${BASH_LINENO[0]} contains the line number in the script of that command
-    # exit the script or return to try again, etc.
-    exit $errcode  # or use some other value or do return instead 
+    errcode=$?
+    echo "Error code: $errorcode" 
+    echo "Error command: " echo "$BASH_COMMAND" 
+    echo "Error on line: ${BASH_LINENO[0]}"
+    exit $errcode 
 } 
 trap handle_error ERR
 
@@ -23,6 +18,7 @@ trap handle_error ERR
 # Module loads
 ##############################################################################
 
+module purge
 module load dev/intel-compilers/15.0.7
 
 ##############################################################################
@@ -37,7 +33,7 @@ prefix="/usr/local/packages/mpi/openmpi/${version}/${compiler}"
 modulefile="/usr/local/modulefiles/mpi/openmpi/${version}/${compiler}"
 filename="openmpi-${version}.tar.gz"
 baseurl="http://www.open-mpi.org/software/ompi/v${short_version}/downloads/"
-workers=16  # for building in parallel
+mca_conf="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/openmpi-mca-params.conf"
 
 ##############################################################################
 # Create build, install and modulefile dirs
@@ -65,9 +61,14 @@ tar -xzf openmpi-${version}.tar.gz
 cd openmpi-${version}
 
 ./configure --prefix=${prefix} --with-psm2 CC=icc CXX=icpc FC=ifort
-make -j${workers}
+make 
 make check
 make install
+
+##############################################################################
+# Configure default settings
+##############################################################################
+cp ${mca_conf} ${prefix}/etc/openmpi-mca-params.conf
 
 ##############################################################################
 # Download and install examples

--- a/sharc/software/install_scripts/mpi/openmpi/2.0.1/intel-15.0.7/openmpi-mca-params.conf
+++ b/sharc/software/install_scripts/mpi/openmpi/2.0.1/intel-15.0.7/openmpi-mca-params.conf
@@ -1,0 +1,62 @@
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# This is the default system-wide MCA parameters defaults file.
+# Specifically, the MCA parameter "mca_param_files" defaults to a
+# value of
+# "$HOME/.openmpi/mca-params.conf:$sysconf/openmpi-mca-params.conf"
+# (this file is the latter of the two).  So if the default value of
+# mca_param_files is not changed, this file is used to set system-wide
+# MCA parameters.  This file can therefore be used to set system-wide
+# default MCA parameters for all users.  Of course, users can override
+# these values if they want, but this file is an excellent location
+# for setting system-specific MCA parameters for those users who don't
+# know / care enough to investigate the proper values for them.
+
+# Note that this file is only applicable where it is visible (in a
+# filesystem sense).  Specifically, MPI processes each read this file
+# during their startup to determine what default values for MCA
+# parameters should be used.  mpirun does not bundle up the values in
+# this file from the node where it was run and send them to all nodes;
+# the default value decisions are effectively distributed.  Hence,
+# these values are only applicable on nodes that "see" this file.  If
+# $sysconf is a directory on a local disk, it is likely that changes
+# to this file will need to be propagated to other nodes.  If $sysconf
+# is a directory that is shared via a networked filesystem, changes to
+# this file will be visible to all nodes that share this $sysconf.
+
+# The format is straightforward: one per line, mca_param_name =
+# rvalue.  Quoting is ignored (so if you use quotes or escape
+# characters, they'll be included as part of the value).  For example:
+
+# Disable run-time MPI parameter checking
+#   mpi_param_check = 0
+
+# Note that the value "~/" will be expanded to the current user's home
+# directory.  For example:
+
+# Change component loading path
+#   component_path = /usr/local/lib/openmpi:~/my_openmpi_components
+
+# See "ompi_info --param all all" for a full listing of Open MPI MCA
+# parameters available and their default values.
+
+mtl = psm2 
+btl = ^tcp,openib
+oob_tcp_if_include = p3p1.321

--- a/sharc/software/libs/intel_ipp.rst
+++ b/sharc/software/libs/intel_ipp.rst
@@ -9,9 +9,10 @@ Parallel Studio Composer Edition version
 ----------------------------------------
 
 IPP can be used with and without :ref:`other Parallel Studio packages <sharc-intel-parallel-studio>`.
-To access it: ::
+To access it, use one of the following: ::
 
         module load libs/intel-ipp/2017.0/binary
+        module load libs/intel-ipp/2015.7/binary
 
 Licensing and availability
 --------------------------
@@ -28,3 +29,9 @@ The following notes are primarily for system administrators.
 Installed as part of :ref:`Parallel Studio Composer Edition 2017 <sharc-intel-parallel-studio>`.
 
 :download:`This modulefile </sharc/software/modulefiles/libs/intel-ipp/2017.0/binary>` was installed as ``/usr/local/modulefiles/libs/intel-ipp/2017.0/binary``.
+
+**Intel IPP 2015.7**
+
+Installed as part of :ref:`Parallel Studio Composer Edition 2015.7 <sharc-intel-parallel-studio>`.
+
+:download:`This modulefile </sharc/software/modulefiles/libs/intel-ipp/2015.7/binary>` was installed as ``/usr/local/modulefiles/libs/intel-ipp/2015.7/binary``.

--- a/sharc/software/libs/intel_mkl.rst
+++ b/sharc/software/libs/intel_mkl.rst
@@ -9,9 +9,10 @@ Parallel Studio Composer Edition version
 ----------------------------------------
 
 MKL can be used with and without :ref:`other Parallel Studio packages <sharc-intel-parallel-studio>`.
-To access it: ::
+To access it run **one** of the following: ::
 
     module load libs/intel-mkl/2017.0/binary
+    module load libs/intel-mkl/2015.7/binary
 
 Sample C and Fortran programs demonstrating matrix multiplication 
 are available for **version 2017.0** in the directory ``$MKL_SAMPLES``: ::
@@ -80,8 +81,16 @@ Installation Notes
 
 The following notes are primarily for system administrators.
 
-**Intel MKL 2017.0**
+Intel MKL 2017.0
+^^^^^^^^^^^^^^^^
 
 Installed as part of :ref:`Parallel Studio Composer Edition 2017 <sharc-intel-parallel-studio>`.
 
 :download:`This modulefile </sharc/software/modulefiles/libs/intel-mkl/2017.0/binary>` was installed as ``/usr/local/modulefiles/libs/intel-mkl/2017.0/binary``.
+
+Intel MKL 2015.7
+^^^^^^^^^^^^^^^^
+
+Installed as part of :ref:`Parallel Studio Composer Edition 2015.7 <sharc-intel-parallel-studio>`.
+
+:download:`This modulefile </sharc/software/modulefiles/libs/intel-mkl/2015.7/binary>` was installed as ``/usr/local/modulefiles/libs/intel-mkl/2015.7/binary``.

--- a/sharc/software/libs/intel_tbb.rst
+++ b/sharc/software/libs/intel_tbb.rst
@@ -18,11 +18,12 @@ Here we request six cores from the clusters' scheduler: ::
 
         $ qrsh -pe openmp 6
 
-Next, we need to *active* a specific version of TBB: ::
+Next, we need to *active* a specific version of TBB.  Run **one** of the following: ::
 
         $ module load libs/intel-tbb/2017.0/binary
+        $ module load libs/intel-tbb/2015.7/binary
 
-You can find sample TBB programs in the directory ``$TBB_SAMPLES``: ::
+You can find sample TBB programs **for TBB 2017.0** in the directory ``$TBB_SAMPLES``: ::
 
         $ ls $TBB_SAMPLES
 
@@ -75,7 +76,8 @@ Installation Notes
 
 The following notes are primarily for system administrators.
 
-**Intel TBB 2017.0**
+Intel TBB 2017.0
+^^^^^^^^^^^^^^^^
 
 Installed as part of :ref:`Parallel Studio Composer Edition 2017
 <sharc-intel-parallel-studio>`.
@@ -83,3 +85,13 @@ Installed as part of :ref:`Parallel Studio Composer Edition 2017
 :download:`This modulefile 
 </sharc/software/modulefiles/libs/intel-tbb/2017.0/binary>` was installed as
 ``/usr/local/modulefiles/libs/intel-tbb/2017.0/binary``.
+
+Intel TBB 2015.7
+^^^^^^^^^^^^^^^^
+
+Installed as part of :ref:`Parallel Studio Composer Edition 2015.7
+<sharc-intel-parallel-studio>`.
+
+:download:`This modulefile 
+</sharc/software/modulefiles/libs/intel-tbb/2015.7/binary>` was installed as
+``/usr/local/modulefiles/libs/intel-tbb/2015.7/binary``.

--- a/sharc/software/modulefiles/dev/intel-compilers/15.0.7
+++ b/sharc/software/modulefiles/dev/intel-compilers/15.0.7
@@ -1,0 +1,100 @@
+#%Module1.0#####################################################################
+##
+## Intel compilers 15.0.7 module file
+## 
+################################################################################
+
+## Module file logging
+#source /usr/local/etc/module_logging.tcl
+##
+
+proc ModulesHelp { } {
+        global $compilerversion
+
+        puts stderr "   Makes `Intel C++ and Fortran compilers plus debugger version $compilerversion' available for use"
+}
+
+module-whatis   "Makes Intel C++ and Fortran compilers (ifort and icc) and debugger available"
+
+conflict dev/intel-compilers
+
+set     compilerversion 15.0.7
+set     parallelstudioversion 2015.7
+set     intelroot    /usr/local/packages/dev/intel-ps-xe-ce/$parallelstudioversion/binary
+ 
+# load java  ( needed with debugging etc. ) 
+module load apps/java
+
+# Compiler variables determined using
+# env2 -from bash -to modulecmd "/usr/local/packages/dev/intel-ps-xe-ce/2015.7/binary/bin/compilervars.sh intel64" | sed -e "s#/usr/local/packages/dev/intel-ps-xe-ce/2015.7/binary#\$intelroot#g" -e 's/[{}]//g' | grep -v 'append-path MANPATH ;'
+append-path MIC_LD_LIBRARY_PATH $intelroot/composer_xe_2015.7.235/compiler/lib/mic;
+append-path MIC_LD_LIBRARY_PATH $intelroot/composer_xe_2015.7.235/mpirt/lib/mic;
+append-path MIC_LD_LIBRARY_PATH $intelroot/composer_xe_2015.7.235/compiler/lib/mic;
+append-path MIC_LD_LIBRARY_PATH $intelroot/composer_xe_2015.7.235/mkl/lib/mic;
+append-path MIC_LD_LIBRARY_PATH $intelroot/composer_xe_2015.7.235/tbb/lib/mic;
+prepend-path PATH $intelroot/composer_xe_2015.7.235/debugger/gdb/intel64_mic/bin;
+prepend-path PATH $intelroot/composer_xe_2015.7.235/bin/intel64;
+append-path INTEL_LICENSE_FILE $intelroot/composer_xe_2015.7.235/licenses;
+append-path INTEL_LICENSE_FILE /opt/intel/licenses;
+append-path INTEL_LICENSE_FILE /home/sa_cs1wf/intel/licenses;
+append-path CPATH $intelroot/composer_xe_2015.7.235/ipp/include;
+append-path CPATH $intelroot/composer_xe_2015.7.235/mkl/include;
+append-path CPATH $intelroot/composer_xe_2015.7.235/tbb/include;
+append-path LD_LIBRARY_PATH $intelroot/composer_xe_2015.7.235/compiler/lib/intel64;
+append-path LD_LIBRARY_PATH $intelroot/composer_xe_2015.7.235/mpirt/lib/intel64;
+append-path LD_LIBRARY_PATH $intelroot/composer_xe_2015.7.235/ipp/../compiler/lib/intel64;
+append-path LD_LIBRARY_PATH $intelroot/composer_xe_2015.7.235/ipp/lib/intel64;
+append-path LD_LIBRARY_PATH $intelroot/composer_xe_2015.7.235/ipp/tools/intel64/perfsys;
+append-path LD_LIBRARY_PATH $intelroot/composer_xe_2015.7.235/compiler/lib/intel64;
+append-path LD_LIBRARY_PATH $intelroot/composer_xe_2015.7.235/mkl/lib/intel64;
+append-path LD_LIBRARY_PATH $intelroot/composer_xe_2015.7.235/tbb/lib/intel64/gcc4.4;
+append-path LD_LIBRARY_PATH $intelroot/composer_xe_2015.7.235/debugger/libipt/intel64/lib;
+prepend-path MANPATH $intelroot/composer_xe_2015.7.235/debugger/gdb/intel64_mic/share/man/;
+prepend-path MANPATH $intelroot/composer_xe_2015.7.235/debugger/gdb/intel64/share/man/;
+prepend-path MANPATH $intelroot/composer_xe_2015.7.235/man/en_US;
+prepend-path MANPATH $intelroot/composer_xe_2015.7.235/man/en_US;
+append-path LIBRARY_PATH $intelroot/composer_xe_2015.7.235/compiler/lib/intel64;
+append-path LIBRARY_PATH $intelroot/composer_xe_2015.7.235/ipp/../compiler/lib/intel64;
+append-path LIBRARY_PATH $intelroot/composer_xe_2015.7.235/ipp/lib/intel64;
+append-path LIBRARY_PATH $intelroot/composer_xe_2015.7.235/compiler/lib/intel64;
+append-path LIBRARY_PATH $intelroot/composer_xe_2015.7.235/mkl/lib/intel64;
+append-path LIBRARY_PATH $intelroot/composer_xe_2015.7.235/tbb/lib/intel64/gcc4.4;
+append-path INFOPATH $intelroot/composer_xe_2015.7.235/debugger/gdb/intel64/share/info/;
+append-path INFOPATH $intelroot/composer_xe_2015.7.235/debugger/gdb/intel64_mic/share/info/;
+append-path MIC_LIBRARY_PATH $intelroot/composer_xe_2015.7.235/compiler/lib/mic;
+append-path MIC_LIBRARY_PATH $intelroot/composer_xe_2015.7.235/mpirt/lib/mic;
+append-path MIC_LIBRARY_PATH $intelroot/composer_xe_2015.7.235/tbb/lib/mic;
+append-path NLSPATH $intelroot/composer_xe_2015.7.235/compiler/lib/intel64/locale/%l_%t/%N;
+append-path NLSPATH $intelroot/composer_xe_2015.7.235/ipp/lib/intel64/locale/%l_%t/%N;
+append-path NLSPATH $intelroot/composer_xe_2015.7.235/mkl/lib/intel64/locale/%l_%t/%N;
+append-path NLSPATH $intelroot/composer_xe_2015.7.235/debugger/gdb/intel64_mic/share/locale/%l_%t/%N;
+append-path NLSPATH $intelroot/composer_xe_2015.7.235/debugger/gdb/intel64/share/locale/%l_%t/%N;
+
+# Debugger variables determined using
+# env2 -from bash -to modulecmd "/usr/local/packages/dev/intel-ps-xe-ce/2015.7/binary/composer_xe_2015.7.235/bin/debuggervars.sh intel64" | sed -e "s#/usr/local/packages/dev/intel-ps-xe-ce/2015.7/binary#\$intelroot#g" -e 's/[{}]//g'
+prepend-path PATH $intelroot/composer_xe_2015.7.235/debugger/gdb/intel64_mic/bin;
+prepend-path LD_LIBRARY_PATH $intelroot/composer_xe_2015.7.235/debugger/libipt/intel64/lib;
+prepend-path MANPATH $intelroot/composer_xe_2015.7.235/debugger/gdb/intel64_mic/share/man/;
+prepend-path MANPATH $intelroot/composer_xe_2015.7.235/debugger/gdb/intel64/share/man/;
+append-path INFOPATH $intelroot/composer_xe_2015.7.235/debugger/gdb/intel64/share/info/;
+append-path INFOPATH $intelroot/composer_xe_2015.7.235/debugger/gdb/intel64_mic/share/info/;
+prepend-path NLSPATH $intelroot/composer_xe_2015.7.235/debugger/gdb/intel64/share/locale/%l_%t/%N;
+prepend-path NLSPATH $intelroot/composer_xe_2015.7.235/debugger/gdb/intel64_mic/share/locale/%l_%t/%N;
+
+# Shorthand variables for compilers
+
+set     cc              icc
+set     cxx             icpc
+set     f77             ifort
+set     f90             ifort
+set     f95             ifort
+set     fc              ifort
+setenv          CC              $cc
+setenv          CXX             $cxx
+setenv          F77             $f77
+setenv          FC              $fc
+setenv          F90             $f90
+setenv          F95             $f95
+
+# License file (points at license server)
+setenv INTEL_LICENSE_FILE /usr/local/packages/dev/intel-ps-xe-ce/license.lic

--- a/sharc/software/modulefiles/libs/intel-ipp/2015.7/binary
+++ b/sharc/software/modulefiles/libs/intel-ipp/2015.7/binary
@@ -1,0 +1,35 @@
+#%Module1.0#####################################################################
+#
+# Intel Integrated Performance Primitives (IPP) 2015.7 module file
+# 
+################################################################################
+
+## Module file logging
+#source /usr/local/etc/module_logging.tcl
+
+proc ModulesHelp { } {
+        global version
+
+        puts stderr "   Makes the `Intel Integrated Performance Primitives (IPP) $version' available for use"
+}
+
+module-whatis   "Makes the `Intel Integrated Performance Primitives (IPP)' available for use"
+
+# module variables
+#
+set     version      2015.7
+set     intelpsroot     /usr/local/packages/dev/intel-ps-xe-ce/$version/binary/
+
+# Variables determined using
+# env2 -from bash -to modulecmd "/usr/local/packages/dev/intel-ps-xe-ce/2015.7/binary/composer_xe_2015.7.235/ipp/bin/ippvars.sh intel64" | sed -e "s#/usr/local/packages/dev/intel-ps-xe-ce/2015.7/binary#\$intelpsroot#g" -e 's/[{}]//g'
+prepend-path CPATH $intelpsroot/composer_xe_2015.7.235/ipp/include;
+prepend-path LD_LIBRARY_PATH $intelpsroot/composer_xe_2015.7.235/ipp/tools/intel64/perfsys;
+prepend-path LD_LIBRARY_PATH $intelpsroot/composer_xe_2015.7.235/ipp/lib/intel64;
+prepend-path LD_LIBRARY_PATH $intelpsroot/composer_xe_2015.7.235/ipp/../compiler/lib/intel64;
+prepend-path LIBRARY_PATH $intelpsroot/composer_xe_2015.7.235/ipp/lib/intel64;
+prepend-path LIBRARY_PATH $intelpsroot/composer_xe_2015.7.235/ipp/../compiler/lib/intel64;
+prepend-path NLSPATH $intelpsroot/composer_xe_2015.7.235/ipp/lib/intel64/locale/%l_%t/%N;
+setenv IPPROOT $intelpsroot/compilers_and_libraries_2017.0.098/linux/ipp;
+
+# License file (points at license server)
+setenv INTEL_LICENSE_FILE /usr/local/packages/dev/intel-ps-xe-ce/license.lic

--- a/sharc/software/modulefiles/libs/intel-mkl/2015.7/binary
+++ b/sharc/software/modulefiles/libs/intel-mkl/2015.7/binary
@@ -1,0 +1,38 @@
+#%Module1.0#####################################################################
+#
+# Intel Math Kernel Library (MKL) 2015.7 module file
+# 
+################################################################################
+
+# Module file logging
+source /usr/local/etc/module_logging.tcl
+
+proc ModulesHelp { } {
+        global version
+
+        puts stderr "   Makes the `Intel Math Kernel Library (MLK) $version' available for use"
+}
+
+module-whatis   "Makes the `Intel Math Kernel Library (MLK) available for use"
+
+# module variables
+#
+set     version      2015.7
+set     intelpsroot     /usr/local/packages/dev/intel-ps-xe-ce/$version/binary/
+
+# Variables determined using
+# env2 -from bash -to modulecmd "/usr/local/packages/dev/intel-ps-xe-ce/2015.7/binary/composer_xe_2015.7.235/mkl/bin/mklvars.sh intel64" | sed -e "s#/usr/local/packages/dev/intel-ps-xe-ce/2015.7/binary#\$intelpsroot#g" -e 's/[{}]//g'
+prepend-path MIC_LD_LIBRARY_PATH $intelpsroot/composer_xe_2015.7.235/mkl/lib/mic;
+prepend-path MIC_LD_LIBRARY_PATH $intelpsroot/composer_xe_2015.7.235/compiler/lib/mic;
+prepend-path CPATH $intelpsroot/composer_xe_2015.7.235/mkl/include;
+prepend-path LD_LIBRARY_PATH $intelpsroot/composer_xe_2015.7.235/mkl/lib/intel64;
+prepend-path LD_LIBRARY_PATH $intelpsroot/composer_xe_2015.7.235/compiler/lib/intel64;
+prepend-path MANPATH $intelpsroot/composer_xe_2015.7.235/man/en_US;
+prepend-path LIBRARY_PATH $intelpsroot/composer_xe_2015.7.235/mkl/lib/intel64;
+prepend-path LIBRARY_PATH $intelpsroot/composer_xe_2015.7.235/compiler/lib/intel64;
+prepend-path NLSPATH $intelpsroot/composer_xe_2015.7.235/mkl/lib/intel64/locale/%l_%t/%N;
+
+setenv MKLROOT $intelpsroot/composer_xe_2015.7.235/mkl
+
+# License file (points at license server)
+setenv INTEL_LICENSE_FILE /usr/local/packages/dev/intel-ps-xe-ce/license.lic

--- a/sharc/software/modulefiles/libs/intel-tbb/2015.7/binary
+++ b/sharc/software/modulefiles/libs/intel-tbb/2015.7/binary
@@ -1,0 +1,34 @@
+#%Module1.0#####################################################################
+#
+# Intel Threading Building Blocks (TBB) 2015.7 module file
+# 
+################################################################################
+
+# Module file logging
+source /usr/local/etc/module_logging.tcl
+
+proc ModulesHelp { } {
+        global version
+
+        puts stderr "   Makes `Intel Threading Building Blocks (TBB) $version' available for use"
+}
+
+module-whatis   "Makes `Intel Threading Building Blocks (TBB)' available for use"
+
+# module variables
+#
+set     version      2015.7
+set     intelpsroot     /usr/local/packages/dev/intel-ps-xe-ce/$version/binary/
+
+# Variables determined using
+# env2 -from bash -to modulecmd "/usr/local/packages/dev/intel-ps-xe-ce/2015.7/binary/composer_xe_2015.7.235/tbb/bin/tbbvars.sh intel64" | sed -e "s#/usr/local/packages/dev/intel-ps-xe-ce/2015.7/binary#\$intelpsroot#g" -e 's/[{}]//g'
+prepend-path MIC_LD_LIBRARY_PATH $intelpsroot/composer_xe_2015.7.235/tbb/lib/mic;
+prepend-path CPATH $intelpsroot/composer_xe_2015.7.235/tbb/include;
+prepend-path LD_LIBRARY_PATH $intelpsroot/composer_xe_2015.7.235/tbb/lib/intel64/gcc4.4;
+prepend-path LIBRARY_PATH $intelpsroot/composer_xe_2015.7.235/tbb/lib/intel64/gcc4.4;
+prepend-path MIC_LIBRARY_PATH $intelpsroot/composer_xe_2015.7.235/tbb/lib/mic;
+
+setenv TBBROOT $intelpsroot/compilers_and_libraries_2017.0.098/linux/tbb;
+
+# License file (points at license server)
+setenv INTEL_LICENSE_FILE /usr/local/packages/dev/intel-ps-xe-ce/license.lic

--- a/sharc/software/modulefiles/mpi/openmpi/1.10.4/intel-15.0.7
+++ b/sharc/software/modulefiles/mpi/openmpi/1.10.4/intel-15.0.7
@@ -1,0 +1,34 @@
+#%Module1.0#####################################################################
+##
+## OpenMPI (+ Intel compilers) module file
+##
+
+## Module file logging
+source /usr/local/etc/module_logging.tcl
+##
+
+proc ModulesHelp { } {
+    global openmpiversion
+    global compiler
+
+    puts stderr "   Adds `openmpi-$openmpiversion' (+ Intel compilers) to your PATH environment variable and necessary libraries"
+}
+
+set openmpiversion   1.10.4
+set compilerversion  15.0.7
+set openmpiroot      /usr/local/packages/mpi/openmpi/$openmpiversion/intel-$compilerversion
+
+module-whatis   "Adds `openmpi-$openmpiversion' (+ Intel compilers) to your PATH environment variable and necessary libraries"
+
+#setenv OMPI_MCA_btl_tcp_if_include eth0
+#setenv OMPI_MCA_btl tcp,self
+
+module load dev/intel-compilers/$compilerversion
+
+setenv MPI_HOME $openmpiroot
+
+prepend-path CPATH $openmpiroot/include
+prepend-path PATH $openmpiroot/bin
+prepend-path LD_LIBRARY_PATH $openmpiroot/lib
+prepend-path LIBRARY_PATH $openmpiroot/lib
+prepend-path MANPATH $openmpiroot/share/man

--- a/sharc/software/modulefiles/mpi/openmpi/2.0.1/intel-15.0.7
+++ b/sharc/software/modulefiles/mpi/openmpi/2.0.1/intel-15.0.7
@@ -1,0 +1,34 @@
+#%Module1.0#####################################################################
+##
+## OpenMPI (+ Intel compilers) module file
+##
+
+## Module file logging
+source /usr/local/etc/module_logging.tcl
+##
+
+proc ModulesHelp { } {
+    global openmpiversion
+    global compiler
+
+    puts stderr "   Adds `openmpi-$openmpiversion' (+ Intel compilers) to your PATH environment variable and necessary libraries"
+}
+
+set openmpiversion   2.0.1
+set compilerversion  15.0.7
+set openmpiroot      /usr/local/packages/mpi/openmpi/$openmpiversion/intel-$compilerversion
+
+module-whatis   "Adds `openmpi-$openmpiversion' (+ Intel compilers) to your PATH environment variable and necessary libraries"
+
+#setenv OMPI_MCA_btl_tcp_if_include eth0
+#setenv OMPI_MCA_btl tcp,self
+
+module load dev/intel-compilers/$compilerversion
+
+setenv MPI_HOME $openmpiroot
+
+prepend-path CPATH $openmpiroot/include
+prepend-path PATH $openmpiroot/bin
+prepend-path LD_LIBRARY_PATH $openmpiroot/lib
+prepend-path LIBRARY_PATH $openmpiroot/lib
+prepend-path MANPATH $openmpiroot/share/man

--- a/sharc/software/parallel/openmpi-intel.rst
+++ b/sharc/software/parallel/openmpi-intel.rst
@@ -77,7 +77,7 @@ Version 2.0.1, Intel 15.0.7 compiler
 #. Test by running some <Examples>_.
 
 Version 1.10.4, Intel 15.0.7 compiler
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 #. Ensure :ref:`Intel compilers 15.0.7 <sharc-intel-compilers>` are installed and licensed.
 #. Download, compile and install OpenMPI 1.10.4 using :download:`this script </sharc/software/install_scripts/mpi/openmpi/1.10.4/intel-15.0.7/install.sh>`.

--- a/sharc/software/parallel/openmpi-intel.rst
+++ b/sharc/software/parallel/openmpi-intel.rst
@@ -15,6 +15,8 @@ Versions
 You can load a specific version using ::
 
    module load mpi/openmpi/2.0.1/intel-17.0.0
+   module load mpi/openmpi/2.0.1/intel-15.0.7
+   module load mpi/openmpi/1.10.4/intel-15.0.7
 
 See `here <https://mail-archive.com/announce@lists.open-mpi.org/msg00085.html>`__ for a brief guide to the new features in OpenMPI 2.x and `here <https://raw.githubusercontent.com/open-mpi/ompi/v2.x/NEWS>`__ for a detailed view of the changes between OpenMPI versions.
 
@@ -58,9 +60,26 @@ Installation notes
 
 These are primarily for administrators of the system.
 
-**Version 2.0.1**
+Version 2.0.1, Intel 17.0.0 compiler
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 #. Ensure :ref:`Intel compilers 17.0.0 <sharc-intel-compilers>` are installed and licensed.
 #. Download, compile and install OpenMPI 2.0.1 using :download:`this script </sharc/software/install_scripts/mpi/openmpi/2.0.1/intel-17.0.0/install.sh>`.
 #. Install :download:`this modulefile </sharc/software/modulefiles/mpi/openmpi/2.0.1/intel-17.0.0>` as ``/usr/local/modulefiles/mpi/openmpi/2.0.1/intel-17.0.0``
+#. Test by running some <Examples>_.
+
+Version 2.0.1, Intel 15.0.7 compiler
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+#. Ensure :ref:`Intel compilers 15.0.7 <sharc-intel-compilers>` are installed and licensed.
+#. Download, compile and install OpenMPI 2.0.1 using :download:`this script </sharc/software/install_scripts/mpi/openmpi/2.0.1/intel-15.0.7/install.sh>`.
+#. Install :download:`this modulefile </sharc/software/modulefiles/mpi/openmpi/2.0.1/intel-15.0.7>` as ``/usr/local/modulefiles/mpi/openmpi/2.0.1/intel-15.0.7``
+#. Test by running some <Examples>_.
+
+Version 1.10.4, Intel 15.0.7 compiler
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+#. Ensure :ref:`Intel compilers 15.0.7 <sharc-intel-compilers>` are installed and licensed.
+#. Download, compile and install OpenMPI 1.10.4 using :download:`this script </sharc/software/install_scripts/mpi/openmpi/1.10.4/intel-15.0.7/install.sh>`.
+#. Install :download:`this modulefile </sharc/software/modulefiles/mpi/openmpi/1.10.4/intel-15.0.7>` as ``/usr/local/modulefiles/mpi/openmpi/1.10.4/intel-15.0.7``
 #. Test by running some <Examples>_.


### PR DESCRIPTION
- [x] cached installer 
- [x] install script
- [x] modulefiles (compilers, MKL, TBB, IPP)
- [x] documentation
- [x] openmpi 2.0.1 build (install script, modulefile and documentation)
- [x] openmpi 1.10.4 build (install script, modulefile and documentation)
- [x] testing

