### PR TITLE
Limit max version of Sphinx theme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,8 +39,8 @@ Building the documentation on a local Windows machine
 
 #. Create a new *conda environment* for building the documentation by running the following from this window: ::
 
-    conda create -n sheffield_hpc python=3.6 sphinx
-    pip install sphinx_bootstrap_theme
+    conda create -n sheffield_hpc python=3.6 
+    pip install -r requirements.txt
 
 #. To build the HTML documentation run: ::
 
@@ -73,7 +73,7 @@ Building the documentation on a local Linux machine
 
 #. Install the Python packages needed to build the HTML documentation: ::
 
-     pip3 install --requirement requirements.txt
+     pip3 install -r requirements.txt
 
 #. Build the documentation: ::
 
@@ -86,8 +86,8 @@ Building the documentation on a local Mac machine
 #. Install the Python packages needed to build the HTML documentation.  If you are using (mini)conda create a new *conda environment* for building the documentation by running: ::
 
     export PATH=${HOME}/miniconda3/bin:$PATH
-    conda create -n sheffield_hpc python=3.6 sphinx
-    pip install sphinx_bootstrap_theme
+    conda create -n sheffield_hpc python=3.6
+    pip install -r requirements.txt
 
    If you are *not* using (mini)conda to provide Python 3: ::
 
@@ -103,7 +103,7 @@ Building the documentation on a local Mac machine
 Continuous build and serve
 ##########################
 
-The package `sphinx-autobuild <https://github.com/GaretJax/sphinx-autobuild>`_ provides a watcher that automatically rebuilds the site as files are modified. To use it, install (in addition to the shpinx packages) with the following: ::
+The package `sphinx-autobuild <https://github.com/GaretJax/sphinx-autobuild>`_ provides a watcher that automatically rebuilds the site as files are modified. To use it, install (in addition to the Sphinx packages) with the following: ::
 
     pip install sphinx-autobuild
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-sphinx
-sphinx-bootstrap-theme>=0.4.7
+sphinx==1.5.3  # should be same version as currently used by ReadTheDocs
+sphinx-bootstrap-theme>=0.4.7,<0.5.0


### PR DESCRIPTION
The `requirements.txt` file used by ReadTheDocs to build this Sphinx documentation previously asked that a version of `sphinx-bootstrap-theme` newer than 0.4.7 be installed.  It appears that following the release of 0.5.0 our ReadTheDocs-hosted documentation looks a bit odd.  I've therefore restricted the version of that package to >=0.4.7 but <0.5.0 until we've found a way of making the 0.5.0 styling and layout changes look a bit better.