### PR TITLE
OpenMPI 1.x on ShARC: specify MCA OOB interface using CIDR network addr

### DIFF
--- a/sharc/software/install_scripts/mpi/openmpi/1.10.4/gcc-4.9.4/openmpi-mca-params.conf
+++ b/sharc/software/install_scripts/mpi/openmpi/1.10.4/gcc-4.9.4/openmpi-mca-params.conf
@@ -59,4 +59,4 @@
 
 mtl = psm2 
 btl = ^tcp,openib
-oob_tcp_if_include = p3p1.321
+oob_tcp_if_include = 172.30.64.0/22

--- a/sharc/software/install_scripts/mpi/openmpi/1.10.4/gcc-6.2/openmpi-mca-params.conf
+++ b/sharc/software/install_scripts/mpi/openmpi/1.10.4/gcc-6.2/openmpi-mca-params.conf
@@ -59,4 +59,4 @@
 
 mtl = psm2 
 btl = ^tcp,openib
-oob_tcp_if_include = p3p1.321
+oob_tcp_if_include = oob_tcp_if_include = 172.30.64.0/22

--- a/sharc/software/parallel/openmpi-gcc.rst
+++ b/sharc/software/parallel/openmpi-gcc.rst
@@ -84,14 +84,20 @@ These are primarily for administrators of the system.
 
 **Version 1.10.4, gcc 6.2**
 
-1. Enable :ref:`GCC <gcc_sharc>` 6.2.0.
-2. Download, compile and install OpenMPI 1.10.4 using :download:`this script </sharc/software/install_scripts/mpi/openmpi/1.10.4/gcc-6.2/install.sh>`.
-3. Install :download:`this modulefile </sharc/software/modulefiles/mpi/openmpi/1.10.4/gcc-6.2>` as ``/usr/local/modulefiles/mpi/openmpi/1.10.4/gcc-6.2``
+#. Enable :ref:`GCC <gcc_sharc>` 6.2.0.
+#. Download, compile and install OpenMPI 1.10.4 using :download:`this script </sharc/software/install_scripts/mpi/openmpi/1.10.4/gcc-6.2/install.sh>`.
+#. Configure the OpenMPI *Modular Component Architecture* (MCA) by copying :download:`this script </sharc/software/install_scripts/mpi/openmpi/1.10.4/gcc-6.2/openmpi-mca-params.conf>` to ``/usr/local/packages/mpi/openmpi/1.10.4/gcc-6.2/``; this configures: 
+   * the ``mtl`` (MCA *Matching Transport Layer*) to use the ``psm2`` driver (i.e. use the high-bandwidth, low-latency Intel OmniPath fabric);
+   * the ``btl`` (MCA *Byte Transport Layer*) to use Omnipath but (not not Ethernet);
+   * the ``oob`` (MCA out of band messaging) to use the intra-cluster Ethernet fabric (specified using a network address in CIDR format rather than by specifying Ethernet interface name, which can vary between nodes).
+#. Install :download:`this modulefile </sharc/software/modulefiles/mpi/openmpi/1.10.4/gcc-6.2>` as ``/usr/local/modulefiles/mpi/openmpi/1.10.4/gcc-6.2``
 
-	
-	
+**Version 1.10.4, gcc 4.9.4**
 
-	
-	
- 
-
+#. Enable :ref:`GCC <gcc_sharc>` 4.9.4.
+#. Download, compile and install OpenMPI 1.10.4 using :download:`this script </sharc/software/install_scripts/mpi/openmpi/1.10.4/gcc-4.9.4/install.sh>`.
+#. Configure the OpenMPI *Modular Component Architecture* (MCA) by copying :download:`this script </sharc/software/install_scripts/mpi/openmpi/1.10.4/gcc-4.9.4/openmpi-mca-params.conf>` to ``/usr/local/packages/mpi/openmpi/1.10.4/gcc-4.9.4/``; this configures: 
+   * the ``mtl`` (MCA *Matching Transport Layer*) to use the ``psm2`` driver (i.e. use the high-bandwidth, low-latency Intel OmniPath fabric);
+   * the ``btl`` (MCA *Byte Transport Layer*) to use Omnipath but (not not Ethernet);
+   * the ``oob`` (MCA out of band messaging) to use the intra-cluster Ethernet fabric (specified using a network address in CIDR format rather than by specifying Ethernet interface name, which can vary between nodes).
+#. Install :download:`this modulefile </sharc/software/modulefiles/mpi/openmpi/1.10.4/gcc-4.9.4>` as ``/usr/local/modulefiles/mpi/openmpi/1.10.4/gcc-4.9.4``


### PR DESCRIPTION
…rather than network interface, as the latter varies between GPU and non-GPU nodes.