### PR TITLE
addition to vcftools module file

### DIFF
--- a/iceberg/software/install_scripts/apps/gcc/5.2/vcftools/0.1.14
+++ b/iceberg/software/install_scripts/apps/gcc/5.2/vcftools/0.1.14
@@ -9,6 +9,8 @@ source /usr/local/etc/module_logging.tcl
 
 module load compilers/gcc/5.2
 
+module load libs/gcc/4.4.7/zlib/1.2.8/
+
 proc ModulesHelp { } {
         puts stderr "Makes the vcftools library available"
 }


### PR DESCRIPTION
I have amended the vcftools module file to load zlib/1.2.8

This was a User request to improve 'speed' of the tool since it was defaulting to the 'slower' zlib/1.2.3