### PR TITLE
scotch lib on sharc: rst, install and module files

### DIFF
--- a/sharc/software/install_scripts/libs/scotch/6.0.4/install_scotch.sh
+++ b/sharc/software/install_scripts/libs/scotch/6.0.4/install_scotch.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+# This is a template script for building and installing software on iceberg.
+# You should use it to document how you install things.
+# You will need to configure any module loads the build needs and then
+# configure the variables for the build.
+# This script will then create the directories you need and download and unzip
+# the source in to the build dir.
+
+
+############################# Module Loads ###################################
+module load dev/gcc/6.2
+module load mpi/openmpi/2.0.1/gcc-6.2
+
+############################## Variable Setup ################################
+version=6.0.4
+prefix=/usr/local/packages/libs/scotch/$version/gcc-6.2-openmpi-2.0.1
+build_dir=/scratch/$USER/scotch
+
+filename=scotch_$version.tar.gz
+baseurl=http://gforge.inria.fr/frs/download.php/file/34618
+
+# Set this to 'sudo' if you want to create the install dir using sudo.
+#sudo='sudo'
+
+
+##############################################################################
+# This should not need modifying
+##############################################################################
+
+# Create the build dir
+
+if [ ! -d $build_dir ]
+then
+    mkdir -p $build_dir
+fi
+
+cd $build_dir
+
+# Create the install directory
+if [ ! -d $prefix ]
+then
+   mkdir -p $prefix
+   chown $USER:app-admins $prefix
+fi
+
+# Download the source
+if [ -e $filename ]
+then
+  echo "Install tarball exists. Download not required."
+else
+  echo "Downloading source"
+  wget $baseurl/$filename
+fi
+
+##############################################################################
+
+##############################################################################
+# Installation (Write the install script here)
+##############################################################################
+
+tar -xvf $filename
+
+cd scotch_$version
+
+cd src
+ln -s Make.inc/Makefile.inc.x86-64_pc_linux2 ./Makefile.inc
+echo "prefix=$prefix" >> Makefile.inc
+cat Makefile.inc
+make scotch ptscotch
+
+cd check
+make check
+
+cd ..
+make install

--- a/sharc/software/libs/scotch.rst
+++ b/sharc/software/libs/scotch.rst
@@ -1,0 +1,31 @@
+SCOTCH
+======
+
+.. sidebar:: SCOTCH
+   
+   :Version: 6.0.4
+   :Dependancies: GCC compiler and Open MPI
+   :URL: http://scotch.gforge.inria.fr/ 
+   :Documentation: https://gforge.inria.fr/docman/?group_id=248
+
+
+Software package and libraries for sequential and parallel graph partitioning, static mapping and clustering, sequential mesh and hypergraph partitioning, and sequential and parallel sparse matrix block ordering
+
+
+Usage
+-----
+
+SCOTCH and PT SCOTCH 6.0.4 can be activated using the module file::
+
+    module load libs/scotch/6.0.4/gcc-6.2-openmpi-2.0.1
+
+Installation notes
+------------------
+
+SCOTCH was installed using the
+:download:`install_scotch.sh </sharc/software/install_scripts/libs/scotch/6.0.4/install_scotch.sh>` script; the module
+file is
+:download:`gcc-6.2-openmpi-2.0.1 </sharc/software/modulefiles/libs/scotch/6.0.4/gcc-6.2-openmpi-2.0.1>`.
+
+The installation was tested using the ''make check'' command as part of running the above installation script.
+    

--- a/sharc/software/modulefiles/libs/scotch/6.0.4/gcc-6.2-openmpi-2.0.1
+++ b/sharc/software/modulefiles/libs/scotch/6.0.4/gcc-6.2-openmpi-2.0.1
@@ -1,0 +1,27 @@
+#%Module1.0#####################################################################
+##
+## Scotch and PT Scotch  6.0.4 module file
+##
+#  By David M. Rogers June 2017
+################################################################################
+
+## Module file logging
+source /usr/local/etc/module_logging.tcl
+##
+
+# load dependent modules
+module load dev/gcc/6.2
+module load mpi/openmpi/2.0.1/gcc-6.2
+
+proc ModulesHelp { } {
+        puts stderr "Makes the Scotch and PT Scotch 6.0.4 library available"
+}
+
+set S_DIR /usr/local/packages/libs/scotch/6.0.4/gcc-6.2-openmpi-2.0.1
+
+module-whatis   "Makes the Scotch and PT Scotch 6.0.4 library available"
+
+# module variables
+prepend-path LD_LIBRARY_PATH $S_DIR/lib
+prepend-path LIBRARY_PATH $S_DIR/lib
+prepend-path MAN_PATH $S_DIR/man


### PR DESCRIPTION
Scotch and PT Scotch libs on Sharc installed and required for Code Saturne 4.0.7 (plus other codes too, possibly). Three files: scotch.rst, install_scotch.sh and gcc-6.2-openmpi-2.0.1 (module file). 