### PR TITLE
Enable intersphinx support (for linking to from other docs)

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -19,7 +19,9 @@ import shutil
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = []
+extensions = [
+    'sphinx.ext.intersphinx'
+]
 
 # Add any paths that contain templates here, relative to this directory.
 # templates_path = ['_templates']


### PR DESCRIPTION
Needed for cross-referencing the ShARC/Iceberg docs from the docs for Beagle (Insigneo shared mem cluster).