### PR TITLE
ShARC: Add libunistring 

### DIFF
--- a/iceberg/software/libs/libunistring.rst
+++ b/iceberg/software/libs/libunistring.rst
@@ -6,19 +6,26 @@ libunistring
 .. sidebar:: libunistring
 
    :Latest version: 0.9.5
-   :URL: http://www.gnu.org/software/libunistring/#TOCdownloading/
+   :URL: http://www.gnu.org/software/libunistring/
 
-Text files are nowadays usually encoded in Unicode, and may consist of very different scripts – from Latin letters to Chinese Hanzi –, with many kinds of special characters – accents, right-to-left writing marks, hyphens, Roman numbers, and much more. But the POSIX platform APIs for text do not contain adequate functions for dealing with particular properties of many Unicode characters. In fact, the POSIX APIs for text have several assumptions at their base which don't hold for Unicode text.
+Text files are nowadays usually encoded in Unicode, and may consist of very
+different scripts - from Latin letters to Chinese Hanzi, with many kinds of
+special characters: accents, right-to-left writing marks, hyphens, Roman
+numbers, and much more. But the POSIX platform APIs for text do not contain
+adequate functions for dealing with particular properties of many Unicode
+characters. In fact, the POSIX APIs for text have several assumptions at their
+base which don’t hold for Unicode text.
 
-This library provides functions for manipulating Unicode strings and for manipulating C strings according to the Unicode standard.
+This library provides functions for manipulating Unicode strings and for
+manipulating C strings according to the Unicode standard.
 
 Usage
 -----
-To make this library available, run the following module command ::
+To make this library available, run the following module command: ::
 
         module load libs/gcc/4.8.2/libunistring/0.9.5
 
-This correctly populates the environment variables LD_LIBRARY_PATH, LIBRARY_PATH and CPLUS_INCLUDE_PATH
+This correctly populates the environment variables ``LD_LIBRARY_PATH``, ``LIBRARY_PATH`` and ``CPLUS_INCLUDE_PATH``.
 
 Installation notes
 ------------------

--- a/sharc/software/install_scripts/libs/libunistring/0.9.7/gcc-4.9.4/install.sh
+++ b/sharc/software/install_scripts/libs/libunistring/0.9.7/gcc-4.9.4/install.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+#
+# Install the libunistring library on ShARC 
+
+LUS_VERS=0.9.7
+LUS_TARBALL="libunistring-${LUS_VERS}.tar.gz"
+LUS_TARBALL_URL="http://ftp.gnu.org/gnu/libunistring/${LUS_TARBALL}"
+COMPILER=gcc
+COMPILER_VERS=4.9.4
+BUILD_DIR="${TMPDIR-/tmp}/libunistring/${LUS_VERS}/${COMPILER}-${COMPILER_VERS}/"
+PREFIX="/usr/local/packages/libs/libunistring/${LUS_VERS}/${COMPILER}-${COMPILER_VERS}/"
+MODULEFILE="/usr/local/modulefiles/libs/libunistring/${LUS_VERS}/${COMPILER}-${COMPILER_VERS}"
+
+# Signal handling for failure
+handle_error () {
+    errcode=$? 
+    echo "Error code: $errorcode" 
+    echo "Errored command: " echo "$BASH_COMMAND" 
+    echo "Error on line: ${BASH_LINENO[0]}"
+    exit $errcode  
+}
+trap handle_error ERR
+
+# Make and switch to build directory
+mkdir -m 0700 -p $BUILD_DIR
+pushd $BUILD_DIR
+
+# Activate a compiler
+module purge
+module load dev/${COMPILER}/${COMPILER_VERS}
+
+# Create build, install and modulefile dirs
+mkdir -m 0700 -p $BUILD_DIR
+for d in $PREFIX $(dirname $MODULEFILE); do
+    mkdir -m 2775 -p $d
+done
+
+# Download tarball
+wget -N $LUS_TARBALL_URL $LUS_CHECKSUMS_URL
+# Unpack it (if not done already)
+if [[ ! -f .unpacked ]]; then
+    tar -zxf $LUS_TARBALL
+    touch .unpacked
+fi
+
+pushd libunistring-${LUS_VERS}
+./configure --prefix=${PREFIX}
+make -j ${OMP_NUM_THREADS-1}
+make check
+make install
+popd
+popd
+
+# Set permissions and ownership
+for d in $PREFIX $(dirname $MODULEFILE); do
+    chmod -R g+w $d
+    chown -R ${USER}:app-admins $d
+done

--- a/sharc/software/libs/libunistring.rst
+++ b/sharc/software/libs/libunistring.rst
@@ -34,8 +34,6 @@ Version 0.9.7
 
 This build was installed as a dependency of `boost_sharc` (build using the same C++ standard library); Boost in turn was installed as a dependency of Caffe.
 
-#. Download, configure, build, test and install using :download:`this script </sharc/software/install_scripts/libunistring/0.9.7/gcc-4.9.4/install.sh>`
+#. Download, configure, build, test and install using :download:`this script </sharc/software/install_scripts/libs/libunistring/0.9.7/gcc-4.9.4/install.sh>`
 #. Check the console output of the install process to check that no tests have errored/failed: ``TOTAL: 499 / PASS: 489 / SKIP: 10``
-#. Install :download:`this modulefile </sharc/software/modulefiles/libunistring/0.9.7/gcc-4.9.4>` as ``/usr/local//modulefiles/libunistring/0.9.7/gcc-4.9.4``
-
-
+#. Install :download:`this modulefile </sharc/software/modulefiles/libs/libunistring/0.9.7/gcc-4.9.4>` as ``/usr/local//modulefiles/libs/libunistring/0.9.7/gcc-4.9.4``

--- a/sharc/software/libs/libunistring.rst
+++ b/sharc/software/libs/libunistring.rst
@@ -1,0 +1,41 @@
+libunistring
+============
+
+.. sidebar:: libunistring
+
+   :Latest Version: 0.9.7
+   :URL: http://www.gnu.org/software/libunistring/
+
+Text files are nowadays usually encoded in Unicode, and may consist of very
+different scripts - from Latin letters to Chinese Hanzi, with many kinds of
+special characters: accents, right-to-left writing marks, hyphens, Roman
+numbers, and much more. But the POSIX platform APIs for text do not contain
+adequate functions for dealing with particular properties of many Unicode
+characters. In fact, the POSIX APIs for text have several assumptions at their
+base which don’t hold for Unicode text.
+
+This library provides functions for manipulating Unicode strings and for
+manipulating C strings according to the Unicode standard.
+
+Usage
+-----
+To make the library available, run the following: ::
+
+       module load libs/libunistring/0.9.7/gcc-4.9.4
+
+This correctly populates the environment variables ``LD_LIBRARY_PATH``, ``LIBRARY_PATH`` and ``CPATH``.
+
+Installation Notes
+------------------
+This section is primarily for administrators of the system.
+
+Version 0.9.7
+^^^^^^^^^^^^^
+
+This build was installed as a dependency of `boost_sharc` (build using the same C++ standard library); Boost in turn was installed as a dependency of Caffe.
+
+#. Download, configure, build, test and install using :download:`this script </sharc/software/install_scripts/libunistring/0.9.7/gcc-4.9.4/install.sh>`
+#. Check the console output of the install process to check that no tests have errored/failed: ``TOTAL: 499 / PASS: 489 / SKIP: 10``
+#. Install :download:`this modulefile </sharc/software/modulefiles/libunistring/0.9.7/gcc-4.9.4>` as ``/usr/local//modulefiles/libunistring/0.9.7/gcc-4.9.4``
+
+

--- a/sharc/software/modulefiles/libs/libunistring/0.9.7/gcc-4.9.4
+++ b/sharc/software/modulefiles/libs/libunistring/0.9.7/gcc-4.9.4
@@ -1,0 +1,22 @@
+#%Module1.0#####################################################################
+##
+## libunistring 0.9.7 module file
+##
+
+## Module file logging
+source /usr/local/etc/module_logging.tcl
+
+set vers 0.9.7 
+
+proc ModulesHelp { } {
+    global $vers
+    puts stderr "Makes the libunistring $vers library available"
+}
+
+set LIBUNISTRING_DIR /usr/local/packages/libs/libunistring/0.9.7/gcc-4.9.4
+
+module-whatis   "Makes the libunistring $vers library available"
+
+prepend-path LD_LIBRARY_PATH $LIBUNISTRING_DIR/lib/
+prepend-path LIBRARY_PATH $LIBUNISTRING_DIR/lib
+prepend-path CPATH $LIBUNISTRING_DIR/include


### PR DESCRIPTION
Prerequisite for installing Boost (#489)

Also add a small fix to the install notes for Iceberg.