### PR TITLE
remove mem referred to in text in Maple/Mathematica/Octave

### DIFF
--- a/iceberg/software/apps/maple.rst
+++ b/iceberg/software/apps/maple.rst
@@ -32,7 +32,7 @@ It is not possible to run Maple worksheets in batch mode. Instead, you must conv
 An example Sun Grid Engine submission script that makes use of a .mpl file called, for example, **mycode.mpl** is ::
 
     #!/bin/bash
-    # Request 4 gigabytes of real memory (mem)
+    # Request 4 gigabytes of real memory
     #$ -l rmem=4G
 
     module load apps/binapps/maple/2015

--- a/iceberg/software/apps/mathematica.rst
+++ b/iceberg/software/apps/mathematica.rst
@@ -73,7 +73,7 @@ Copy and paste the above into a text file called `very_simple_mathematica.m`
 An example batch submission script for this file is ::
 
   #!/bin/bash
-  # Request 4 gigabytes of real memory (mem)
+  # Request 4 gigabytes of real memory
   #$ -l rmem=4G
 
   module load apps/binapps/mathematica/10.3.1

--- a/iceberg/software/apps/octave.rst
+++ b/iceberg/software/apps/octave.rst
@@ -35,7 +35,7 @@ Batch Usage
 Here is an example batch submission script that will run an Octave program called `foo.m` ::
 
   #!/bin/bash
-  # Request 5 gigabytes of real memory (mem)
+  # Request 5 gigabytes of real memory
   #$ -l rmem=5G
   # Request 64 hours of run time
   #$ -l h_rt=64:00:00


### PR DESCRIPTION
Remove references to 'mem' in descriptive text for iceberg packages Maple, Mathematica & Octave.