### PR TITLE
Openmpi211

### DIFF
--- a/sharc/software/install_scripts/mpi/openmpi/2.1.1/gcc-4.8.5/install.sh
+++ b/sharc/software/install_scripts/mpi/openmpi/2.1.1/gcc-4.8.5/install.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+# This is a template script for building and installing software on ShARC.
+# You should use it to document how you install things.
+# You will need to configure any module loads the build needs and then 
+# configure the variables for the build.
+# This script will then create the directories you need and download and unzip
+# the source in to the build dir.
+
+############################# Error handling ###################################
+
+handle_error () {
+    errcode=$? # save the exit code as the first thing done in the trap function 
+    echo "error $errorcode" 
+    echo "the command executing at the
+    time of the error was" echo "$BASH_COMMAND" 
+    echo "on line ${BASH_LINENO[0]}"
+    # do some error handling, cleanup, logging, notification $BASH_COMMAND
+    # contains the command that was being executed at the time of the trap
+    # ${BASH_LINENO[0]} contains the line number in the script of that command
+    # exit the script or return to try again, etc.
+    exit $errcode  # or use some other value or do return instead 
+} 
+trap handle_error ERR
+
+
+############################# Module Loads ###################################
+
+
+############################## Variable Setup ################################
+short_version=2.1
+version=${short_version}.1
+build_dir="/scratch/${USER}/openmpi_${version}"
+prefix="/usr/local/packages/mpi/openmpi/${version}/gcc-4.8.5"
+workers=4  # for building in parallel
+
+filename="openmpi-${version}.tar.gz"
+baseurl="http://www.open-mpi.org/software/ompi/v${short_version}/downloads/"
+
+##################### Create build and install dir ###########################
+
+[[ -d $build_dir ]] || mkdir -p $build_dir
+cd $build_dir
+
+mkdir -p $prefix
+chown ${USER}:app-admins $prefix
+chmod 2775 $prefix
+
+######################### Download source ###################################
+if [[ -e $filename ]]; then
+    echo "Install tarball exists. Download not required."                         
+else                                                                            
+    echo "Downloading source" 
+    wget ${baseurl}/${filename}
+fi
+
+##############################################################################
+# Build and install
+##############################################################################
+
+tar -xzf openmpi-${version}.tar.gz
+cd openmpi-${version}
+
+./configure --prefix=${prefix} --with-psm2
+make -j${workers}
+make check
+make install
+
+##############################################################################
+# Download and install examples
+##############################################################################
+
+pushd ${prefix}
+wget https://github.com/open-mpi/ompi/archive/v${version}.zip
+unzip v${version}.zip 
+mv ompi-${version}/examples .
+rm -r ompi-${version} v${version}.zip
+popd
+
+##############################################################################
+# Make sure install is writable by app-admins
+##############################################################################
+
+chmod -R g+w ${prefix}
+

--- a/sharc/software/install_scripts/mpi/openmpi/2.1.1/gcc-5.4/install.sh
+++ b/sharc/software/install_scripts/mpi/openmpi/2.1.1/gcc-5.4/install.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+# This is a template script for building and installing software on ShARC.
+# You should use it to document how you install things.
+# You will need to configure any module loads the build needs and then 
+# configure the variables for the build.
+# This script will then create the directories you need and download and unzip
+# the source in to the build dir.
+
+############################# Error handling ###################################
+
+handle_error () {
+    errcode=$? # save the exit code as the first thing done in the trap function 
+    echo "error $errorcode" 
+    echo "the command executing at the
+    time of the error was" echo "$BASH_COMMAND" 
+    echo "on line ${BASH_LINENO[0]}"
+    # do some error handling, cleanup, logging, notification $BASH_COMMAND
+    # contains the command that was being executed at the time of the trap
+    # ${BASH_LINENO[0]} contains the line number in the script of that command
+    # exit the script or return to try again, etc.
+    exit $errcode  # or use some other value or do return instead 
+} 
+trap handle_error ERR
+
+
+############################# Module Loads ###################################
+
+module load dev/gcc/5.4
+
+############################## Variable Setup ################################
+short_version=2.1
+version=${short_version}.1
+build_dir="/scratch/${USER}/openmpi_${version}"
+prefix="/usr/local/packages/mpi/openmpi/${version}/gcc-5.4"
+workers=4  # for building in parallel
+
+filename="openmpi-${version}.tar.gz"
+baseurl="http://www.open-mpi.org/software/ompi/v${short_version}/downloads/"
+
+##################### Create build and install dir ###########################
+
+[[ -d $build_dir ]] || mkdir -p $build_dir
+cd $build_dir
+
+mkdir -p $prefix
+chown ${USER}:app-admins $prefix
+chmod 2775 $prefix
+
+######################### Download source ###################################
+if [[ -e $filename ]]; then
+    echo "Install tarball exists. Download not required."                         
+else                                                                            
+    echo "Downloading source" 
+    wget ${baseurl}/${filename}
+fi
+
+##############################################################################
+# Build and install
+##############################################################################
+
+tar -xzf openmpi-${version}.tar.gz
+cd openmpi-${version}
+
+./configure --prefix=${prefix} --with-psm2
+make -j${workers}
+make check
+make install
+
+##############################################################################
+# Download and install examples
+##############################################################################
+
+pushd ${prefix}
+wget https://github.com/open-mpi/ompi/archive/v${version}.zip
+unzip v${version}.zip 
+mv ompi-${version}/examples .
+rm -r ompi-${version} v${version}.zip
+popd
+
+##############################################################################
+# Make sure install is writable by app-admins
+##############################################################################
+
+chmod -R g+w ${prefix}
+

--- a/sharc/software/modulefiles/mpi/openmpi/2.1.1/gcc-4.8.5
+++ b/sharc/software/modulefiles/mpi/openmpi/2.1.1/gcc-4.8.5
@@ -1,0 +1,32 @@
+#%Module1.0#####################################################################
+##
+## openmpi module file
+##
+
+## Module file logging
+source /usr/local/etc/module_logging.tcl
+##
+
+proc ModulesHelp { } {
+    global openmpiversion
+
+    puts stderr "   Adds `openmpi-$openmpiversion' to your PATH environment variable and necessary libraries"
+}
+
+set openmpiversion   2.1.1
+set compiler         gcc
+set compilerversion  4.8.5
+set openmpiroot      /usr/local/packages/mpi/openmpi/$openmpiversion/$compiler-$compilerversion
+
+module-whatis   "loads the necessary `openmpi-$openmpiversion' library paths"
+
+#setenv OMPI_MCA_btl_tcp_if_include eth0
+#setenv OMPI_MCA_btl tcp,self
+
+setenv MPI_HOME $openmpiroot
+
+prepend-path CPATH $openmpiroot/include
+prepend-path PATH $openmpiroot/bin
+prepend-path LD_LIBRARY_PATH $openmpiroot/lib
+prepend-path LIBRARY_PATH $openmpiroot/lib
+prepend-path MANPATH $openmpiroot/share/man

--- a/sharc/software/modulefiles/mpi/openmpi/2.1.1/gcc-5.4
+++ b/sharc/software/modulefiles/mpi/openmpi/2.1.1/gcc-5.4
@@ -1,0 +1,34 @@
+#%Module1.0#####################################################################
+##
+## openmpi module file
+##
+
+## Module file logging
+source /usr/local/etc/module_logging.tcl
+##
+
+proc ModulesHelp { } {
+    global openmpiversion
+
+    puts stderr "   Adds `openmpi-$openmpiversion' to your PATH environment variable and necessary libraries"
+}
+
+set openmpiversion   2.1.1
+set compiler         gcc
+set compilerversion  5.4
+set openmpiroot      /usr/local/packages/mpi/openmpi/$openmpiversion/$compiler-$compilerversion
+
+module-whatis   "loads the necessary `openmpi-$openmpiversion' library paths"
+
+#setenv OMPI_MCA_btl_tcp_if_include eth0
+#setenv OMPI_MCA_btl tcp,self
+
+module load dev/$compiler/$compilerversion
+
+setenv MPI_HOME $openmpiroot
+
+prepend-path CPATH $openmpiroot/include
+prepend-path PATH $openmpiroot/bin
+prepend-path LD_LIBRARY_PATH $openmpiroot/lib
+prepend-path LIBRARY_PATH $openmpiroot/lib
+prepend-path MANPATH $openmpiroot/share/man

--- a/sharc/software/parallel/openmpi-gcc.rst
+++ b/sharc/software/parallel/openmpi-gcc.rst
@@ -15,6 +15,7 @@ Versions
 You can load a specific version using ::
 
    module load mpi/openmpi/2.1.1/gcc-6.2
+   module load mpi/openmpi/2.1.1/gcc-5.4
    module load mpi/openmpi/2.1.1/gcc-4.9.4
    module load mpi/openmpi/2.0.1/gcc-6.2
    module load mpi/openmpi/2.0.1/gcc-5.4
@@ -71,6 +72,12 @@ These are primarily for administrators of the system.
 1. Enable :ref:`GCC <gcc_sharc>` 6.2.0.
 2. Download, compile and install OpenMPI 2.1.1 using the :download:`this script </sharc/software/install_scripts/mpi/openmpi/2.1.1/gcc-6.2/install.sh>`.
 3. Install :download:`this modulefile </sharc/software/modulefiles/mpi/openmpi/2.1.1/gcc-6.2>` as ``/usr/local/modulefiles/mpi/openmpi/2.1.1/gcc-6.2``
+
+**Version 2.1.1, gcc 5.4**
+
+1. Enable :ref:`GCC <gcc_sharc>` 5.4.0.
+2. Download, compile and install OpenMPI 2.1.1 using the :download:`this script </sharc/software/install_scripts/mpi/openmpi/2.1.1/gcc-5.4/install.sh>`.
+3. Install :download:`this modulefile </sharc/software/modulefiles/mpi/openmpi/2.1.1/gcc-5.4>` as ``/usr/local/modulefiles/mpi/openmpi/2.1.1/gcc-5.4``
 
 **Version 2.1.1, gcc 4.8.5**
 

--- a/sharc/software/parallel/openmpi-gcc.rst
+++ b/sharc/software/parallel/openmpi-gcc.rst
@@ -15,6 +15,7 @@ Versions
 You can load a specific version using ::
 
    module load mpi/openmpi/2.1.1/gcc-6.2
+   module load mpi/openmpi/2.1.1/gcc-4.9.4
    module load mpi/openmpi/2.0.1/gcc-6.2
    module load mpi/openmpi/2.0.1/gcc-5.4
    module load mpi/openmpi/2.0.1/gcc-4.9.4
@@ -70,6 +71,11 @@ These are primarily for administrators of the system.
 1. Enable :ref:`GCC <gcc_sharc>` 6.2.0.
 2. Download, compile and install OpenMPI 2.1.1 using the :download:`this script </sharc/software/install_scripts/mpi/openmpi/2.1.1/gcc-6.2/install.sh>`.
 3. Install :download:`this modulefile </sharc/software/modulefiles/mpi/openmpi/2.1.1/gcc-6.2>` as ``/usr/local/modulefiles/mpi/openmpi/2.1.1/gcc-6.2``
+
+**Version 2.1.1, gcc 4.8.5**
+
+1. Download, compile and install OpenMPI 2.1.1 using the :download:`this script </sharc/software/install_scripts/mpi/openmpi/2.1.1/gcc-4.8.5/install.sh>`.
+2. Install :download:`this modulefile </sharc/software/modulefiles/mpi/openmpi/2.1.1/gcc-4.8.5>` as ``/usr/local/modulefiles/mpi/openmpi/2.1.1/gcc-4.8.5``
 
 **Version 2.0.1, gcc 6.2**
 


### PR DESCRIPTION
More builds of Openmpi-2.1.1 for testing - 
gcc 4.8.5 (default GCC)
gcc 5.4 (requested by user for testing)