### PR TITLE
Basic DRMAA docs / revise scheduler intro page

### DIFF
--- a/hpc/scheduler/drmaa.rst
+++ b/hpc/scheduler/drmaa.rst
@@ -76,6 +76,9 @@ You can submit multiple jobs iteratively, reusing your DRMAA job template for ef
 
 If you want to submit a :ref:`job array <parallel_jobarray>` rather than a single job then you can call the `runBulkJob method instead of runJob <http://drmaa-python.readthedocs.io/en/latest/tutorials.html#running-a-job>`_.
 
+.. warning::
+    Starting a single DRMAA session then attempting to submit jobs from different Python threads `currently does not work <https://github.com/pygridtools/drmaa-python/issues/44>`_.
+
 Waiting on jobs
 ^^^^^^^^^^^^^^^
 

--- a/hpc/scheduler/drmaa.rst
+++ b/hpc/scheduler/drmaa.rst
@@ -49,6 +49,8 @@ Submitting a job
 You can then submit a job using a script like this:
 
 .. literalinclude:: drmaa_submit_job.py
+   :caption: drmaa_submit_job.py
+   :caption: drmaa-example-py
    :language: python
    :linenos:
 
@@ -94,6 +96,23 @@ Checking the status of a job
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Within a DRMAA Session you can check to see if any job is queuing, running, has completed successfully, has failed or is in some other state.  See the `documentation <http://drmaa-python.readthedocs.io/en/latest/tutorials.html#getting-job-status>`__ for more information including an example.  
+
+Email notifications
+^^^^^^^^^^^^^^^^^^^
+
+You can enable email notifications for jobs finishing or aborting by setting two attributes of your `JobTemplate` object (`jt` in :ref:`this example <drmaa-example-py>`):
+
+.. code-block:: python
+
+     jt.blockEmail = False
+     jt.email = ['somebody@sheffield.ac.uk']
+
+This is equivalent to having the following in a Grid Engine batch job submission script:
+
+.. code-block:: bash
+
+    #$ -m ea
+    #$ -M somebody@sheffield.ac.uk
 
 Futher information
 ^^^^^^^^^^^^^^^^^^

--- a/hpc/scheduler/drmaa.rst
+++ b/hpc/scheduler/drmaa.rst
@@ -49,8 +49,8 @@ Submitting a job
 You can then submit a job using a script like this:
 
 .. literalinclude:: drmaa_submit_job.py
+   :name: drmaa-example-py
    :caption: drmaa_submit_job.py
-   :caption: drmaa-example-py
    :language: python
    :linenos:
 
@@ -117,7 +117,7 @@ This is equivalent to having the following in a Grid Engine batch job submission
 Futher information
 ^^^^^^^^^^^^^^^^^^
 
-See the `documentation <http://drmaa-python.readthedocs.io/en/latest/>`__ for the DRMAA Python bindings; you may find the enclosed `reference information <http://drmaa-python.readthedocs.io/en/latest/drmaa.html>`_ useful.
+See the `documentation <http://drmaa-python.readthedocs.io/en/latest/>`__ for the DRMAA Python bindings; you may find the enclosed `reference information <http://drmaa-python.readthedocs.io/en/latest/drmaa.html>`_ useful.  Note that not all features of these bindings are described in this documentation!
 
 Java bindings
 -------------

--- a/hpc/scheduler/drmaa.rst
+++ b/hpc/scheduler/drmaa.rst
@@ -17,7 +17,7 @@ Why is it useful?
 
 Using DRMAA you may find it easier to automate the submission and control of jobs.  
 
-Also, you might want to use a Computational Pipeline manager such as `Ruffus <http://www.ruffus.org.uk/>`_) to run sets of related (possibly dependent) jobs on a cluster; these may use DRMAA beind the scenes to create and manage jobs.
+Also, you might want to use a Computational Pipeline manager (such as `Ruffus <http://www.ruffus.org.uk/>`_) to run sets of related (possibly dependent) jobs on a cluster; these may use DRMAA beind the scenes to create and manage jobs.
 
 Using DRMAA from Python
 -----------------------
@@ -35,7 +35,7 @@ The simplest way to install them is to use a :ref:`conda environment <sharc-pyth
         # Start an interactive session
         qrshx  
         # Ensure conda is available
-        module load apps/python conda  
+        module load apps/python/conda  
         # Create a conda environment
         conda create -n drmaa-test-sharc python=3.6  
         # Activate this environment
@@ -84,7 +84,7 @@ If you want to submit a :ref:`job array <parallel_jobarray>` rather than a singl
 Email notifications
 ^^^^^^^^^^^^^^^^^^^
 
-You can enable email notifications for jobs finishing or aborting by setting two attributes of your `JobTemplate` object (`jt` in :ref:`this example <drmaa-example-py>`):
+You can enable email notifications for jobs finishing or aborting by setting two attributes of your ``JobTemplate`` object (``jt`` in :ref:`this example <drmaa-example-py>`):
 
 .. code-block:: python
 
@@ -101,26 +101,32 @@ This is equivalent to having the following in a Grid Engine batch job submission
 Other useful job template attributes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
- * Requesting arbitrary resources from Grid Engine (virtual memory, real memory, parallel environments, run time, Projects): ::
+* Requesting arbitrary resources from Grid Engine such as virtual memory (``vmem``), real memory (``mem``), parallel environments (e.g. ``-pe mpi``), run time (``h_rt``), Grid Engine Projects e.g. ::
 
-        jt.nativeSpecification = '-l gpu=1 -P gpu -l h_rt=00:30:00 -l rmem=2G -pe smp 2'
+       jt.nativeSpecification = '-l h_rt=00:30:00 -l rmem=2G -pe smp 2'
 
- * Set the paths to the job standard output and error files: ::
+* Set the paths to the job standard output and error files: ::
 
-        jt.outputPath = os.path.join(os.getcwd(), 'output.log')
-        jt.errorPath = os.path.join(os.getcwd(), 'error.log')
+       jt.outputPath = os.path.join(os.getcwd(), 'output.log')
+       jt.errorPath = os.path.join(os.getcwd(), 'error.log')
 
- * Send standard output and error to the same file: ::
+* Send standard output and error to the same file: ::
 
-        jt.joinFiles = True
+       jt.joinFiles = True
 
- * Name your job (equivalent to ``-N my_job`` in a Grid Engine batch job submission script): ::
+* Name your job (equivalent to ``-N my_job`` in a Grid Engine batch job submission script): ::
 
-        jt.jobName = 'my_job'
+       jt.jobName = 'my_job'
 
- * Set one or more environment variables in your job using a Python `dictionary <https://docs.python.org/3/tutorial/datastructures.html#dictionaries>`_: ::
+* Set one or more environment variables in your job using a Python `dictionary <https://docs.python.org/3/tutorial/datastructures.html#dictionaries>`_: ::
 
-        jt.jobEnvironment = {'SOMEKEY': 'somevalue', 'ANOTHERKEY', 'anothervalue'}
+       jt.jobEnvironment = {'SOMEKEY': 'somevalue', 'ANOTHERKEY', 'anothervalue'}
+
+.. warning::
+    You cannot presently request one or more **GPUs** using DRMAA without explicitly using the ``gpu`` Grid Engine Project i.e. 
+    jobs created using a Job Template ``jt`` where ``jt.nativeSpecification = '-l gpu=1'`` will be rejected by the job scheduler 
+    but jobs with ``jt.nativeSpecification = '-P gpu -l gpu=1'`` will be accepted.
+    This is due to a `bug in the scheduler <https://arc.liv.ac.uk/trac/SGE/ticket/1342>`_.
 
 Waiting on jobs
 ^^^^^^^^^^^^^^^

--- a/hpc/scheduler/drmaa.rst
+++ b/hpc/scheduler/drmaa.rst
@@ -81,22 +81,6 @@ If you want to submit a :ref:`job array <parallel_jobarray>` rather than a singl
 .. warning::
     Starting a single DRMAA session then attempting to submit jobs from different Python threads `currently does not work <https://github.com/pygridtools/drmaa-python/issues/44>`_.
 
-Waiting on jobs
-^^^^^^^^^^^^^^^
-
-Within a DRMAA Session you can wait indefinitely or forever for one, several or all submitted jobs to complete.  See the `documentation <http://drmaa-python.readthedocs.io/en/latest/tutorials.html#waiting-for-a-job>`__ for more information including an example.  Jobs are identified by (Grid Engine) job ID, so they do not need to have been submitted by DRMAA.
-
-Controlling jobs
-^^^^^^^^^^^^^^^^
-
-Within a DRMAA Session you can also terminate, suspend, resume, hold and release a job.  See the `documentation <http://drmaa-python.readthedocs.io/en/latest/tutorials.html#controlling-a-job>`__ for more information including an example.  Again, jobs are identified by (Grid Engine) job ID, so they do not need to have been submitted by DRMAA.
-
-
-Checking the status of a job
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Within a DRMAA Session you can check to see if any job is queuing, running, has completed successfully, has failed or is in some other state.  See the `documentation <http://drmaa-python.readthedocs.io/en/latest/tutorials.html#getting-job-status>`__ for more information including an example.  
-
 Email notifications
 ^^^^^^^^^^^^^^^^^^^
 
@@ -113,6 +97,45 @@ This is equivalent to having the following in a Grid Engine batch job submission
 
     #$ -m ea
     #$ -M somebody@sheffield.ac.uk
+
+Other useful job template attributes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+ * Requesting arbitrary resources from Grid Engine (virtual memory, real memory, parallel environments, run time, Projects): ::
+
+        jt.nativeSpecification = '-l gpu=1 -P gpu -l h_rt=00:30:00 -l rmem=2G -pe smp 2'
+
+ * Set the paths to the job standard output and error files: ::
+
+        jt.outputPath = os.path.join(os.getcwd(), 'output.log')
+        jt.errorPath = os.path.join(os.getcwd(), 'error.log')
+
+ * Send standard output and error to the same file: ::
+
+        jt.joinFiles = True
+
+ * Name your job (equivalent to ``-N my_job`` in a Grid Engine batch job submission script): ::
+
+        jt.jobName = 'my_job'
+
+ * Set one or more environment variables in your job using a Python `dictionary <https://docs.python.org/3/tutorial/datastructures.html#dictionaries>`_: ::
+
+        jt.jobEnvironment = {'SOMEKEY': 'somevalue', 'ANOTHERKEY', 'anothervalue'}
+
+Waiting on jobs
+^^^^^^^^^^^^^^^
+
+Within a DRMAA Session you can wait indefinitely or forever for one, several or all submitted jobs to complete.  See the `documentation <http://drmaa-python.readthedocs.io/en/latest/tutorials.html#waiting-for-a-job>`__ for more information including an example.  Jobs are identified by (Grid Engine) job ID, so they do not need to have been submitted by DRMAA.
+
+Controlling jobs
+^^^^^^^^^^^^^^^^
+
+Within a DRMAA Session you can also terminate, suspend, resume, hold and release a job.  See the `documentation <http://drmaa-python.readthedocs.io/en/latest/tutorials.html#controlling-a-job>`__ for more information including an example.  Again, jobs are identified by (Grid Engine) job ID, so they do not need to have been submitted by DRMAA.
+
+Checking the status of a job
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Within a DRMAA Session you can check to see if any job is queuing, running, has completed successfully, has failed or is in some other state.  See the `documentation <http://drmaa-python.readthedocs.io/en/latest/tutorials.html#getting-job-status>`__ for more information including an example.  
 
 Futher information
 ^^^^^^^^^^^^^^^^^^

--- a/hpc/scheduler/drmaa.rst
+++ b/hpc/scheduler/drmaa.rst
@@ -1,0 +1,112 @@
+.. _drmaa:
+
+DRMAA
+=====
+
+The Distributed Resource Management Application API (DRMAA) is a specification for 
+**programatically submitting/controlling jobs** to/on job scheduling software 
+such as the :ref:`Grid Engine <sge-queue>` software used on 
+the :ref:`sharc` and :ref:`iceberg` clusters.  
+
+Support for DRMAA is built in to Grid Engine and other scheduling software such as Torque, PBS, HTCondor and SLURM.
+
+There are DRMAA `bindings <https://en.wikipedia.org/wiki/Language_binding>`_ (i.e. wrappers) available for several programming languages.
+
+Why is it useful?
+-----------------
+
+Using DRMAA you may find it easier to automate the submission and control of jobs.  
+
+Also, you might want to use a Computational Pipeline manager such as `Ruffus <http://www.ruffus.org.uk/>`_) to run sets of related (possibly dependent) jobs on a cluster; these may use DRMAA beind the scenes to create and manage jobs.
+
+Using DRMAA from Python
+-----------------------
+
+Install DRMAA bindings
+^^^^^^^^^^^^^^^^^^^^^^
+
+The `Python bindings for DRMAA <http://drmaa-python.readthedocs.io/en/latest/>`_ are compatible with Python 2 and Python 3.
+The simplest way to install them is to use a :ref:`conda environment <sharc-python-conda>` e.g. 
+
+.. code-block:: bash
+
+        # Connect to ShARC
+        ssh sharc  
+        # Start an interactive session
+        qrshx  
+        # Ensure conda is available
+        module load apps/python conda  
+        # Create a conda environment
+        conda create -n drmaa-test-sharc python=3.6  
+        # Activate this environment
+        source activate drmaa-test-sharc  
+        # Install the python bindings for DRMAA
+        pip install drmaa  
+
+Submitting a job 
+^^^^^^^^^^^^^^^^
+
+You can then submit a job using a script like this:
+
+.. literalinclude:: drmaa_submit_job.py
+   :language: python
+   :linenos:
+
+where ``myjob.sh`` is:
+
+.. code-block:: bash
+
+        #!/bin/bash 
+        echo "Hello from ${JOB_ID}. I received these arguments: $1, $2"
+
+To actually submit the job: ::
+    
+    $ # Make your job script executable
+    $ chmod +x myjob.sh
+
+    $ python drmaa_submit_job.py
+    Creating a job template
+    Job 401022 submitted
+    Cleaning up
+
+    $ cat myjob.sh.o401022 
+    Hello from 401022. I received these arguments: alpha, beta
+
+You can submit multiple jobs iteratively, reusing your DRMAA job template for efficiency.
+
+If you want to submit a :ref:`job array <parallel_jobarray>` rather than a single job then you can call the `runBulkJob method instead of runJob <http://drmaa-python.readthedocs.io/en/latest/tutorials.html#running-a-job>`_.
+
+Waiting on jobs
+^^^^^^^^^^^^^^^
+
+Within a DRMAA Session you can wait indefinitely or forever for one, several or all submitted jobs to complete.  See the `documentation <http://drmaa-python.readthedocs.io/en/latest/tutorials.html#waiting-for-a-job>`__ for more information including an example.  Jobs are identified by (Grid Engine) job ID, so they do not need to have been submitted by DRMAA.
+
+Controlling jobs
+^^^^^^^^^^^^^^^^
+
+Within a DRMAA Session you can also terminate, suspend, resume, hold and release a job.  See the `documentation <http://drmaa-python.readthedocs.io/en/latest/tutorials.html#controlling-a-job>`__ for more information including an example.  Again, jobs are identified by (Grid Engine) job ID, so they do not need to have been submitted by DRMAA.
+
+
+Checking the status of a job
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Within a DRMAA Session you can check to see if any job is queuing, running, has completed successfully, has failed or is in some other state.  See the `documentation <http://drmaa-python.readthedocs.io/en/latest/tutorials.html#getting-job-status>`__ for more information including an example.  
+
+Futher information
+^^^^^^^^^^^^^^^^^^
+
+See the `documentation <http://drmaa-python.readthedocs.io/en/latest/>`__ for the DRMAA Python bindings; you may find the enclosed `reference information <http://drmaa-python.readthedocs.io/en/latest/drmaa.html>`_ useful.
+
+Java bindings
+-------------
+
+Java bindings for DRMAA are not currently available on :ref:`sharc` or :ref:`iceberg`.
+
+Administrator notes
+-------------------
+
+Grid Engine's implementation of the DRMAA shared library lives at ``$SGE_ROOT/lib/lx-amd64/libdrmaa.so``.
+
+It is discovered by bindings using the ``DRMAA_LIBRARY_PATH`` environment variable, 
+which is set to the above for all users using a shell script in ``/etc/profile.d/``.
+

--- a/hpc/scheduler/drmaa_submit_job.py
+++ b/hpc/scheduler/drmaa_submit_job.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+import drmaa
+import os
+
+
+def main():
+    """
+    Create a DRMAA session then submit a job.
+    Note, need file called myjob.sh in the current directory.
+    """
+    with drmaa.Session() as s:
+        print('Creating a job template')
+        jt = s.createJobTemplate()
+        # The job is to run an executable in the current working directory
+        jt.remoteCommand = os.path.join(os.getcwd(), 'myjob.sh')
+        # Arguments to the remote command
+        jt.args = ['alpha', 'beta']
+        # Join the standard output and error logs
+        jt.joinFiles = True
+
+        job_id = s.runJob(jt)
+        print('Job {} submitted'.format(job_id))
+
+        print('Cleaning up')
+        s.deleteJobTemplate(jt)
+
+
+if __name__ == '__main__':
+    main()

--- a/hpc/scheduler/index.rst
+++ b/hpc/scheduler/index.rst
@@ -10,7 +10,20 @@ Scheduler
 
     ./*
 
-This is a reference section for commands that allow you to interact with the scheduler.
+Getting started 
+---------------
+
+See our guide to :ref:`sge-queue`.
+
+Submitting and controlling jobs programmatically
+------------------------------------------------
+
+See our guide to the :ref:`drmaa` API.
+
+Reference information
+---------------------
+
+Commands that allow you to interact with the scheduler:
 
 * :ref:`qhost` - Show's the status of Sun Grid Engine hosts.
 * :ref:`qrsh` - Requests an interactive session on a worker node. No support for graphical applications.


### PR DESCRIPTION
Simple guide to the DRMAA API, focussing on the Python bindings.  Addresses #612.

Made minor changes to the scheduler overview page to ensure that the DRMAA docs and our introduction to using the scheduler are easier to find.