### PR TITLE
remove -l mem from Castep & idlde from idl on ShARC

### DIFF
--- a/sharc/software/apps/CASTEP.rst
+++ b/sharc/software/apps/CASTEP.rst
@@ -170,7 +170,6 @@ The following script was submitted via ``qsub`` from the ``Test`` subdirectory o
 .. code-block:: bash
 
    #!/bin/bash
-   #$ -l mem=10G
    #$ -l rmem=10G
    module load apps/castep/16.11/intel-15.0.7
 
@@ -188,7 +187,6 @@ The following script was submitted via ``qsub`` from the ``Test`` subdirectory o
 
    #!/bin/bash
    #$ -pe mpi 4
-   #$ -l mem=10G
    #$ -l rmem=10G
    module load apps/castep/16.11/intel-15.0.7-openmpi-2.0.1
 

--- a/sharc/software/apps/idl.rst
+++ b/sharc/software/apps/idl.rst
@@ -12,14 +12,13 @@ IDL is a data analysis language that first appeared in 1977.
 
 Usage
 -----
-If you wish to use the IDLDE then you may need to request more memory for the interactive session using something like ``qsh -l rmem=8G``.
 
 IDL versions can be activated using specific module files::
 
 	module load apps/idl/8.5/binary
 	module load apps/sswidl/8.5/binary
 
-Then run using ``idl`` or ``idlde`` for the interactive development environment. Note apps/sswidl/8.5 is the SolarSoft IDL environment. 
+Then run using ``idl``. Note apps/sswidl/8.5 is the SolarSoft IDL environment. 
 
 The IDL licence is restricted - please contact us via helpdesk if you need to use this software.
 


### PR DESCRIPTION
Removed -l mem from Test section for Castep.

Removed development environment command idlde because 1) it doesn't work 2) nobody uses it....2 users on iceberg and they do not require it on ShARC.