### PR TITLE
code saturne 4.0.7 on sharc: rst, 2 module files and 2 install scripts

### DIFF
--- a/sharc/software/apps/code_saturne.rst
+++ b/sharc/software/apps/code_saturne.rst
@@ -33,7 +33,7 @@ Users are encouraged to write their own batch submission scripts. The following 
     module load apps/code_saturne/4.0.7/gcc-4.9.4-openmpi-1.10.4
 
     # Run solver.
-    mpiexec -n 4 /usr/local/packages/apps/code_saturne/4.0.7/gcc-4.9.4-openmpi-1.10.4/libexec/code_saturne/cs_solver --param case1.xml --mpi $@
+    mpiexec -n 4 cs_solver --param case1.xml --mpi $@
     export CS_RET=$?
 
     exit $CS_RET

--- a/sharc/software/apps/code_saturne.rst
+++ b/sharc/software/apps/code_saturne.rst
@@ -1,0 +1,90 @@
+Code Saturne
+============
+
+.. sidebar:: Code Saturne
+   
+   :Version: 4.0.7
+   :Dependencies: GCC compiler, Open MPI, Scotch/PT-Scotch and Libxml2. Modules loaded for GCC 4.9.4 and Open MPI 1.10.4 *or* GCC 6.2.0 and Open MPI 2.0.1
+   :URL: http://code-saturne.org/cms/ 
+   :Documentation: http://code-saturne.org/cms/documentation
+
+*Code_Saturne* solves the Navier-Stokes equations for 2D, 2D-axisymmetric and 3D flows, steady or unsteady, laminar or turbulent, incompressible or weakly dilatable, isothermal or not, with scalars transport if required.
+
+Usage
+-----
+
+Code Saturne 4.0.7 can be activated using the module files::
+
+    module load apps/code_saturne/4.0.7/gcc-4.9.4-openmpi-1.10.4
+    module load apps/code_saturne/4.0.7/gcc-6.2-openmpi-2.0.1
+	
+Batch jobs
+----------
+
+Users are encouraged to write their own batch submission scripts. The following is an example batch submission script, ``run_solver.sh``, to run Code Saturne and which is submitted to the queue by typing ``qsub run_solver.sh``.::
+
+    #!/bin/bash
+    #$ -cwd
+    #$ -l h_rt=00:30:00
+    #$ -l rmem=2G
+    #$ -pe mpi 4
+
+    # Load environment if this script is run directly.
+    module load apps/code_saturne/4.0.7/gcc-4.9.4-openmpi-1.10.4
+
+    # Run solver.
+    mpiexec -n 4 /usr/local/packages/apps/code_saturne/4.0.7/gcc-4.9.4-openmpi-1.10.4/libexec/code_saturne/cs_solver --param case1.xml --mpi $@
+    export CS_RET=$?
+
+    exit $CS_RET
+
+The script requests 4 cores using the MPI parallel environment ``mpi`` with a runtime of 30 mins and 2G of real memory per core. The Code Saturne input file is ``case1.xml``.
+*Note:* The above batch script was adapted from the ``run_solver`` script generated during the batch usage test (see Installation notes below).
+
+Installation notes
+------------------
+
+Code Saturne 4.0.7 was installed with GCC 4.9.4 and Open MPI 1.10.4 using the
+:download:`install_code_saturne.sh </sharc/software/install_scripts/apps/code_saturne/4.0.7/gcc-4.9.4-openmpi-1.10.4/install_code_saturne.sh>` script; the module
+file is
+:download:`gcc-4.9.4-openmpi-1.10.4 </sharc/software/modulefiles/apps/code_saturne/4.0.7/gcc-4.9.4-openmpi-1.10.4>`.
+
+Code Saturne 4.0.7 was installed with GCC 6.2.0 and Open MPI 2.0.1 using the
+:download:`install_code_saturne.sh </sharc/software/install_scripts/apps/code_saturne/4.0.7/gcc-6.2-openmpi-2.0.1/install_code_saturne.sh>` script; the module
+file is
+:download:`gcc-6.2-openmpi-2.0.1 </sharc/software/modulefiles/apps/code_saturne/4.0.7/gcc-6.2-openmpi-2.0.1>`.
+
+Both of the above installations used the libraries Scotch/PT-Scotch 6.0.4 and Libxml2 2.9.1. No additional, optional libraries were used during compilation.  
+
+**Post-installation:** Please read the instructions at the end of the install script for the Code Saturne files to manually edit.
+
+The installation of Code Saturne 4.0.7 was tested using the following example calculations.
+
+**Interactive usage** test::
+
+    $ module load apps/code_saturne/4.0.7/gcc-4.9.4-openmpi-1.10.4
+    $ code_saturne create -s T_junction -c case1
+    $ cp $build_dir/examples/1-simple_junction/case1/case1.xml ./T_junction/case1/DATA
+    $ cp $build_dir/examples/1-simple_junction/mesh/downcomer.des ./T_junction/MESH
+    $ cd ./T_junction/case1/DATA
+    $ code_saturne run --param case1.xml
+    $ cd ../RESU/yyyymmdd-hhmm
+	
+The output ``./T_junction/case1/RESU/yyyymmdd-hhmm/listing`` file should contain "END OF CALCULATION".
+
+**Batch usage** test using the parallel environment ``mpi 4`` (performed after the interactive test above)::
+
+    $ cd ./T_junction/case1/DATA
+    $ code_saturne run --initialize --param case1.xml --nprocs 4
+    $ cd ../RESU/yyyymmdd-hhmm
+    $ vi run_solver
+    $ qsub run_solver
+	
+The output ``./T_junction/case1/RESU/yyyymmdd-hhmm/listing`` file should contain "END OF CALCULATION".
+
+**User subroutines** test (performed after the above two tests)::
+
+    $ cd ./T_junction/case1/SRC
+    $ cp ./REFERENCE/cs_user_parameters.f90 .
+    $ code_saturne compile
+

--- a/sharc/software/install_scripts/apps/code_saturne/4.0.7/gcc-4.9.4-openmpi-1.10.4/install_code_saturne.sh
+++ b/sharc/software/install_scripts/apps/code_saturne/4.0.7/gcc-4.9.4-openmpi-1.10.4/install_code_saturne.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+# This is a template script for building and installing software on iceberg.
+# You should use it to document how you install things.
+# You will need to configure any module loads the build needs and then
+# configure the variables for the build.
+# This script will then create the directories you need and download and unzip
+# the source in to the build dir.
+
+
+############################# Module Loads ###################################
+module load dev/gcc/4.9.4
+module load mpi/openmpi/1.10.4/gcc-4.9.4
+module load libs/scotch/6.0.4/gcc-6.2-openmpi-2.0.1
+
+############################## Variable Setup ################################
+version=4.0.7
+prefix=/usr/local/packages/apps/code_saturne/$version/gcc-4.9.4-openmpi-1.10.4
+build_dir=/scratch/$USER/code_saturne
+
+filename=code_saturne-4.0.7.tar.gz
+baseurl=http://code-saturne.org/cms/sites/default/files/releases
+
+# Set this to 'sudo' if you want to create the install dir using sudo.
+#sudo='sudo'
+
+
+##############################################################################
+# This should not need modifying
+##############################################################################
+
+# Create the build dir
+
+if [ ! -d $build_dir ]
+then
+    mkdir -p $build_dir
+fi
+
+cd $build_dir
+
+# Create the install directory
+if [ ! -d $prefix ]
+then
+   mkdir -p $prefix
+   chown $USER:app-admins $prefix
+fi
+
+# Download the source
+if [ -e $filename ]
+then
+  echo "Install tarball exists. Download not required."
+else
+  echo "Downloading source"
+  wget $baseurl/$filename
+fi
+
+##############################################################################
+
+##############################################################################
+# Installation (Write the install script here)
+##############################################################################
+
+tar -xvf $filename
+
+cd code_saturne-$version
+
+./configure --disable-gui --prefix=/usr/local/packages/apps/code_saturne/4.0.7/gcc-4.9.4-openmpi-1.10.4 --with-mpi=/usr/local/packages/mpi/openmpi/1.10.4/gcc-4.9.4 --with-scotch=/usr/local/packages/libs/scotch/6.0.4/gcc-6.2-openmpi-2.0.1
+
+make -j 4 && make install
+
+cd $prefix/etc
+cp code_saturne.cfg.template code_saturne.cfg
+# In file code_saturne.cfg edit the following lines as follows
+# line 11   batch=SGE
+# line 54   bindir = /usr/local/packages/mpi/openmpi/1.10.4/gcc-4.9.4
+# line 56   mpiexec = mpiexec
+# line 69   mpiexec_n_per_node = ''
+
+cd $prefix/share/code_saturne/batch
+# In file batch.SGE edit the following line as follows
+# line 6    #$ -pe mpi 4
+
+cd $prefix/lib/python2.7/site-packages/code_saturne
+# In file cs_config.py edit the following lines as follows
+# line 104  self.compilers = {'cc': "/usr/local/packages/dev/gcc/4.9.4/bin/gcc",
+# line 105                    'cxx': "/usr/local/packages/dev/gcc/4.9.4/bin/g++",
+# line 106                    'fc': "/usr/local/packages/dev/gcc/4.9.4/bin/gfortran",
+# line 107                    'ld': "/usr/local/packages/dev/gcc/4.9.4/bin/gcc",

--- a/sharc/software/install_scripts/apps/code_saturne/4.0.7/gcc-6.2-openmpi-2.0.1/install_code_saturne.sh
+++ b/sharc/software/install_scripts/apps/code_saturne/4.0.7/gcc-6.2-openmpi-2.0.1/install_code_saturne.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+# This is a template script for building and installing software on iceberg.
+# You should use it to document how you install things.
+# You will need to configure any module loads the build needs and then
+# configure the variables for the build.
+# This script will then create the directories you need and download and unzip
+# the source in to the build dir.
+
+
+############################# Module Loads ###################################
+module load dev/gcc/6.2
+module load mpi/openmpi/2.0.1/gcc-6.2
+module load libs/scotch/6.0.4/gcc-6.2-openmpi-2.0.1
+
+############################## Variable Setup ################################
+version=4.0.7
+prefix=/usr/local/packages/apps/code_saturne/$version/gcc-6.2-openmpi-2.0.1
+build_dir=/scratch/$USER/code_saturne
+
+filename=code_saturne-4.0.7.tar.gz
+baseurl=http://code-saturne.org/cms/sites/default/files/releases
+
+# Set this to 'sudo' if you want to create the install dir using sudo.
+#sudo='sudo'
+
+
+##############################################################################
+# This should not need modifying
+##############################################################################
+
+# Create the build dir
+
+if [ ! -d $build_dir ]
+then
+    mkdir -p $build_dir
+fi
+
+cd $build_dir
+
+# Create the install directory
+if [ ! -d $prefix ]
+then
+   mkdir -p $prefix
+   chown $USER:app-admins $prefix
+fi
+
+# Download the source
+if [ -e $filename ]
+then
+  echo "Install tarball exists. Download not required."
+else
+  echo "Downloading source"
+  wget $baseurl/$filename
+fi
+
+##############################################################################
+
+##############################################################################
+# Installation (Write the install script here)
+##############################################################################
+
+tar -xvf $filename
+
+cd code_saturne-$version
+
+./configure --disable-gui --prefix=/usr/local/packages/apps/code_saturne/4.0.7/gcc-6.2-openmpi-2.0.1 --with-mpi=/usr/local/packages/mpi/openmpi/2.0.1/gcc-6.2 --with-scotch=/usr/local/packages/libs/scotch/6.0.4/gcc-6.2-openmpi-2.0.1
+
+make -j 4 && make install
+
+cd $prefix/etc
+cp code_saturne.cfg.template code_saturne.cfg
+# In file code_saturne.cfg edit the following lines as follows
+# line 11   batch=SGE
+# line 54   bindir = /usr/local/packages/mpi/openmpi/2.0.1/gcc-6.2
+# line 56   mpiexec = mpiexec
+# line 69   mpiexec_n_per_node = ''
+
+cd $prefix/share/code_saturne/batch
+# In file batch.SGE edit the following line as follows
+# line 6    #$ -pe mpi 4
+
+cd $prefix/lib/python2.7/site-packages/code_saturne
+# In file cs_config.py edit the following lines as follows
+# line 104  self.compilers = {'cc': "/usr/local/packages/dev/gcc/6.2.0/bin/gcc",
+# line 105                    'cxx': "/usr/local/packages/dev/gcc/6.2.0/bin/g++",
+# line 106                    'fc': "/usr/local/packages/dev/gcc/6.2.0/bin/gfortran",
+# line 107                    'ld': "/usr/local/packages/dev/gcc/6.2.0/bin/gcc",

--- a/sharc/software/modulefiles/apps/code_saturne/4.0.7/gcc-4.9.4-openmpi-1.10.4
+++ b/sharc/software/modulefiles/apps/code_saturne/4.0.7/gcc-4.9.4-openmpi-1.10.4
@@ -1,0 +1,32 @@
+#%Module1.0#####################################################################
+##
+## Code Saturne module file
+##
+#  By David M. Rogers June 2017
+################################################################################
+
+## Module file logging
+source /usr/local/etc/module_logging.tcl
+##
+
+proc ModulesHelp { } {
+        global version
+
+        puts stderr "   Makes Code Saturne Version 4.0.7 available for use"
+}
+
+#set USER $::env(USER)
+
+module-whatis   "Makes Code Saturne Version 4.0.7 available"
+
+# load modules
+ module load mpi/openmpi/1.10.4/gcc-4.9.4
+
+# module variables
+#
+ set     version 4.0.7
+ set     codesaturneroot /usr/local/packages/apps/code_saturne/4.0.7/gcc-4.9.4-openmpi-1.10.4
+
+ prepend-path MANPATH $codesaturneroot/share/man
+ prepend-path PATH $codesaturneroot/bin
+ 

--- a/sharc/software/modulefiles/apps/code_saturne/4.0.7/gcc-4.9.4-openmpi-1.10.4
+++ b/sharc/software/modulefiles/apps/code_saturne/4.0.7/gcc-4.9.4-openmpi-1.10.4
@@ -28,5 +28,5 @@ module-whatis   "Makes Code Saturne Version 4.0.7 available"
  set     codesaturneroot /usr/local/packages/apps/code_saturne/4.0.7/gcc-4.9.4-openmpi-1.10.4
 
  prepend-path MANPATH $codesaturneroot/share/man
- prepend-path PATH $codesaturneroot/bin
+ prepend-path PATH $codesaturneroot/bin:$codesaturneroot/libexec/code_saturne
  

--- a/sharc/software/modulefiles/apps/code_saturne/4.0.7/gcc-6.2-openmpi-2.0.1
+++ b/sharc/software/modulefiles/apps/code_saturne/4.0.7/gcc-6.2-openmpi-2.0.1
@@ -1,0 +1,32 @@
+#%Module1.0#####################################################################
+##
+## Code Saturne module file
+##
+#  By David M. Rogers June 2017
+################################################################################
+
+## Module file logging
+source /usr/local/etc/module_logging.tcl
+##
+
+proc ModulesHelp { } {
+        global version
+
+        puts stderr "   Makes Code Saturne Version 4.0.7 available for use"
+}
+
+#set USER $::env(USER)
+
+module-whatis   "Makes Code Saturne Version 4.0.7 available"
+
+# load modules
+ module load mpi/openmpi/2.0.1/gcc-6.2
+
+# module variables
+#
+ set     version 4.0.7
+ set     codesaturneroot /usr/local/packages/apps/code_saturne/4.0.7/gcc-6.2-openmpi-2.0.1
+
+ prepend-path MANPATH $codesaturneroot/share/man
+ prepend-path PATH $codesaturneroot/bin
+ 

--- a/sharc/software/modulefiles/apps/code_saturne/4.0.7/gcc-6.2-openmpi-2.0.1
+++ b/sharc/software/modulefiles/apps/code_saturne/4.0.7/gcc-6.2-openmpi-2.0.1
@@ -28,5 +28,5 @@ module-whatis   "Makes Code Saturne Version 4.0.7 available"
  set     codesaturneroot /usr/local/packages/apps/code_saturne/4.0.7/gcc-6.2-openmpi-2.0.1
 
  prepend-path MANPATH $codesaturneroot/share/man
- prepend-path PATH $codesaturneroot/bin
+ prepend-path PATH $codesaturneroot/bin:$codesaturneroot/libexec/code_saturne
  


### PR DESCRIPTION
Code Saturne 4.0.7 on Sharc compiled with gcc 4.9.4/openmpi 1.10.4 and with gcc 6.2.0/openmpi 2.0.1 (in order to resolve execution issues, so kept both versions).