### PR TITLE
Make Spark less noisy on ShARC

### DIFF
--- a/iceberg/software/apps/spark.rst
+++ b/iceberg/software/apps/spark.rst
@@ -13,36 +13,36 @@ Interactive Usage
 -----------------
 After connecting to Iceberg (see :ref:`ssh`),  start an interactive session with the :ref:`qrsh` or :ref:`qrshx` command.
 
-To make Spark available, execute the following module command ::
+To make Spark available, execute the following module command: ::
 
     module load apps/gcc/4.4.7/spark/2.0
 
 Installation notes
 ------------------
-Spark was built using the system gcc 4.4.7 ::
+Spark was built using the system gcc 4.4.7: ::
 
   tar -xvzf ./spark-2.0.0.tgz
   cd spark-2.0.0
   build/mvn -DskipTests clean package
 
-  mkdir /usr/local/packages6/apps/gcc/4.4.7/spark
+  mkdir -p /usr/local/packages6/apps/gcc/4.4.7/spark
   mv spark-2.0.0 /usr/local/packages6/apps/gcc/4.4.7/spark/
   
-The default install of Spark is incredibly verbose. Even a 'Hello World' program results in many lines of `[INFO]`.
-To make it a little quieter ::
+The default install of Spark is incredibly verbose. Even a 'Hello World' program results in many lines of ``[INFO]``.
+To make it a little quieter, reduce the default log4j level from ``INFO`` to ``WARN``: ::
 
-    cp /usr/local/packages6/apps/gcc/4.4.7/spark/spark-2.0.0/conf/log4j.properties.template /usr/local/packages6/apps/gcc/4.4.7/spark/spark-2.0.0/conf/log4j.properties
+    cd /usr/local/packages6/apps/gcc/4.4.7/spark/spark-2.0.0/conf/
+    cp log4j.properties.template log4j.properties
     
-Edit the file `log4j.properties` so that the line beginning `log4j.rootCategory` reads ::
+Edit the file ``log4j.properties`` so that the line beginning ``log4j.rootCategory`` reads: ::
  
      log4j.rootCategory=WARN, console
-   
 
 Modulefile
 ----------
 **Version 2.0**
 
-* The module file is on the system at `/usr/local/modulefiles/apps/gcc/4.4.7/spark/2.0`
+* The module file is on the system at ``/usr/local/modulefiles/apps/gcc/4.4.7/spark/2.0``
 
 Its contents are ::
 

--- a/sharc/software/apps/spark.rst
+++ b/sharc/software/apps/spark.rst
@@ -88,14 +88,22 @@ Spark 2.0 was built using the system gcc 4.8.5 ::
     cd ..
     mv spark-2.1.0 /usr/local/packages/apps/spark/2.1
 
+The default install of Spark is incredibly verbose. Even a 'Hello World' program results in many lines of ``[INFO]``.
+To make it a little quieter, the default log4j level has been reduced from ``INFO`` to ``WARN``: ::
+
+    cd /usr/local/packages/apps/spark/2.1/spark-2.1.0/conf/
+    cp log4j.properties.template log4j.properties
+    
+The file ``log4j.properties`` was then edited so that the line beginning ``log4j.rootCategory`` reads: ::
+ 
+     log4j.rootCategory=WARN, console
+
 Modulefile
 ----------
 
 **Version 2.1**
 
-* The module file is on the system at `/usr/local/modulefiles/apps/spark/2.1.0/gcc-4.8.5`
-
-Its contents are ::
+The following module file is on the system at ``/usr/local/modulefiles/apps/spark/2.1.0/gcc-4.8.5`` ::
 
     #%Module1.0#####################################################################
     ##


### PR DESCRIPTION
Done by reducing the log4j log level (from `INFO` to `WARN`; already done on Iceberg).