### PR TITLE
ShARC: install icu library

### DIFF
--- a/iceberg/software/libs/icu.rst
+++ b/iceberg/software/libs/icu.rst
@@ -38,8 +38,9 @@ This Icu 58.1 build links against the GCC 4.9.2 C++ standard library and was ins
         tar -xvzf icu4c-58_1-src.tgz
         cd icu/source
         ./runConfigureICU Linux/gcc --prefix=/usr/local/packages6/libs/gcc/4.9.2/icu/58.1/
-        make check
         make
+        make check
+        make install
 
 Version 55
 ^^^^^^^^^^

--- a/sharc/software/install_scripts/libs/icu/58.2/gcc-4.9.4/install.sh
+++ b/sharc/software/install_scripts/libs/icu/58.2/gcc-4.9.4/install.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+#
+# Install the ICU library on ShARC 
+
+ICU_VERS=58.2
+ICU_TARBALL="icu4c-${ICU_VERS/./_}-src.tgz"
+ICU_TARBALL_URL="http://download.icu-project.org/files/icu4c/${ICU_VERS}/icu4c-${ICU_VERS/./_}-src.tgz"
+ICU_CHECKSUMS_URL="https://ssl.icu-project.org/files/icu4c/${ICU_VERS}/icu4c-src-${ICU_VERS/./_}.md5"
+COMPILER=gcc
+COMPILER_VERS=4.9.4
+BUILD_DIR="${TMPDIR-/tmp}/icu/${ICU_VERS}/${COMPILER}-${COMPILER_VERS}/"
+PREFIX="/usr/local/packages/libs/icu/${ICU_VERS}/${COMPILER}-${COMPILER_VERS}/"
+MODULEFILE="/usr/local/modulefiles/libs/icu/${ICU_VERS}/${COMPILER}-${COMPILER_VERS}"
+
+# Signal handling for failure
+handle_error () {
+    errcode=$? 
+    echo "Error code: $errorcode" 
+    echo "Errored command: " echo "$BASH_COMMAND" 
+    echo "Error on line: ${BASH_LINENO[0]}"
+    exit $errcode  
+}
+trap handle_error ERR
+
+# Make and switch to build directory
+mkdir -m 0700 -p $BUILD_DIR
+pushd $BUILD_DIR
+
+# Activate a compiler
+module purge
+module load dev/${COMPILER}/${COMPILER_VERS}
+
+# Create build, install and modulefile dirs
+mkdir -m 0700 -p $BUILD_DIR
+for d in $prefix $(dirname $modulefile); do
+    mkdir -m 2775 -p $d
+done
+
+# Download tarball
+wget -N $ICU_TARBALL_URL $ICU_CHECKSUMS_URL
+# Check its validity
+md5sum -c *md5 2>&1 | egrep -q ': OK$'
+# Unpack it (if not done already)
+if [[ ! -f .unpacked ]]; then
+    tar -zxf $ICU_TARBALL
+    touch .unpacked
+fi
+
+pushd icu/source/
+./runConfigureICU Linux/gcc --prefix=$PREFIX
+# Build and run tests
+make -j ${OMP_NUM_THREADS-1} check
+make install
+popd
+popd
+
+# Set permissions and ownership
+for d in $prefix $(dirname $MODULEFILE); do
+    chmod -R g+w $d
+    chown -R ${USER}:app-admins $d
+done

--- a/sharc/software/libs/icu.rst
+++ b/sharc/software/libs/icu.rst
@@ -1,0 +1,31 @@
+icu - International Components for Unicode
+==========================================
+
+.. sidebar:: icu
+
+   :Latest Version: 58.2
+   :URL: http://site.icu-project.org/
+
+ICU is a mature, widely used set of C/C++ and Java libraries providing Unicode and Globalization support for software applications. ICU is widely portable and gives applications the same results on all platforms and between C/C++ and Java software.
+
+ICU is released under a nonrestrictive open source license that is suitable for use with both commercial software and with other open source or free software.
+
+Usage
+-----
+Version 58.2 of the icu library for C requires gcc version 4.9.2 (for the C++ standard library); To make the library **and this compiler** available, run the following: ::
+
+        module load libs/icu/58.2/gcc-4.9.2
+
+Installation Notes
+------------------
+This section is primarily for administrators of the system.
+
+Version 58.2
+^^^^^^^^^^^^
+
+This Icu 58.2 build links against the GCC 4.9.2 C++ standard library and was installed as a dependency of `boost_sharc` (build using the same C++ standard library); Boost in turn was installed as a dependency of Caffe.
+
+#. Download, configure, build, test and install using :download:`this script </sharc/software/install_scripts/icu/58.2/gcc-4.9.4/install.sh>`
+#. Check the console output of the install process for ``All tests OK``
+#. Install :download:`this modulefile </sharc/software/modulefiles/icu/58.2/gcc-4.9.4>` as ``/usr/local//modulefiles/icu/58.2/gcc-4.9.4``
+

--- a/sharc/software/libs/icu.rst
+++ b/sharc/software/libs/icu.rst
@@ -4,6 +4,7 @@ icu - International Components for Unicode
 .. sidebar:: icu
 
    :Latest Version: 58.2
+   :Dependencies: gcc
    :URL: http://site.icu-project.org/
 
 ICU is a mature, widely used set of C/C++ and Java libraries providing Unicode and Globalization support for software applications. ICU is widely portable and gives applications the same results on all platforms and between C/C++ and Java software.
@@ -12,9 +13,9 @@ ICU is released under a nonrestrictive open source license that is suitable for 
 
 Usage
 -----
-Version 58.2 of the icu library for C requires gcc version 4.9.2 (for the C++ standard library); To make the library **and this compiler** available, run the following: ::
+Version 58.2 of the icu library for C requires gcc version 4.9.4 (for the C++ standard library); To make the library **and this compiler** available, run the following: ::
 
-        module load libs/icu/58.2/gcc-4.9.2
+        module load libs/icu/58.2/gcc-4.9.4
 
 Installation Notes
 ------------------
@@ -23,9 +24,9 @@ This section is primarily for administrators of the system.
 Version 58.2
 ^^^^^^^^^^^^
 
-This Icu 58.2 build links against the GCC 4.9.2 C++ standard library and was installed as a dependency of `boost_sharc` (build using the same C++ standard library); Boost in turn was installed as a dependency of Caffe.
+This Icu 58.2 build links against the GCC 4.9.4 C++ standard library and was installed as a dependency of `boost_sharc` (build using the same C++ standard library); Boost in turn was installed as a dependency of Caffe.
 
-#. Download, configure, build, test and install using :download:`this script </sharc/software/install_scripts/icu/58.2/gcc-4.9.4/install.sh>`
+#. Download, configure, build, test and install using :download:`this script </sharc/software/install_scripts/libs/icu/58.2/gcc-4.9.4/install.sh>`
 #. Check the console output of the install process for ``All tests OK``
-#. Install :download:`this modulefile </sharc/software/modulefiles/icu/58.2/gcc-4.9.4>` as ``/usr/local//modulefiles/icu/58.2/gcc-4.9.4``
+#. Install :download:`this modulefile </sharc/software/modulefiles/libs/icu/58.2/gcc-4.9.4>` as ``/usr/local/modulefiles/libs/icu/58.2/gcc-4.9.4``
 

--- a/sharc/software/modulefiles/libs/icu/58.2/gcc-4.9.4
+++ b/sharc/software/modulefiles/libs/icu/58.2/gcc-4.9.4
@@ -1,0 +1,24 @@
+#%Module1.0#####################################################################
+##
+## ICU 58.2 module file
+##
+
+## Module file logging
+source /usr/local/etc/module_logging.tcl
+##
+
+set vers 58.2
+set compiler gcc
+set compilervers 4.9.4
+
+proc ModulesHelp { } {
+    global vers
+    puts stderr "Makes the icu $vers library (plus $compiler $compilervers) available"
+}
+module-whatis   "Makes the icu $vers library (plus $compiler $compilervers) available"
+
+set ICU_HOME /usr/local/packages/libs/icu/$vers/$compiler-$compilervers
+
+prepend-path LD_LIBRARY_PATH $ICU_HOME/lib
+prepend-path LIBRARY_PATH $ICU_HOME/lib
+prepend-path CPATH $ICU_HOME/include


### PR DESCRIPTION
Prerequisite for installing Boost (#489)

Also add a small fix to the install notes for Iceberg.