### PR TITLE
ansys on sharc: rst, 2 * install and 2 * module files

### DIFF
--- a/sharc/software/apps/ansys.rst
+++ b/sharc/software/apps/ansys.rst
@@ -52,7 +52,7 @@ Users are encouraged to write their own batch submission scripts. The following 
 
     fluent 2d -i flnt.inp -g -t8 -sge -mpi=intel -rsh -sgepe mpi-rsh
 	
-The script requests 8 cores using the MPI parallel environment ''mpi-rsh'' with a runtime of 30 mins and 1G of real memory per core. The Fluent input file is ''flnt.inp''. The ``mpi-rsh`` tight-integration parallel environment is required to run Ansys/Fluent using MPI.
+The script requests 8 cores using the MPI parallel environment ''mpi-rsh'' with a runtime of 30 mins and 1G of real memory per core. The Fluent input file is ''flnt.inp''.
 
 	
 Installation notes
@@ -65,4 +65,4 @@ file is
 Ansys 17.2 was installed using the
 :download:`install_ansys.sh </sharc/software/install_scripts/apps/ansys/17.2/install_ansys.sh>` script, the module
 file is
-:download:`17.2 </sharc/software/modulefiles/apps/ansys/17.2>`. The binary installations were tested by launching ``ansyswb`` and by using the above batch submission script.
+:download:`17.2 </sharc/software/modulefiles/apps/ansys/17.2>`. The binary installations were tested by launching ``ansyswb`` and by using the above batch submission script. The ``mpi-rsh`` tight-integration parallel environment is required to run Ansys/Fluent using MPI due to password-less ssh being disabled across nodes on ShARC.

--- a/sharc/software/apps/ansys.rst
+++ b/sharc/software/apps/ansys.rst
@@ -52,7 +52,7 @@ Users are encouraged to write their own batch submission scripts. The following 
 
     fluent 2d -i flnt.inp -g -t8 -sge -mpi=intel -rsh -sgepe mpi-rsh
 	
-The script requests 8 cores using the MPI parallel environment ``mpi-rsh`` with a runtime of 30 mins and 1G of real memory per core. The Fluent input file is ``lnt.inp``.
+The script requests 8 cores using the MPI parallel environment ``mpi-rsh`` with a runtime of 30 mins and 1G of real memory per core. The Fluent input file is ``flnt.inp``.
 
 	
 Installation notes

--- a/sharc/software/apps/ansys.rst
+++ b/sharc/software/apps/ansys.rst
@@ -1,0 +1,68 @@
+ANSYS
+=====
+
+.. sidebar:: ANSYS
+   
+   :Versions: 16.1, 17.2
+   :Dependencies: No prerequsite modules loaded. However, If using the User Defined Functions (UDF) will also need the following: For ANSYS Mechanical, Workbench, CFX and AutoDYN: Intel 14.0 or above; Compiler For Fluent: GCC 4.6.1 or above
+   :URL: http://www.ansys.com 
+   :Local URL: http://www.shef.ac.uk/cics/research/software/fluent
+
+
+The Ansys suite of programs can be used to numerically simulate a large variety of structural and fluid dynamics problems found in many engineering, physics, medical, aeronotics and automative industry applications.
+
+
+Usage
+-----
+
+Ansys can be activated using the module files::
+
+    module load apps/ansys/16.1
+    module load apps/ansys/17.2
+
+The Ansys Workbench GUI executable is ``ansyswb``. ``ansyswb`` can be launched during an interactive session with X Window support (e.g. an interactive ``qsh`` session).
+The Ansys exectuable is ``ansys`` and ``fluent`` is the executable for Fluent. Typing ``ansys -g`` or ``fluent -g -help`` will display a list of usage options.
+
+
+Batch jobs
+----------
+
+The easiest way of running batch jobs for a particular version of Ansys (e.g. 17.2) is::
+    
+    module load apps/ansys/17.2
+    runansys
+	
+Or the same for Fluent::
+
+    module load apps/ansys/17.2
+    runfluent
+	
+The ``runfluent`` and ``runansys`` commands submit a Fluent journal or Ansys input file into the batch system and can take a number of different parameters, according to your requirements.
+Typing ``runansys`` or ``runfluent`` will display information about their usage.
+	
+Users are encouraged to write their own batch submission scripts. The following is an example batch submission script, ``my_job.sh``, to run ``fluent`` 16.1 and which is submitted to the queue by typing ``qsub my_job.sh``::
+
+    #!/bin/bash
+    #$ -cwd
+    #$ -l h_rt=00:30:00
+    #$ -l rmem=1G
+    #$ -pe mpi-rsh 8
+
+    module load apps/ansys/16.1
+
+    fluent 2d -i flnt.inp -g -t8 -sge -mpi=intel -rsh -sgepe mpi-rsh
+	
+The script requests 8 cores using the MPI parallel environment ''mpi-rsh'' with a runtime of 30 mins and 1G of real memory per core. The Fluent input file is ''flnt.inp''. The ``mpi-rsh`` tight-integration parallel environment is required to run Ansys/Fluent using MPI.
+
+	
+Installation notes
+------------------
+
+Ansys 16.1 was installed using the
+:download:`install_ansys.sh </sharc/software/install_scripts/apps/ansys/16.1/install_ansys.sh>` script, the module
+file is
+:download:`16.1 </sharc/software/modulefiles/apps/ansys/16.1>`.
+Ansys 17.2 was installed using the
+:download:`install_ansys.sh </sharc/software/install_scripts/apps/ansys/17.2/install_ansys.sh>` script, the module
+file is
+:download:`17.2 </sharc/software/modulefiles/apps/ansys/17.2>`. The binary installations were tested by launching ``ansyswb`` and by using the above batch submission script.

--- a/sharc/software/apps/ansys.rst
+++ b/sharc/software/apps/ansys.rst
@@ -40,7 +40,7 @@ Or the same for Fluent::
 The ``runfluent`` and ``runansys`` commands submit a Fluent journal or Ansys input file into the batch system and can take a number of different parameters, according to your requirements.
 Typing ``runansys`` or ``runfluent`` will display information about their usage.
 	
-Users are encouraged to write their own batch submission scripts. The following is an example batch submission script, ``my_job.sh``, to run ``fluent`` 16.1 and which is submitted to the queue by typing ``qsub my_job.sh``::
+Users are encouraged to write their own batch submission scripts. The following is an example batch submission script, ``my_job.sh``, to run ``fluent`` version 16.1 and which is submitted to the queue by typing ``qsub my_job.sh``::
 
     #!/bin/bash
     #$ -cwd
@@ -52,7 +52,7 @@ Users are encouraged to write their own batch submission scripts. The following 
 
     fluent 2d -i flnt.inp -g -t8 -sge -mpi=intel -rsh -sgepe mpi-rsh
 	
-The script requests 8 cores using the MPI parallel environment ''mpi-rsh'' with a runtime of 30 mins and 1G of real memory per core. The Fluent input file is ''flnt.inp''.
+The script requests 8 cores using the MPI parallel environment ``mpi-rsh`` with a runtime of 30 mins and 1G of real memory per core. The Fluent input file is ``lnt.inp``.
 
 	
 Installation notes

--- a/sharc/software/install_scripts/apps/ansys/16.1/install_ansys.sh
+++ b/sharc/software/install_scripts/apps/ansys/16.1/install_ansys.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# This is a template script for building and installing software on iceberg.
+# You should use it to document how you install things.
+# You will need to configure any module loads the build needs and then
+# configure the variables for the build.
+# This script will then create the directories you need and download and unzip
+# the source in to the build dir.
+
+############################# Module Loads ###################################
+
+
+############################## Variable Setup ################################
+version=16.1
+prefix=/usr/local/packages/apps/ansys/$version
+package_dir=/scratch/$USER/ansys_package_$version
+
+filename=/usr/local/media/ansys/Ansys161-Linux/INSTALL
+baseurl=
+
+# Set this to 'sudo' if you want to create the install dir using sudo.
+#sudo='sudo'
+
+##############################################################################
+# This should not need modifying
+##############################################################################
+
+# Create the install directory
+if [ ! -d $prefix ]
+then
+   mkdir -p $prefix
+   chown -R $USER $prefix
+   chgrp -R app-admins $prefix
+fi
+
+#create package directory
+if [ ! -d $package_dir ]; then
+    mkdir -p $package_dir
+fi
+
+#create source directory
+#if [ ! -d $source_dir ]; then
+#    mkdir -p $source_dir
+#fi
+
+cd $package_dir
+
+# Download the source
+if [ -e $filename ]
+then
+  echo "Install tarball exists. Download not required."
+else
+  echo "Downloading source"
+  wget $baseurl/$filename
+fi
+
+##############################################################################
+
+##############################################################################
+# Installation (Write the install script here)
+##############################################################################
+
+$filename
+
+# follow the Ansys GUI install instructions,
+# in GUI set install directory to
+# /usr/local/packages/apps/ansys/16.1
+# the licence server is 1055@ansyslm.shef.ac.uk
+# this is a binary install
+
+bash

--- a/sharc/software/install_scripts/apps/ansys/17.2/install_ansys.sh
+++ b/sharc/software/install_scripts/apps/ansys/17.2/install_ansys.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# This is a template script for building and installing software on iceberg.
+# You should use it to document how you install things.
+# You will need to configure any module loads the build needs and then
+# configure the variables for the build.
+# This script will then create the directories you need and download and unzip
+# the source in to the build dir.
+
+############################# Module Loads ###################################
+
+
+############################## Variable Setup ################################
+version=17.2
+prefix=/usr/local/packages/apps/ansys/$version
+package_dir=/scratch/$USER/ansys_package_$version
+
+filename=/usr/local/media/ansys/Ansys172-Linux/INSTALL
+baseurl=
+
+# Set this to 'sudo' if you want to create the install dir using sudo.
+#sudo='sudo'
+
+##############################################################################
+# This should not need modifying
+##############################################################################
+
+# Create the install directory
+if [ ! -d $prefix ]
+then
+   mkdir -p $prefix
+   chown -R $USER $prefix
+   chgrp -R app-admins $prefix
+fi
+
+#create package directory
+if [ ! -d $package_dir ]; then
+    mkdir -p $package_dir
+fi
+
+#create source directory
+#if [ ! -d $source_dir ]; then
+#    mkdir -p $source_dir
+#fi
+
+cd $package_dir
+
+# Download the source
+if [ -e $filename ]
+then
+  echo "Install tarball exists. Download not required."
+else
+  echo "Downloading source"
+  wget $baseurl/$filename
+fi
+
+##############################################################################
+
+##############################################################################
+# Installation (Write the install script here)
+##############################################################################
+
+$filename
+
+# follow the Ansys GUI install instructions,
+# in GUI set install directory to
+# /usr/local/packages/apps/ansys/17.2
+# the licence server is 1055@ansyslm.shef.ac.uk
+# this is a binary install
+
+bash

--- a/sharc/software/modulefiles/apps/ansys/16.1
+++ b/sharc/software/modulefiles/apps/ansys/16.1
@@ -1,0 +1,30 @@
+#%Module10.2#####################################################################
+##
+## ANSYS 14.5 module file
+##
+#  By Deniz Savas on  February 2015; D.M.Rogers May 2017
+################################################################################
+
+## Module file logging
+source /usr/local/etc/module_logging.tcl
+##
+
+proc ModulesHelp { } {
+        global version
+
+        puts stderr "   Makes ANSYS Version 16.1 available for use"
+}
+
+module-whatis   "Makes ANSYS V16.1 available"
+
+# module variables
+#
+ set localroot     /usr/local/packages/apps/shef/ansys/batch:/usr/local/packages/apps/shef/ansys/
+ set ANSYS_DIR     /usr/local/packages/apps/ansys/16.1/v161
+
+ setenv  ANSYSROOT $ANSYS_DIR
+ setenv  ANSYSVER 161
+ setenv  ANSWBCOMMAND $ANSYS_DIR/Framework/bin/Linux64/runwb2
+ setenv  FLUENT_INC $ANSYS_DIR/fluent
+
+prepend-path PATH $localroot:$ANSYS_DIR/ansys/bin:$ANSYS_DIR/Framework/bin/Linux64/:$ANSYS_DIR/fluent/bin:$ANSYS_DIR/CFD-Post/bin:$ANSYS_DIR/CFX/bin:$ANSYS_DIR/Icepak/bin:$ANSYS_DIR/TurboGrid/bin:$ANSYS_DIR/polyflow/bin:$ANSYS_DIR/ansys/bin

--- a/sharc/software/modulefiles/apps/ansys/17.2
+++ b/sharc/software/modulefiles/apps/ansys/17.2
@@ -1,0 +1,30 @@
+#%Module10.2#####################################################################
+##
+## ANSYS 17.2 module file
+##
+#  By Deniz Savas on  November 2016; D.M.Rogers May 2017
+################################################################################
+
+## Module file logging
+source /usr/local/etc/module_logging.tcl
+##
+
+proc ModulesHelp { } {
+        global version
+
+        puts stderr "   Makes ANSYS Version 17.2 available for use"
+}
+
+module-whatis   "Makes ANSYS V17.2 available"
+
+# module variables
+#
+ set localroot     /usr/local/packages/apps/shef/ansys/batch:/usr/local/packages/apps/shef/ansys/
+ set ANSYS_DIR     /usr/local/packages/apps/ansys/17.2/v172
+
+ setenv  ANSYSROOT $ANSYS_DIR
+ setenv  ANSYSVER 172
+ setenv  ANSWBCOMMAND $ANSYS_DIR/Framework/bin/Linux64/runwb2
+ setenv  FLUENT_INC $ANSYS_DIR/fluent
+
+prepend-path PATH $localroot:$ANSYS_DIR/ansys/bin:$ANSYS_DIR/Framework/bin/Linux64/:$ANSYS_DIR/fluent/bin:$ANSYS_DIR/CFD-Post/bin:$ANSYS_DIR/CFX/bin:$ANSYS_DIR/Icepak/bin:$ANSYS_DIR/TurboGrid/bin:$ANSYS_DIR/polyflow/bin


### PR DESCRIPTION
Ansys 16.1 and 17.2 installed on Sharc. Both use the tight-integration mpi-rsh PE. One .rst file, two install scripts and two module files.