### PR TITLE
JupyterHub: note that sessions persist if browser tab closed

### DIFF
--- a/hpc/jupyterhub/sess_monit.rst
+++ b/hpc/jupyterhub/sess_monit.rst
@@ -3,6 +3,9 @@
 Monitoring and controlling your Jupyter session
 ===============================================
 
+Monitoring and control
+----------------------
+
 If you want to see what Jupyter Notebooks and Terminals your Jupyter server is running then
 
 #. Click the *Home* browser tab;
@@ -24,6 +27,26 @@ If you want to **stop your entire Jupyter server** (i.e. end your JupyterHub ses
 
 Your JupyterHub session **may terminate for other reasons**:
 
-* The cluster's job scheduler may stop your JupyterHub job if your Jupyter server exceeds the amount of RAM you requested via the :ref:`Spawner Options <jh_spawner_opts>` page.
-* Your JupyterHub job has been running for longer than the (fixed) duration specified on the :ref:`Spawner Options <jh_spawner_opts>` page.
+* The cluster's job scheduler may stop your JupyterHub job if 
+  your Jupyter server exceeds the amount of RAM you requested 
+  via the :ref:`Spawner Options <jh_spawner_opts>` page.
+* Your JupyterHub job has been running for longer than 
+  the (fixed) duration specified on the :ref:`Spawner Options <jh_spawner_opts>` page.
 
+---
+
+Session persistence
+-------------------
+
+You can **close your Jupyter-related browser tabs** and your Jupyter session will **keep running**
+until it terminates for one of the reasons listed above.  
+
+You can then revisit the JupyterHub site to 
+reconnect to your Jupyter session and **carry on from where you left off**.
+
+.. warning::
+
+   If you leave your Jupyter session running and are not using it then 
+   you are using CPU cores, memory and possibly GPUs that **cannot be used by others**.  
+
+   **Please stop your Jupyter session if you no longer need it**.

--- a/hpc/jupyterhub/sess_monit.rst
+++ b/hpc/jupyterhub/sess_monit.rst
@@ -12,7 +12,7 @@ If you want to see what Jupyter Notebooks and Terminals your Jupyter server is r
 #. Click the *Running* browser tab.
 
 Here you can **shut down (close) individual Notebooks**, which may be useful to free up 
-the memory and CPU cores that the cluster's job scheduler has alllocated for your JupyterHub session.
+the memory and CPU cores that the cluster's job scheduler has allocated for your JupyterHub session.
 
 .. image:: /images/jupyterhub/sharc-jh-show-running.png
 

--- a/hpc/jupyterhub/terminal.rst
+++ b/hpc/jupyterhub/terminal.rst
@@ -19,7 +19,7 @@ You can use this terminal to perform any command-line-only operation on the clus
   (as illustrated above);
 * **Searching for files/directories**;
 * **Configuring Python or R environments** 
-  (although there is an (enabled) plugin for 
+  (although there is an (enabled) plug-in for 
   creating/selecting environments and 
   installing/upgrading/removing packages 
   :ref:`using Jupyter's graphical interface <jh_conda>`);


### PR DESCRIPTION
Jupyter sessions persist if web browser tabs are closed so users need to be mindful to explicitly stop sessions if no longer required.