### PR TITLE
Remove the "Source (GitHub)" link from the nav bar

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -81,8 +81,7 @@ html_theme_options = {'navbar_sidebarrel':False,
                       'navbar_links': [
                           ("Home", "index"),
                           ("Research Computing @ CiCS", "https://www.shef.ac.uk/cics/research", True),
-                          ("Research Software Engineering @ TUOS", "https://rse.shef.ac.uk", True),
-                          ("Source (GitHub)", "https://github.com/rcgsheffield/sheffield_hpc", True),
+                          ("Research Software Engineering @ TUOS", "https://rse.shef.ac.uk", True)
                       ],
                       'globaltoc_depth': 1}
 


### PR DESCRIPTION
The addition of this link has caused the search bar to re-flow off the nav for me:
![screen shot 2017-07-18 at 13 07 42](https://user-images.githubusercontent.com/1391051/28316276-1b6fe8e6-6bba-11e7-9411-b5471013b36e.png)


and there is a "fork me on GitHub" link which points to the same place.