### PR TITLE
Iceberg matlab

### DIFF
--- a/iceberg/software/apps/matlab.rst
+++ b/iceberg/software/apps/matlab.rst
@@ -22,7 +22,7 @@ The latest version of MATLAB (currently 2017b) is made available with the comman
 
         module load apps/matlab
 
-Alternatively, you can load a specific version with one of of the following commands: ::
+Alternatively, you can load a specific version with one of the following commands: ::
 
         module load apps/matlab/2013a
         module load apps/matlab/2013b
@@ -61,7 +61,7 @@ MATLAB Compiler and running free-standing compiled MATLAB programs
 ------------------------------------------------------------------
 
 The MATLAB compiler **mcc** can be used to generate standalone executables.
-These executables can then be run on other computers that does not have MATLAB installed. 
+These executables can then be run on other computers that do not have MATLAB installed. 
 We strongly recommend you use R2016b or later versions to take advantage of this feature. 
 
 To compile a MATLAB function or script for example called ``myscript.m`` the following steps are required: ::
@@ -133,7 +133,7 @@ For example, during your MATLAB session type: ::
     global sge_params
     sge_params='-l rmem=8G -l h_rt=36:00:00'
 
-to make sure that all the MATLAB batch jobs will use up to 8GBytes of memory and will not be killed
+to make sure that all the MATLAB batch jobs will use up to 8 GBytes of memory and will not be killed
 unless they exceed 36 hours of run time.
 
 

--- a/iceberg/software/apps/matlab.rst
+++ b/iceberg/software/apps/matlab.rst
@@ -5,7 +5,7 @@ MATLAB
 
 .. sidebar:: MATLAB
 
-   :Versions:  2013a , 2013b , 2014a, 2015a, 2016a
+   :Versions:  2013a, 2013b, 2014a, 2015a, 2016a, 2016b, 2017b
    :Support Level: FULL
    :Dependancies: None
    :URL: http://uk.mathworks.com/products/matlab
@@ -18,7 +18,7 @@ Interactive Usage
 -----------------
 After connecting to iceberg (see :ref:`ssh`),  start an interactive session with the ``qsh`` command.
 
-The latest version of MATLAB (currently 2016a) is made available with the command: ::
+The latest version of MATLAB (currently 2017b) is made available with the command: ::
 
         module load apps/matlab
 
@@ -29,43 +29,45 @@ Alternatively, you can load a specific version with one of of the following comm
         module load apps/matlab/2014a
         module load apps/matlab/2015a
         module load apps/matlab/2016a
+	module load apps/matlab/2016b
+	module load apps/matlab/2017b
 
 You can then run MATLAB by entering ``matlab``
 
 Serial (one CPU) Batch usage
 ----------------------------
 Here, we assume that you wish to run the program ``helloworld.m`` on the system: ::
-	
+
 	function helloworld
-		disp('Hello World!')
-	end	
+		disp('Hello World')
+	end
 
 First, you need to write a batch submission file. We assume you'll call this ``my_job.sge``: ::
 
         #!/bin/bash
         #$ -l rmem=4G                  # Request  4 GB of real memory
         #$ -cwd                        # Run job from current directory
-        module load apps/matlab/2016a  # Make specific version of MATLAB available
-
-        matlab -nodesktop -nosplash -r helloworld
+        module load apps/matlab/2017b  # Make specific version of MATLAB available
+        matlab -nodesktop -r helloworld
 
 Ensuring that ``helloworld.m`` and ``my_job.sge`` are both in your current working directory, submit your job to the batch system: ::
 
         qsub my_job.sge
 
-Note that we are running the script ``helloworld.m`` but we drop the ``.m`` in the call to MATLAB. That is, we do ``-r helloworld`` rather than ``-r helloworld.m``. The output will be written to the job ``.o`` file when the job finishes.
+Note that we are running the script ``helloworld.m`` but we drop the ``.m`` in the call to MATLAB. That is, we do ``-r helloworld`` rather than ``-r helloworld.m``.
+ 
 
 MATLAB Compiler and running free-standing compiled MATLAB programs
 ------------------------------------------------------------------
 
 The MATLAB compiler **mcc** can be used to generate standalone executables.
 These executables can then be run on other computers that does not have MATLAB installed. 
-We strongly recommend you use R2016a or later versions to take advantage of this feature. 
+We strongly recommend you use R2016b or later versions to take advantage of this feature. 
 
 To compile a MATLAB function or script for example called ``myscript.m`` the following steps are required: ::
 
-        # Load the matlab 2016a module
-        module load apps/matlab/2016a  
+        # Load the matlab 2017b module
+        module load apps/matlab/2017b  
 
         # Compile your program to generate the executable myscript and 
         # also generate a shell script named run_myscript.sh 
@@ -81,7 +83,7 @@ For example if the first line of ``myscript.m`` reads: ::
 
 then to run it with 1.0, 2.0, 3.0 as its parameters you will need to type: ::
 
-    ./run_myscript.sh $MCRROOT 1.0 2.0  3.0 
+    ./run_myscript.sh $MCRROOT 1.0 2.0 3.0 
 
 After a successful compilation and running you can transfer your executable and the runscript to another computer.
 That computer does not have to have MATLAB installed or licensed on it but it will have to have the MATLAB runtime system installed. 
@@ -97,7 +99,7 @@ Finally the environment variable ``$MCRROOT`` can be set to the directory contai
 Parallel MATLAB on iceberg
 --------------------------
 
-Currently we recommend the 2015a version of MATLAB for parallel work, and task arrays requiring more than a few hours runtime.
+Currently we recommend the 2015a version of MATLAB for parallel work.
 
 The default cluster configuration named **local** provides parallel working environment by 
 using the CPUs of the worker node that is running the current MATLAB session.
@@ -116,7 +118,7 @@ Run MATLAB in that session and select 5 workers: ::
         matlab
         parpool ('local' , 5 )
 
-The above example will use 5 MATLAB workers on a single iceberg node to run a parallel task.  Note that being granted a multi-core interactive session by the scheduler is dependent on Iceberg's loading at the time of request. It is not guaranteed. However the user can reduce the number of cores requested, which will improve their chances of being granted a multi-core session.
+The above example will use 5 MATLAB workers on a single iceberg node to run a parallel task.
 
 To take advantage of the multiple iceberg nodes, you will need to make use of a parallel cluster profile named ``sge``.
 This can be done by issuing a locally provided MATLAB command named ``iceberg`` that imports the
@@ -131,8 +133,8 @@ For example, during your MATLAB session type: ::
     global sge_params
     sge_params='-l rmem=8G -l h_rt=36:00:00'
 
-to make sure that all the MATLAB batch jobs will use up to 8 GBytes of memory and will not be killed
-unless they exceed 36 hours of runtime.
+to make sure that all the MATLAB batch jobs will use up to 8GBytes of memory and will not be killed
+unless they exceed 36 hours of run time.
 
 
 Training
@@ -157,9 +159,9 @@ Installation and configuration is a four-stage process:
 In more detail:
 
 #. If necessary, update the floating license keys on ``licserv4.shef.ac.uk`` to ensure that the licenses are served for the versions to install.
-#. Log on to Mathworks site to download the MATLAB installer package for 64-bit Linux ( for R2016a this was called ``matlab_R2016a_glnxa64.zip`` )
+#. Log on to Mathworks site to download the MATLAB installer package for 64-bit Linux ( for R2017b this was called ``matlab_R2017b_glnxa64.zip`` )
 
-#. ``unzip`` the installer package in a directory with ~10GB of space (needed as many MATLAB *archive* files will subsequently be downloaded here).  Using a directory on an NFS mount (e.g. ``/data/${USER}/MathWorks/R2016a``) allows the same downloaded archives to be used to install MATLAB on multiple clusters.
+#. ``unzip`` the installer package in a directory with ~10GB of space (needed as many MATLAB *archive* files will subsequently be downloaded here).  Using a directory on an NFS mount (e.g. ``/data/${USER}/MathWorks/R2017b``) allows the same downloaded archives to be used to install MATLAB on multiple clusters.
 #. ``./install`` to start the graphical installer (needed to download the MATLAB archive files).
 #. Select install choice of *Log in to Mathworks Account* and log in with a *License Administrator* account (not a *Licensed End User* (personal) account).
 #. Select *Download only*.
@@ -168,7 +170,7 @@ In more detail:
     
     fileInstallationKey=XXXXX-XXXXX-XXXXX-XXXXX-XXXXX-XXXXX-XXXXX-XXXXX-XXXXX-XXXXX-XXXXX-XXXXX-XXXXX-XXXXX-XXXXX-XXXXX-XXXXX-XXXXX-XXXXX-XXXXX-XXXXX
     agreeToLicense=yes
-    outputFile=matlab_2016a_install.log
+    outputFile=matlab_2017b_install.log
     mode=silent
     licensePath=/usr/local/packages6/matlab/network.lic
     lmgrFiles=false
@@ -176,11 +178,11 @@ In more detail:
 
 #. Create the installation directory e.g.: ::
 
-    mkdir -m 2755 -p /usr/local/packages6/matlab/R2016a
-    chown ${USER}:app-admins /usr/local/packages6/matlab/R2016a
+    mkdir -m 2755 -p /usr/local/packages6/matlab/R2017b
+    chown ${USER}:app-admins /usr/local/packages6/matlab/R2017b
 
 #. Run the installer using our customized ``installer_input.txt`` like so: ``./install -mode silent -inputFile ${PWD}/installer_input.txt`` ; installation should finish with exit status ``0`` if all has worked.
-#. Install a *modulefile* with a name and path like ``/usr//local/modulefiles/apps/matlab/2016a`` and contents like ::
+#. Install a *modulefile* with a name and path like ``/usr/local/modulefiles/apps/matlab/2017b`` and contents like ::
 
     #%Module1.0#####################################################################
 
@@ -189,21 +191,19 @@ In more detail:
 
     proc ModulesHelp { } {
         global version
-        puts stderr "	Makes MATLAB 2016a available for use"
+        puts stderr "	Makes MATLAB 2017b available for use"
     }
-    module-whatis   "Makes MATLAB 2016a available"
+    module-whatis   "Makes MATLAB 2017b available"
 
     # Do not use other versions at the same time.
     conflict apps/matlab
 
-    set     version        2016a
-    set     matlabroot     /usr/local/packages6/matlab/R2016a
-    set     mcrroot        /usr/local/packages6/matlab/runtime/R2016a/v901
+    set     version        2017b
+    set     matlabroot     /usr/local/packages6/matlab/R$version
     prepend-path PATH $matlabroot/bin 
-    setenv MCRROOT $mcrroot
 
 #. Ensure the contents of the install directory and the modulefile are writable by those in ``app-admins`` group e.g.: ::
 
-    chmod -R g+w ${USER}:app-admins /usr/local/packages6/matlab/R2016a /usr//local/modulefiles/apps/matlab/2016a
+    chmod -R g+w ${USER}:app-admins /usr/local/packages6/matlab/R2017b /usr/local/modulefiles/apps/matlab/2017b
 
 **TODO**: Documentation for MATLAB parallel configuration.

--- a/iceberg/software/apps/matlab.rst
+++ b/iceberg/software/apps/matlab.rst
@@ -54,7 +54,7 @@ Ensuring that ``helloworld.m`` and ``my_job.sge`` are both in your current worki
 
         qsub my_job.sge
 
-Note that we are running the script ``helloworld.m`` but we drop the ``.m`` in the call to MATLAB. That is, we do ``-r helloworld`` rather than ``-r helloworld.m``.
+Note that we are running the script ``helloworld.m`` but we drop the ``.m`` in the call to MATLAB. That is, we do ``-r helloworld`` rather than ``-r helloworld.m``. The output will be written to the job ``.o`` file when the job finishes.
  
 
 MATLAB Compiler and running free-standing compiled MATLAB programs
@@ -118,7 +118,7 @@ Run MATLAB in that session and select 5 workers: ::
         matlab
         parpool ('local' , 5 )
 
-The above example will use 5 MATLAB workers on a single iceberg node to run a parallel task.
+The above example will use 5 MATLAB workers on a single iceberg node to run a parallel task. Note that being granted a multi-core interactive session by the scheduler is dependent on Iceberg’s loading at the time of request. It is not guaranteed. However the user can reduce the number of cores requested, which will improve their chances of being granted a multi-core session.
 
 To take advantage of the multiple iceberg nodes, you will need to make use of a parallel cluster profile named ``sge``.
 This can be done by issuing a locally provided MATLAB command named ``iceberg`` that imports the

--- a/iceberg/software/apps/matlab.rst
+++ b/iceberg/software/apps/matlab.rst
@@ -99,7 +99,7 @@ Finally the environment variable ``$MCRROOT`` can be set to the directory contai
 Parallel MATLAB on iceberg
 --------------------------
 
-Currently we recommend the 2015a version of MATLAB for parallel work.
+Currently we recommend the 2015a version of MATLAB for parallel work, and task arrays requiring more than a few hours runtime.
 
 The default cluster configuration named **local** provides parallel working environment by 
 using the CPUs of the worker node that is running the current MATLAB session.
@@ -111,7 +111,7 @@ For example, to use the local profile with 5 workers, do the following;
 
 Start a parallel OpenMP job with 6 workers: ::
 
-        qsh -pe openmp 6
+        qsh -pe smp 6
 
 Run MATLAB in that session and select 5 workers: ::
 


### PR DESCRIPTION
Update to show that Matlab2017b installed on iceberg. Mods show that 2017b is newest rather than 2016a. Some additional text added in places to clarify a few points.