### PR TITLE
Fix reference names for Iceberg Abaqus and OpenSim pages

### DIFF
--- a/iceberg/software/apps/abaqus.rst
+++ b/iceberg/software/apps/abaqus.rst
@@ -1,4 +1,4 @@
-.. abaqus:
+.. _abaqus_iceberg:
 
 Abaqus
 ======

--- a/iceberg/software/apps/opensim.rst
+++ b/iceberg/software/apps/opensim.rst
@@ -1,4 +1,4 @@
-.. opensim:
+.. _opensim_iceberg:
 
 OpenSim
 =======


### PR DESCRIPTION
Allows for cross-referencing from other sites via [intersphinx](http://www.sphinx-doc.org/en/stable/ext/intersphinx.html).