### PR TITLE
remove references to limits for mem being applied

### DIFF
--- a/iceberg/software/apps/java.rst
+++ b/iceberg/software/apps/java.rst
@@ -42,23 +42,20 @@ Now, the compiler ::
 
 Virtual Memory
 --------------
-By default, Java requests a lot of *virtual memory* on startup. 
-This is usually a given fraction of the *physical memory* on a node, 
-which can be quite a lot on Iceberg. 
-This then exceeds a user's virtual memory limit set by the scheduler 
-and causes a job to fail.  
-See :ref:`real-vs-virt-mem` for explanations of the difference between virtual and real/physical memory.  
+By default, Java requests a lot of *virtual memory* on startup.
+This is usually a given fraction of the *physical memory* on a node,
+which can be quite a lot on Iceberg.
+See :ref:`real-vs-virt-mem` for explanations of the difference between virtual and real/physical memory.
 
-The ways in which this issue is addressed differ between the versions of Java available on Iceberg:
+The default amount of virtual memory that Java uses at startup is controlled in two different ways on Iceberg:
 
-For versions **prior to 1.8.0u112** we created a wrapper script to ``java`` that uses the ``-Xmx1G`` switch to force Java to restrict its *heap size* to a maximum of 1 GB of memory.  If this is amount is insufficient, you are free to allocate as much memory as you require by setting your own value for ``-Xmx`` but be sure to request enough from the scheduler as well. You'll typically need to request more virtual memory from the scheduler than you specify in the Java ``-Xmx`` switch.
+For versions **prior to 1.8.0u112** we created a wrapper script to ``java`` that uses the ``-Xmx1G`` switch to force Java to restrict its *heap size* to a maximum of 1 GB of memory.  If this is amount is insufficient, you are free to allocate as much memory as you require by setting your own value for ``-Xmx``.
 
-For example, consider the following submission script. Note that it was necessary to request 9 Gigabytes of memory from the scheduler even though we only allocated 5 Gigabytes heap size in Java. The requirement for 9 GB was determined empirically: ::
+For example, consider the following submission script: ::
 
   #!/bin/bash
   #Request 9 gigabytes of real memory from the scheduler (mem)
-  #and 9 gigabytes of virtual memory from the scheduler (mem)
-  #$ -l mem=9G -l rmem=9G
+  #$ -l rmem=9G
 
   # load the Java module
   module load apps/java/1.8u71
@@ -66,7 +63,7 @@ For example, consider the following submission script. Note that it was necessar
   #Run java program allocating 5 Gigabytes
   java -Xmx5G HelloWorld
 
-Note that **the above is not possible** if an appliation (e.g. a startup script for another software package on the cluster) starts ``java`` itself (instead of you explicitly starting it) 
+Note that **the above is not possible** if an appliation (e.g. a startup script for another software package on the cluster) starts ``java`` itself (instead of you explicitly starting it)
 and the above also will not help if an application uses an internally packaged version of Java (rather than one that can be *activated* using ``module load``).
 
 For **versions 1.8.0u112 onwards** the maximum heap size is instead to be restricted using an *environment variable*.  The following is set when you run ``module load ...``: ::
@@ -77,9 +74,9 @@ You can override this default value by running something like: ::
 
         export _JAVA_OPTIONS='-Xmx6G'
 
-before starting your application that depends on Java.  
-``_JAVA_OPTIONS`` can be interpretted by Java programs you start and Java programs started by other programs, 
-as well as by Java Virtual Machines (JVMs) that you activate using ``module load`` and JVMs that are packaged within applications. 
+before starting your application that depends on Java.
+``_JAVA_OPTIONS`` can be interpretted by Java programs you start and Java programs started by other programs,
+as well as by Java Virtual Machines (JVMs) that you activate using ``module load`` and JVMs that are packaged within applications.
 
 Installation notes
 ------------------

--- a/sharc/differences.rst
+++ b/sharc/differences.rst
@@ -21,12 +21,6 @@ Off campus access
 If you are off-campus, you will need to use a VPN connection to access ShARC.
 Iceberg can be accessed without a VPN Connection.
 
-rmem and mem scheduler flags
-----------------------------
-On both systems `-l rmem` is used to request real memory.
-On Iceberg, it is also necessary to make a `-l mem` request to ask for virtual memory.
-`-l mem` is not required on ShARC and will be ignored.
-
 Software and Module names
 -------------------------
 The two systems have different suites of software installed and modules follow different naming schemes.

--- a/sharc/software/apps/java.rst
+++ b/sharc/software/apps/java.rst
@@ -38,11 +38,6 @@ Now, the compiler ::
 
     javac 1.8.0_102
 
-Virtual Memory
---------------
-Those who have used Java on iceberg will be aware that Java's default settings regarding memory usage were changed to prevent it from requesting lots of *virtual memory* at startup (which often exceeded the user's virtual memory limit set by the scheduler, causing his/her job to fail).  
-
-On ShARC, Java's memory usage settings do not need to be changed from their defaults as ShARC's scheduler only monitors and manages *real memory* and not virtual memory, and Java's initial real memory requirements are more modest.  See :ref:`real-vs-virt-mem` for explanations of real and virtual memory.
 
 Installation notes
 ------------------

--- a/troubleshooting.rst
+++ b/troubleshooting.rst
@@ -32,7 +32,7 @@ Follow the trouble-shooting link from the `iceberg browser-access page <http://w
 All failing, you may have to fall back to one of the `non-browser access methods <http://www.sheffield.ac.uk/cics/research/hpc/using/access>`_.
 
 I cannot see my folders in /data or /shared
--------------------------------------------s
+-------------------------------------------
 Some directories such as ``/data/<your username>`` or ``/shared/<your project/`` are made available **on-demand**:.
 For example, if your username is `ab1def` and you look in `/data` straight after logging in, you may not see `/data/ab1def`.
 The directory is there, it has just not been made available (via a process called **mounting**) to you automatically.
@@ -42,8 +42,8 @@ The directory will be automatically unmounted after a period of inactivity.
 My batch job terminates without any messages or warnings
 --------------------------------------------------------
 
-When a batch job that is initiated by using the ``qsub`` command or ``runfluent``, ``runansys`` or ``runabaqus`` commands, it gets allocated specific amount of virtual memory and real-time.
-If a job exceeds either of these memory or time limits it gets terminated immediately and usually without any warning messages.
+When a batch job that is initiated by using the ``qsub`` command or ``runfluent``, ``runansys`` or ``runabaqus`` commands, it gets allocated specific amount of real memory and run-time.
+If a job exceeds either the real memory or time limits it gets terminated immediately and usually without any warning messages.
 
 It is therefore important to estimate the amount of memory and time that is needed to run your job to completion and specify it at the time of submitting the job to the batch queue.
 
@@ -73,14 +73,11 @@ in which case you need to contact ``research-it@sheffield.ac.uk`` and ask to the
 I am getting warning messages and warning emails from my batch jobs about insufficient memory
 ---------------------------------------------------------------------------------------------
 
-There are two types of memory resources that can be requested when submitting batch jobs using the qsub command. These are, virtual memory (``-l mem=nnn``) and real memory (``-l rmem=nnn``).
-Virtual memory limit specified should always be greater than equal to the real memory limit specification.
-
-If a job exceeds its virtual memory resource it gets terminated. However if a job exceeds its real memory resource it does not get terminated but an email message is sent to the user asking him to specify a larger ``rmem=`` parameter the next time, so that the job can run more efficiently.
+If a job exceeds its real memory resource it gets terminated. You can use the ``rmem=`` parameter to increase the amount of real memory that your job requests.
 
 .. _real-vs-virt-mem:
 
-What is rmem ( real memory) and mem ( virtual memory)
+What is rmem (real memory) and mem (virtual memory)
 -----------------------------------------------------
 
 Running a program always involves loading the program instructions and also its data i.e. all variables and arrays that it uses into the computer's memory.
@@ -92,23 +89,19 @@ If the real memory (i.e. RAM) allocated to a job is much smaller than the entire
 
 On the other hand if the RAM allocated to a job is larger than the virtual memory requirement of that job then it will result in waste of RAM resources which will be idle duration of that job.
 
-It is therefore crucial to strike a fine balance between the virtual memory  and the physical memory allocated to a job:
+* The virtual memory limit defined by the ``-l mem`` cluster scheduler parameter defines the maximum amount of virtual memory your job will be allowed to use. **This option is now deprecated** - you can continue to submit jobs requesting virtual memory, however the scheduler **no longer applies any limits to this resource**.
+* The real memory limit is defined by the ``-l rmem`` cluster scheduler parameter and defines the amount of RAM that will be allocated to your job.  The job scheduler will terminate jobs which exceed their real memory resource request.
 
-* The virtual memory limit defined by the ``-l mem`` cluster scheduler parameter defines the maximum amount of virtual memory your job will be allowed to use. If your job's virtual memory requirements exceed this limit during its execution your job will be killed immediately.
-* The real memory limit is defined by the ``-l rmem`` cluster scheduler parameter and defines the amount of RAM that will be allocated to your job.  The way we have configured SGE, if your job starts paging excessively your job is not killed but you receive warning messages to increase the RAM allocated to your job next time by means of the ``rmem`` parameter.
-
-It is important to make sure that your ``-l mem`` value is always greater than your ``-l rmem`` value so as not to waste the valuable RAM resources as mentioned earlier.
 
 Insufficient memory in an interactive session
 ---------------------------------------------
-By default, an interactive session provides you with 2 Gigabytes of RAM (sometimes called real memory) and 6 Gigabytes of Virtual Memory.
+By default, an interactive session provides you with 2 Gigabytes of RAM (sometimes called real memory).
 You can request more than this when running your ``qsh`` or ``qrsh`` command: ::
 
-        qsh -l mem=64G   -l rmem=8G
+        qsh  -l rmem=8G
 
-This asks for 64 Gigabytes of Virtual Memory and 8 Gigabytes of RAM (real memory). Note that you should
+This asks for 8 Gigabytes of RAM (real memory). Note that you should
 
-* not specify more than 768 Gigabytes of virtual memory (``mem``)
 * not specify more than 256 GB of RAM (real memory) (``rmem``)
 
 'Illegal Instruction' errors


### PR DESCRIPTION
Initial attempt at removing references to virtual memory limits for Iceberg for Issue #650 

I've kept the explanation of real vs virtual memory.

(will delay merging until the change actually takes place).