### PR TITLE
ShARC + OpenMPI 1.10.4

### DIFF
--- a/sharc/software/install_scripts/mpi/openmpi/1.10.4/gcc-4.9.4/install.sh
+++ b/sharc/software/install_scripts/mpi/openmpi/1.10.4/gcc-4.9.4/install.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Install OpenMPI 1.10.4 built with GCC 4.9.4 on the ShARC cluster
+
+##############################################################################
+# Error handling
+##############################################################################
+
+handle_error () {
+    errcode=$?
+    echo "Error code: $errorcode" 
+    echo "Error command: " echo "$BASH_COMMAND" 
+    echo "Error on line: ${BASH_LINENO[0]}"
+    exit $errcode 
+} 
+trap handle_error ERR
+
+##############################################################################
+# Module loads
+##############################################################################
+
+module purge
+module load dev/gcc/4.9.4
+
+##############################################################################
+# Variable setup
+##############################################################################
+
+short_version=1.10
+version=${short_version}.4
+build_dir="/scratch/${USER}/openmpi_${version}"
+prefix="/usr/local/packages/mpi/openmpi/${version}/gcc-4.9.4"
+
+filename="openmpi-${version}.tar.gz"
+baseurl="http://www.open-mpi.org/software/ompi/v${short_version}/downloads/"
+mca_conf="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/openmpi-mca-params.conf"
+
+##############################################################################
+# Create build, install and modulefile dirs
+##############################################################################
+
+[[ -d $build_dir ]] || mkdir -p $build_dir
+cd $build_dir
+
+mkdir -p $prefix
+chown ${USER}:app-admins $prefix
+chmod 2775 $prefix
+
+######################### Download source ###################################
+if [[ -e $filename ]]; then
+    echo "Install tarball exists. Download not required."                         
+else                                                                            
+    echo "Downloading source" 
+    wget ${baseurl}/${filename}
+fi
+
+##############################################################################
+# Build and install
+##############################################################################
+
+tar -xzf openmpi-${version}.tar.gz
+cd openmpi-${version}
+
+./configure --prefix=${prefix} --with-psm2
+make
+make check
+make install
+
+##############################################################################
+# Configure default settings
+##############################################################################
+cp ${mca_conf} ${prefix}/etc/openmpi-mca-params.conf
+
+##############################################################################
+# Download and install examples
+##############################################################################
+
+pushd ${prefix}
+curl -L https://github.com/open-mpi/ompi/archive/v${short_version}.tar.gz | tar -zx
+mv ompi-${short_version}/examples .
+rm -r ompi-${short_version}
+popd

--- a/sharc/software/install_scripts/mpi/openmpi/1.10.4/gcc-4.9.4/openmpi-mca-params.conf
+++ b/sharc/software/install_scripts/mpi/openmpi/1.10.4/gcc-4.9.4/openmpi-mca-params.conf
@@ -1,0 +1,62 @@
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart, 
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
+# $COPYRIGHT$
+# 
+# Additional copyrights may follow
+# 
+# $HEADER$
+#
+
+# This is the default system-wide MCA parameters defaults file.
+# Specifically, the MCA parameter "mca_param_files" defaults to a
+# value of
+# "$HOME/.openmpi/mca-params.conf:$sysconf/openmpi-mca-params.conf"
+# (this file is the latter of the two).  So if the default value of
+# mca_param_files is not changed, this file is used to set system-wide
+# MCA parameters.  This file can therefore be used to set system-wide
+# default MCA parameters for all users.  Of course, users can override
+# these values if they want, but this file is an excellent location
+# for setting system-specific MCA parameters for those users who don't
+# know / care enough to investigate the proper values for them.
+
+# Note that this file is only applicable where it is visible (in a
+# filesystem sense).  Specifically, MPI processes each read this file
+# during their startup to determine what default values for MCA
+# parameters should be used.  mpirun does not bundle up the values in
+# this file from the node where it was run and send them to all nodes;
+# the default value decisions are effectively distributed.  Hence,
+# these values are only applicable on nodes that "see" this file.  If
+# $sysconf is a directory on a local disk, it is likely that changes
+# to this file will need to be propagated to other nodes.  If $sysconf
+# is a directory that is shared via a networked filesystem, changes to
+# this file will be visible to all nodes that share this $sysconf.
+
+# The format is straightforward: one per line, mca_param_name =
+# rvalue.  Quoting is ignored (so if you use quotes or escape
+# characters, they'll be included as part of the value).  For example:
+
+# Disable run-time MPI parameter checking
+#   mpi_param_check = 0
+
+# Note that the value "~/" will be expanded to the current user's home
+# directory.  For example:
+
+# Change component loading path
+#   component_path = /usr/local/lib/openmpi:~/my_openmpi_components
+
+# See "ompi_info --param all all" for a full listing of Open MPI MCA
+# parameters available and their default values.
+
+mtl = psm2 
+btl = ^tcp,openib
+oob_tcp_if_include = p3p1.321

--- a/sharc/software/install_scripts/mpi/openmpi/1.10.4/gcc-6.2/openmpi-mca-params.conf
+++ b/sharc/software/install_scripts/mpi/openmpi/1.10.4/gcc-6.2/openmpi-mca-params.conf
@@ -1,0 +1,62 @@
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart, 
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
+# $COPYRIGHT$
+# 
+# Additional copyrights may follow
+# 
+# $HEADER$
+#
+
+# This is the default system-wide MCA parameters defaults file.
+# Specifically, the MCA parameter "mca_param_files" defaults to a
+# value of
+# "$HOME/.openmpi/mca-params.conf:$sysconf/openmpi-mca-params.conf"
+# (this file is the latter of the two).  So if the default value of
+# mca_param_files is not changed, this file is used to set system-wide
+# MCA parameters.  This file can therefore be used to set system-wide
+# default MCA parameters for all users.  Of course, users can override
+# these values if they want, but this file is an excellent location
+# for setting system-specific MCA parameters for those users who don't
+# know / care enough to investigate the proper values for them.
+
+# Note that this file is only applicable where it is visible (in a
+# filesystem sense).  Specifically, MPI processes each read this file
+# during their startup to determine what default values for MCA
+# parameters should be used.  mpirun does not bundle up the values in
+# this file from the node where it was run and send them to all nodes;
+# the default value decisions are effectively distributed.  Hence,
+# these values are only applicable on nodes that "see" this file.  If
+# $sysconf is a directory on a local disk, it is likely that changes
+# to this file will need to be propagated to other nodes.  If $sysconf
+# is a directory that is shared via a networked filesystem, changes to
+# this file will be visible to all nodes that share this $sysconf.
+
+# The format is straightforward: one per line, mca_param_name =
+# rvalue.  Quoting is ignored (so if you use quotes or escape
+# characters, they'll be included as part of the value).  For example:
+
+# Disable run-time MPI parameter checking
+#   mpi_param_check = 0
+
+# Note that the value "~/" will be expanded to the current user's home
+# directory.  For example:
+
+# Change component loading path
+#   component_path = /usr/local/lib/openmpi:~/my_openmpi_components
+
+# See "ompi_info --param all all" for a full listing of Open MPI MCA
+# parameters available and their default values.
+
+mtl = psm2 
+btl = ^tcp,openib
+oob_tcp_if_include = p3p1.321

--- a/sharc/software/install_scripts/mpi/openmpi/1.10.4/intel-15.0.7/install.sh
+++ b/sharc/software/install_scripts/mpi/openmpi/1.10.4/intel-15.0.7/install.sh
@@ -61,7 +61,7 @@ tar -xzf openmpi-${version}.tar.gz
 cd openmpi-${version}
 
 ./configure --prefix=${prefix} --with-psm2 CC=icc CXX=icpc FC=ifort
-make 
+make
 make check
 make install
 
@@ -77,7 +77,7 @@ cp ${mca_conf} ${prefix}/etc/openmpi-mca-params.conf
 pushd ${prefix}
 curl -L https://github.com/open-mpi/ompi/archive/v${short_version}.tar.gz | tar -zx
 mv ompi-${short_version}/examples .
-rm -r ompi-${short_version} 
+rm -r ompi-${short_version}
 popd
 
 echo "Next, install modulefile as $modulefile."

--- a/sharc/software/modulefiles/mpi/openmpi/1.10.4/gcc-4.9.4
+++ b/sharc/software/modulefiles/mpi/openmpi/1.10.4/gcc-4.9.4
@@ -1,0 +1,31 @@
+#%Module1.0#####################################################################
+##
+## openmpi module file
+##
+
+## Module file logging
+source /usr/local/etc/module_logging.tcl
+##
+
+proc ModulesHelp { } {
+    global openmpiversion
+
+    puts stderr "   Adds `openmpi-$openmpiversion' to your PATH environment variable and necessary libraries"
+}
+
+set openmpiversion   1.10.4
+set compiler         gcc
+set compilerversion  4.9.4
+set openmpiroot      /usr/local/packages/mpi/openmpi/$openmpiversion/$compiler-$compilerversion
+
+module-whatis   "loads the necessary `openmpi-$openmpiversion' library paths"
+
+module load dev/$compiler/$compilerversion
+
+setenv MPI_HOME $openmpiroot
+
+prepend-path CPATH $openmpiroot/include
+prepend-path PATH $openmpiroot/bin
+prepend-path LD_LIBRARY_PATH $openmpiroot/lib
+prepend-path LIBRARY_PATH $openmpiroot/lib
+prepend-path MANPATH $openmpiroot/share/man

--- a/sharc/software/modulefiles/mpi/openmpi/1.10.4/gcc-6.2
+++ b/sharc/software/modulefiles/mpi/openmpi/1.10.4/gcc-6.2
@@ -20,9 +20,6 @@ set openmpiroot      /usr/local/packages/mpi/openmpi/$openmpiversion/$compiler-$
 
 module-whatis   "loads the necessary `openmpi-$openmpiversion' library paths"
 
-#setenv OMPI_MCA_btl_tcp_if_include eth0
-#setenv OMPI_MCA_btl tcp,self
-
 module load dev/$compiler/$compilerversion
 
 setenv MPI_HOME $openmpiroot

--- a/sharc/software/modulefiles/mpi/openmpi/1.10.4/intel-15.0.7
+++ b/sharc/software/modulefiles/mpi/openmpi/1.10.4/intel-15.0.7
@@ -20,9 +20,6 @@ set openmpiroot      /usr/local/packages/mpi/openmpi/$openmpiversion/intel-$comp
 
 module-whatis   "Adds `openmpi-$openmpiversion' (+ Intel compilers) to your PATH environment variable and necessary libraries"
 
-#setenv OMPI_MCA_btl_tcp_if_include eth0
-#setenv OMPI_MCA_btl tcp,self
-
 module load dev/intel-compilers/$compilerversion
 
 setenv MPI_HOME $openmpiroot

--- a/sharc/software/parallel/openmpi-gcc.rst
+++ b/sharc/software/parallel/openmpi-gcc.rst
@@ -18,10 +18,12 @@ You can load a specific version using ::
    module load mpi/openmpi/2.0.1/gcc-5.4
    module load mpi/openmpi/2.0.1/gcc-4.9.4
    module load mpi/openmpi/1.10.4/gcc-6.2
+   module load mpi/openmpi/1.10.4/gcc-4.9.4
 
 See `here <https://mail-archive.com/announce@lists.open-mpi.org/msg00085.html>`__ for a brief guide to the new features in OpenMPI 2.x and `here <https://raw.githubusercontent.com/open-mpi/ompi/v2.x/NEWS>`__ for a detailed view of the changes between OpenMPI versions.
 
-Note that if you are using :ref:`CUDA <cuda_sharc>` with OpenMPI then you currently need to use a version of CUDA built with GCC < 5.0.
+**CUDA**: Note that if you are using :ref:`CUDA <cuda_sharc>` with OpenMPI then you currently need to use a version of CUDA built with GCC < 5.0.
+**C++ bindings** If you are using the C++ bindings then you should use OpenMPI 1.10.4 as the bindings have been deprecated in OpenMPI 2.0.1.
 
 Examples
 --------

--- a/sharc/software/parallel/openmpi-intel.rst
+++ b/sharc/software/parallel/openmpi-intel.rst
@@ -20,6 +20,8 @@ You can load a specific version using ::
 
 See `here <https://mail-archive.com/announce@lists.open-mpi.org/msg00085.html>`__ for a brief guide to the new features in OpenMPI 2.x and `here <https://raw.githubusercontent.com/open-mpi/ompi/v2.x/NEWS>`__ for a detailed view of the changes between OpenMPI versions.
 
+**C++ bindings** If you are using the C++ bindings then you should use OpenMPI 1.10.4 as the bindings have been deprecated in OpenMPI 2.0.1.
+
 Examples
 --------
 


### PR DESCRIPTION
Prompted by #493 

- Note in the docs that must use 1.10.4 (over 2.0.1) if want the C++ bindings
- Add build of OpenMPI 1.10.4 using GCC 4.9.4
- Ensure that OpenMPI 1.10.4 is configured properly (OpenMPI `mtl`, `btl` and `oob` settings in `$MPI_HOME/etc/openmpi-mca-params.conf`)