### PR TITLE
updated notes/module/install scripts for OpenMPI 2.1.1 install

### DIFF
--- a/sharc/software/install_scripts/mpi/openmpi/2.1.1/gcc-6.2/install.sh
+++ b/sharc/software/install_scripts/mpi/openmpi/2.1.1/gcc-6.2/install.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+# This is a template script for building and installing software on ShARC.
+# You should use it to document how you install things.
+# You will need to configure any module loads the build needs and then 
+# configure the variables for the build.
+# This script will then create the directories you need and download and unzip
+# the source in to the build dir.
+
+############################# Error handling ###################################
+
+handle_error () {
+    errcode=$? # save the exit code as the first thing done in the trap function 
+    echo "error $errorcode" 
+    echo "the command executing at the
+    time of the error was" echo "$BASH_COMMAND" 
+    echo "on line ${BASH_LINENO[0]}"
+    # do some error handling, cleanup, logging, notification $BASH_COMMAND
+    # contains the command that was being executed at the time of the trap
+    # ${BASH_LINENO[0]} contains the line number in the script of that command
+    # exit the script or return to try again, etc.
+    exit $errcode  # or use some other value or do return instead 
+} 
+trap handle_error ERR
+
+
+############################# Module Loads ###################################
+
+module load dev/gcc/6.2
+
+############################## Variable Setup ################################
+short_version=2.1
+version=${short_version}.1
+build_dir="/scratch/${USER}/openmpi_${version}"
+prefix="/usr/local/packages/mpi/openmpi/${version}/gcc-6.2"
+workers=4  # for building in parallel
+
+filename="openmpi-${version}.tar.gz"
+baseurl="http://www.open-mpi.org/software/ompi/v${short_version}/downloads/"
+
+##################### Create build and install dir ###########################
+
+[[ -d $build_dir ]] || mkdir -p $build_dir
+cd $build_dir
+
+mkdir -p $prefix
+chown ${USER}:app-admins $prefix
+chmod 2775 $prefix
+
+######################### Download source ###################################
+if [[ -e $filename ]]; then
+    echo "Install tarball exists. Download not required."                         
+else                                                                            
+    echo "Downloading source" 
+    wget ${baseurl}/${filename}
+fi
+
+##############################################################################
+# Build and install
+##############################################################################
+
+tar -xzf openmpi-${version}.tar.gz
+cd openmpi-${version}
+
+./configure --prefix=${prefix} --with-psm2
+make -j${workers}
+make check
+make install
+
+##############################################################################
+# Download and install examples
+##############################################################################
+
+pushd ${prefix}
+wget https://github.com/open-mpi/ompi/archive/v${version}.zip
+unzip v${version}.zip 
+mv ompi-${version}/examples .
+rm -r ompi-${version} v${version}.zip
+popd
+
+##############################################################################
+# Make sure install is writable by app-admins
+##############################################################################
+
+chmod -R g+w ${prefix}
+

--- a/sharc/software/modulefiles/mpi/openmpi/2.1.1/gcc-6.2
+++ b/sharc/software/modulefiles/mpi/openmpi/2.1.1/gcc-6.2
@@ -1,0 +1,34 @@
+#%Module1.0#####################################################################
+##
+## openmpi module file
+##
+
+## Module file logging
+source /usr/local/etc/module_logging.tcl
+##
+
+proc ModulesHelp { } {
+    global openmpiversion
+
+    puts stderr "   Adds `openmpi-$openmpiversion' to your PATH environment variable and necessary libraries"
+}
+
+set openmpiversion   2.1.1
+set compiler         gcc
+set compilerversion  6.2
+set openmpiroot      /usr/local/packages/mpi/openmpi/$openmpiversion/$compiler-$compilerversion
+
+module-whatis   "loads the necessary `openmpi-$openmpiversion' library paths"
+
+#setenv OMPI_MCA_btl_tcp_if_include eth0
+#setenv OMPI_MCA_btl tcp,self
+
+module load dev/$compiler/$compilerversion
+
+setenv MPI_HOME $openmpiroot
+
+prepend-path CPATH $openmpiroot/include
+prepend-path PATH $openmpiroot/bin
+prepend-path LD_LIBRARY_PATH $openmpiroot/lib
+prepend-path LIBRARY_PATH $openmpiroot/lib
+prepend-path MANPATH $openmpiroot/share/man

--- a/sharc/software/parallel/openmpi-gcc.rst
+++ b/sharc/software/parallel/openmpi-gcc.rst
@@ -3,7 +3,7 @@ OpenMPI (gcc version)
 
 .. sidebar:: OpenMPI (gcc version)
 
-   :Latest Version: 2.0.1
+   :Latest Version: 2.1.1
    :Dependancies: gcc
    :URL: http://www.open-mpi.org/
 
@@ -14,6 +14,7 @@ Versions
 
 You can load a specific version using ::
 
+   module load mpi/openmpi/2.1.1/gcc-6.2
    module load mpi/openmpi/2.0.1/gcc-6.2
    module load mpi/openmpi/2.0.1/gcc-5.4
    module load mpi/openmpi/2.0.1/gcc-4.9.4
@@ -41,29 +42,34 @@ In more detail ::
     qrsh -pe mpi 4
 
     # Load an MPI implementation
-    module load mpi/openmpi/2.0.1/gcc-6.2
+    module load mpi/openmpi/2.1.1/gcc-6.2
 
     # Copy the examples to your home directory
-    cp -r $MPI_HOME/examples ~/openmpi_2.0.1_examples
+    cp -r $MPI_HOME/examples ~/openmpi_2.1.1_examples
 
     # Compile all programs in the examples directory
-    cd ~/openmpi_2.0.1_examples
+    cd ~/openmpi_2.1.1_examples
     make
 
     # Once compiled, run an example program on all (or a subset) of your MPI nodes using the mpirun utility
      mpirun -np 4 hello_c
 
-
-    Hello, world, I am 0 of 4, (Open MPI v2.0.1, package: Open MPI user@sharc-node002.shef.ac.uk Distribution, ident: 2.0.1, repo rev: v2.0.0-257-gee86e07, Sep 02, 2016, 141)
-    Hello, world, I am 1 of 4, (Open MPI v2.0.1, package: Open MPI user@sharc-node002.shef.ac.uk Distribution, ident: 2.0.1, repo rev: v2.0.0-257-gee86e07, Sep 02, 2016, 141)
-    Hello, world, I am 2 of 4, (Open MPI v2.0.1, package: Open MPI user@sharc-node002.shef.ac.uk Distribution, ident: 2.0.1, repo rev: v2.0.0-257-gee86e07, Sep 02, 2016, 141)
-    Hello, world, I am 3 of 4, (Open MPI v2.0.1, package: Open MPI user@sharc-node002.shef.ac.uk Distribution, ident: 2.0.1, repo rev: v2.0.0-257-gee86e07, Sep 02, 2016, 141)
+    Hello, world, I am 0 of 4, (Open MPI v2.1.1, package: Open MPI sa_cs1ab@sharc-node003.shef.ac.uk Distribution, ident: 2.1.1, repo rev: v2.1.0-100-ga2fdb5b, May 10, 2017, 141)
+    Hello, world, I am 1 of 4, (Open MPI v2.1.1, package: Open MPI sa_cs1ab@sharc-node003.shef.ac.uk Distribution, ident: 2.1.1, repo rev: v2.1.0-100-ga2fdb5b, May 10, 2017, 141) 
+    Hello, world, I am 2 of 4, (Open MPI v2.1.1, package: Open MPI sa_cs1ab@sharc-node003.shef.ac.uk Distribution, ident: 2.1.1, repo rev: v2.1.0-100-ga2fdb5b, May 10, 2017, 141)
+    Hello, world, I am 3 of 4, (Open MPI v2.1.1, package: Open MPI sa_cs1ab@sharc-node003.shef.ac.uk Distribution, ident: 2.1.1, repo rev: v2.1.0-100-ga2fdb5b, May 10, 2017, 141)
 
 
 Installation notes
 ------------------
 
 These are primarily for administrators of the system.
+
+**Version 2.1.1, gcc 6.2**
+
+1. Enable :ref:`GCC <gcc_sharc>` 6.2.0.
+2. Download, compile and install OpenMPI 2.1.1 using the :download:`this script </sharc/software/install_scripts/mpi/openmpi/2.1.1/gcc-6.2/install.sh>`.
+3. Install :download:`this modulefile </sharc/software/modulefiles/mpi/openmpi/2.1.1/gcc-6.2>` as ``/usr/local/modulefiles/mpi/openmpi/2.1.1/gcc-6.2``
 
 **Version 2.0.1, gcc 6.2**
 

--- a/sharc/software/parallel/openmpi-gcc.rst
+++ b/sharc/software/parallel/openmpi-gcc.rst
@@ -54,10 +54,10 @@ In more detail ::
     # Once compiled, run an example program on all (or a subset) of your MPI nodes using the mpirun utility
      mpirun -np 4 hello_c
 
-    Hello, world, I am 0 of 4, (Open MPI v2.1.1, package: Open MPI sa_cs1ab@sharc-node003.shef.ac.uk Distribution, ident: 2.1.1, repo rev: v2.1.0-100-ga2fdb5b, May 10, 2017, 141)
-    Hello, world, I am 1 of 4, (Open MPI v2.1.1, package: Open MPI sa_cs1ab@sharc-node003.shef.ac.uk Distribution, ident: 2.1.1, repo rev: v2.1.0-100-ga2fdb5b, May 10, 2017, 141) 
-    Hello, world, I am 2 of 4, (Open MPI v2.1.1, package: Open MPI sa_cs1ab@sharc-node003.shef.ac.uk Distribution, ident: 2.1.1, repo rev: v2.1.0-100-ga2fdb5b, May 10, 2017, 141)
-    Hello, world, I am 3 of 4, (Open MPI v2.1.1, package: Open MPI sa_cs1ab@sharc-node003.shef.ac.uk Distribution, ident: 2.1.1, repo rev: v2.1.0-100-ga2fdb5b, May 10, 2017, 141)
+    Hello, world, I am 0 of 4, (Open MPI v2.1.1, package: Open MPI user@sharc-node003.shef.ac.uk Distribution, ident: 2.1.1, repo rev: v2.1.0-100-ga2fdb5b, May 10, 2017, 141)
+    Hello, world, I am 1 of 4, (Open MPI v2.1.1, package: Open MPI user@sharc-node003.shef.ac.uk Distribution, ident: 2.1.1, repo rev: v2.1.0-100-ga2fdb5b, May 10, 2017, 141) 
+    Hello, world, I am 2 of 4, (Open MPI v2.1.1, package: Open MPI user@sharc-node003.shef.ac.uk Distribution, ident: 2.1.1, repo rev: v2.1.0-100-ga2fdb5b, May 10, 2017, 141)
+    Hello, world, I am 3 of 4, (Open MPI v2.1.1, package: Open MPI user@sharc-node003.shef.ac.uk Distribution, ident: 2.1.1, repo rev: v2.1.0-100-ga2fdb5b, May 10, 2017, 141)
 
 
 Installation notes


### PR DESCRIPTION
Install notes and files for OpenMPI 2.1.1. install - 

Currently installed for testing - trying to track down hard-to-reproduce issue where MPI processes don't use all the CPU cores they've been allocated by the scheduler.  I currently suspect a bug in OpenMPI - so try to reproduce using latest version.   (I'd be open to arguments for using the latest 2.0.x release instead if people think sticking on the same release is preferable....)

modulefile for install is currently only accessible to app-admins - will be made user-accessible if go live.

Note: the zip file containing the example media seems to be minor-version specific now(?) hence the change to the usual install script.