### PR TITLE
CUDA + cuDNN changes for SHARC

### DIFF
--- a/sharc/GPUComputingShARC.rst
+++ b/sharc/GPUComputingShARC.rst
@@ -8,7 +8,7 @@ Requesting access to GPU facilities
 
 **Public GPU nodes have now been made available to Iceberg and ShARC users, these can be be used without acquiring extra permission.**
 
-Research groups also have an option to purchase and add nodes to the cluster to be managed by CiCs. For these nodes (e.g. :ref:`dgx1_com_groupnodes_sharc`), permission from the group leader is required for access.
+Research groups also have an option to purchase and add nodes to the cluster to be managed by CiCS. For these nodes (e.g. :ref:`dgx1_com_groupnodes_sharc`), permission from the group leader is required for access.
 
 The node owner always have highest priority on the job queue but as a condition for the management of additional nodes on the cluster, the nodes are expected to be used as a resource for running short jobs during idle time. If you would like more information about having CiCs add and manage custom nodes, please contact research-it@sheffield.ac.uk.
 
@@ -23,9 +23,9 @@ Once you are included in the GPU project group you may start using the GPU enabl
 
 the ``-l gpu=`` parameter determines how many GPUs you are requesting. Currently, the maximum number of GPUs allowed per job is set to 8, i.e. you cannot exceed ``-l gpu=8``. Most jobs will only make use of one GPU.
 
-Interactive sessions provide you with 2 Gigabytes of CPU RAM by default which is significantly less than the amount of GPU RAM available. This can lead to issues where your session has insufficient CPU RAM to transfer data to and from the GPU. As such, it is recommended that you request enough CPU memory to communicate properly with the GPU ::
+Interactive sessions provide you with 2 GB of CPU RAM by default which is significantly less than the amount of GPU RAM available. This can lead to issues where your session has insufficient CPU RAM to transfer data to and from the GPU. As such, it is recommended that you request enough CPU memory to communicate properly with the GPU ::
 
-  #Nvidia K80 GPU has 24GB of RAM
+  # NB NVIDIA K80 GPU has 24GB of RAM
   qrshx -l gpu=1 -l rmem=25G
 
 The above will give you 1GB more CPU RAM than the 24GB of GPU RAM available on the Nvidia K80.
@@ -53,13 +53,13 @@ Here is how to request four CPU cores on a node with two GPU *per CPU core*: ::
 
 It is **not currently possible** to request:
 
-* more CPU cores than GPUs
+  * more CPU cores than GPUs
 
-    * e.g. a heterogeneous application which could use all 40 CPU cores in a given node whilst using all 8 GPUs;
+      * e.g. a heterogeneous application which could use all 40 CPU cores in a given node whilst using all 8 GPUs;
 
-* non-multiple ratios of GPUs to CPUs
+  * non-multiple ratios of GPUs to CPUs
 
-    * e.g. a heterogeneous application which uses 4 GPUs, with 1 CPU core per GPU and can additionally use CPU cores for asynchronous host work i.e. an extra 16 cores, totalling 20 CPUs.
+      * e.g. a heterogeneous application which uses 4 GPUs, with 1 CPU core per GPU and can additionally use CPU cores for asynchronous host work i.e. an extra 16 cores, totalling 20 CPUs.
 
 However, such scheduler requests may be supported in future.
 

--- a/sharc/software/install_scripts/libs/CUDA/install.log
+++ b/sharc/software/install_scripts/libs/CUDA/install.log
@@ -1,0 +1,27 @@
+/usr/local/media/nvidia ~/repos/sheffield_hpc/sharc/software/install_scripts/libs/CUDA
+Checking validity of installers using checksums from https://developer.download.nvidia.com/compute/cuda/9.1/Prod/docs/sidebar/md5sum-3.txt
+cuda_9.1.85_387.26_linux.run: OK
+cuda_9.1.85.1_linux.run: OK
+cuda_9.1.85.2_linux.run: OK
+cuda_9.1.85.3_linux.run: OK
+Installing CUDA using /usr/local/media/nvidia//cuda_9.1.85_387.26_linux.run
+Missing recommended library: libXi.so
+Missing recommended library: libXmu.so
+
+Copying samples to /usr/local/packages/libs/CUDA/9.1.85/binary/samples/NVIDIA_CUDA-9.1_Samples now...
+Finished copying samples.
+Applying CUDA_related patch /usr/local/media/nvidia//cuda_9.1.85.1_linux.run
+Welcome to the CUDA Patcher.
+Installation complete!
+Installation directory: /usr/local/packages/libs/CUDA/9.1.85/binary/cuda
+
+Applying CUDA_related patch /usr/local/media/nvidia//cuda_9.1.85.2_linux.run
+Welcome to the CUDA Patcher.
+Installation complete!
+Installation directory: /usr/local/packages/libs/CUDA/9.1.85/binary/cuda
+
+Applying CUDA_related patch /usr/local/media/nvidia//cuda_9.1.85.3_linux.run
+Welcome to the CUDA Patcher.
+Installation complete!
+Installation directory: /usr/local/packages/libs/CUDA/9.1.85/binary/cuda
+

--- a/sharc/software/install_scripts/libs/CUDA/install.sh
+++ b/sharc/software/install_scripts/libs/CUDA/install.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Install CUDA on the ShARC cluster
+
+# Signal handling for failure
+handle_error () {
+    errcode=$?
+    echo "Error code: $errorcode" 
+    echo "Errored command: " echo "$BASH_COMMAND" 
+    echo "Error on line: ${BASH_LINENO[0]}"
+    exit $errcode
+}
+trap handle_error ERR
+
+VERSIONS="9.1.85_387.26 8.0.44 7.5.18"
+
+usage () {
+    echo "Usage: $0 [${VERSIONS// /|}]" 1>&2
+}
+
+if [ "$#" -ne 1 ]; then
+    usage
+    exit -1
+fi
+if [[ ! "$VERSIONS" =~ "$1" ]]; then
+    usage
+    exit -1
+fi
+
+version="$1"
+short_version="$(echo $1 | cut -d_ -f1)"
+
+installer="/usr/local/media/nvidia/cuda_${version}_linux.run"
+chmod +x "$installer"
+
+prefix="/usr/local/packages/libs/CUDA/${short_version}/binary"
+mkdir -m 2775 -p "$prefix"
+chown -R ${USER}:app-admins "$prefix"
+chmod -R g+w "$prefix"
+
+$installer \
+    --toolkit --toolkitpath=${prefix}/cuda \
+    --samples --samplespath=${prefix}/samples \
+    --no-opengl-libs \
+    --silent

--- a/sharc/software/install_scripts/libs/CUDA/install.sh
+++ b/sharc/software/install_scripts/libs/CUDA/install.sh
@@ -4,14 +4,16 @@
 # Signal handling for failure
 handle_error () {
     errcode=$?
-    echo "Error code: $errorcode" 
+    echo "Error code: $errcode" 
     echo "Errored command: " echo "$BASH_COMMAND" 
     echo "Error on line: ${BASH_LINENO[0]}"
     exit $errcode
 }
 trap handle_error ERR
+set -u
 
-VERSIONS="9.1.85_387.26 8.0.44 7.5.18"
+VERSIONS='9.1.85_387.26 8.0.44 7.5.18'
+MEDIA_DIR='/usr/local/media/nvidia/'
 
 usage () {
     echo "Usage: $0 [${VERSIONS// /|}]" 1>&2
@@ -26,19 +28,55 @@ if [[ ! "$VERSIONS" =~ "$1" ]]; then
     exit -1
 fi
 
-version="$1"
-short_version="$(echo $1 | cut -d_ -f1)"
+vers="$1"
+short_vers="$(echo $1 | cut -d_ -f1)"
 
-installer="/usr/local/media/nvidia/cuda_${version}_linux.run"
+pushd $MEDIA_DIR
+
+if [[ $short_vers =~ '9.1' ]]; then
+    echo "Checking validity of installers using checksums from https://developer.download.nvidia.com/compute/cuda/9.1/Prod/docs/sidebar/md5sum-3.txt"
+    md5sum --check $MEDIA_DIR/cuda-9.1-md5sums.txt
+    rc=$?
+    if [[ $rc != 0 ]]; then 
+        echo 1>&2 'Could not validate MD5 checksums of CUDA 9.1 installer or patches; exiting.'
+        exit $rc;
+    fi
+fi
+
+installer="$MEDIA_DIR/cuda_${vers}_linux.run"
 chmod +x "$installer"
 
-prefix="/usr/local/packages/libs/CUDA/${short_version}/binary"
+prefix="/usr/local/packages/libs/CUDA/${short_vers}/binary"
 mkdir -m 2775 -p "$prefix"
 chown -R ${USER}:app-admins "$prefix"
 chmod -R g+w "$prefix"
 
+echo "Installing CUDA using $installer"
 $installer \
     --toolkit --toolkitpath=${prefix}/cuda \
     --samples --samplespath=${prefix}/samples \
     --no-opengl-libs \
     --silent
+
+# Apply patches:
+# * cuBLAS Patch Update: This update to CUDA 9.1 includes new GEMM kernels
+#   optimized for the Volta architecture and improved heuristics to select GEMM
+#   kernels for given input sizes.
+# * Patch 2 (Released Feb 27, 2018)     CUDA Compiler Patch Update: This update
+#   to CUDA 9.1 includes a bug fix to the PTX assembler (ptxas). The fix resolves
+#   an issue when compiling code that performs address calculations using large
+#   immediate operands.  
+# * Patch 3 (Released Mar 5, 2018)  cuBLAS Patch: This CUDA 9.1 patch includes
+#   fixes to GEMM optimizations for convolutional sequence to sequence (seq2seq)
+#   models.
+if [[ $short_vers =~ '9.1' ]]; then
+    for p in 1 2 3; do 
+        patch_file="$MEDIA_DIR/cuda_${short_vers}.${p}_linux.run"
+        echo "Applying CUDA_related patch $patch_file"
+        chmod +x $patch_file
+        $patch_file \
+           --silent \
+           --accept-eula \
+           --installdir=${prefix}/cuda
+    done 
+fi

--- a/sharc/software/install_scripts/libs/cudnn/install_7.0_for_cuda_8.0_cuda_9.1.sh
+++ b/sharc/software/install_scripts/libs/cudnn/install_7.0_for_cuda_8.0_cuda_9.1.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# The script installs cuDNN 5.1 for CUDA 8.0 and CUDA 9.1 in to the correct ShARC directory
+# The script installs cuDNN 7.0 for CUDA 8.0 and CUDA 9.1 in to the correct ShARC directory
 # The binaries can be downloaded from NVIDIA at https://developer.nvidia.com/cudnn
 # and need to be saved in $MEDIA_DIR (see below)
 

--- a/sharc/software/install_scripts/libs/cudnn/install_7.0_for_cuda_8.0_cuda_9.1.sh
+++ b/sharc/software/install_scripts/libs/cudnn/install_7.0_for_cuda_8.0_cuda_9.1.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# The script installs cuDNN 5.1 for CUDA 8.0 and CUDA 9.1 in to the correct ShARC directory
+# The binaries can be downloaded from NVIDIA at https://developer.nvidia.com/cudnn
+# and need to be saved in $MEDIA_DIR (see below)
+
+VERS=7.0
+MEDIA_DIR=/usr/local/media/protected/cuDNN
+PREFIX_BASE=/usr/local/packages/libs/cudnn/$VERS
+
+for cuda_vers in 8.0 9.1; do 
+    install_dir=${PREFIX_BASE}/binary-cuda-${cuda_vers}
+    mkdir -p $install_dir
+    tar -C $install_dir -xvzf ${MEDIA_DIR}/cudnn-${cuda_vers}-linux-x64-v${VERS}.tgz 
+done
+
+sudo chgrp -R app-admins $PREFIX_BASE
+sudo chmod -R g+w $PREFIX_BASE

--- a/sharc/software/libs/cuda.rst
+++ b/sharc/software/libs/cuda.rst
@@ -25,9 +25,9 @@ To check which version of CUDA you are using ::
 
         $ nvcc --version
         nvcc: NVIDIA (R) Cuda compiler driver
-        Copyright (c) 2005-2016 NVIDIA Corporation
-        Built on Sun_Sep__4_22:14:01_CDT_2016
-        Cuda compilation tools, release 8.0, V8.0.44
+        Copyright (c) 2005-2017 NVIDIA Corporation
+        Built on Fri_Nov__3_21:07:56_CDT_2017
+        Cuda compilation tools, release 9.1, V9.1.85
 
 **Important** To compile CUDA programs you also need a compatible version of the :ref:`gcc_sharc`.  As of version 8.0.44, CUDA is compatible with GCC versions:
 
@@ -42,7 +42,7 @@ Compiling the sample programs
 -----------------------------
 You do not need to be using a GPU-enabled node to compile the sample programs but you do need a GPU to run them.
 
-In a `qrsh` session ::
+In a ``qrsh`` session ::
 
         # Load modules
         module load libs/CUDA/9.1.85/binary
@@ -70,7 +70,7 @@ Profiling using nvprof
 
 Note that ``nvprof``, NVIDIA's CUDA profiler cannot write output to the ``/fastdata`` filesystem.
 
-This is because the profiler's output is a `SQLite <https://www.sqlite.org/>__` database and SQLite requires a filesystem that supports file locking
+This is because the profiler's output is a `SQLite <https://www.sqlite.org/>`__ database and SQLite requires a filesystem that supports file locking
 but file locking is not enabled on the (`Lustre <http://lustre.org/>`__) filesystem mounted on ``/fastdata`` (for performance reasons). 
 
 CUDA Training
@@ -86,8 +86,8 @@ Run the command: ::
 
 Example output is ::
 
-        NVRM version: NVIDIA UNIX x86_64 Kernel Module  384.81  Wed Aug 17 22:24:07 PDT 2016
-        GCC version:  gcc version 4.8.5 20150623 (Red Hat 4.8.5-4) (GCC)
+        NVRM version: NVIDIA UNIX x86_64 Kernel Module  390.30  Wed Jan 31 22:08:49 PST 2018
+        GCC version:  gcc version 4.8.5 20150623 (Red Hat 4.8.5-16) (GCC) 
 
 Installation notes
 ------------------
@@ -103,12 +103,13 @@ This service runs ``/usr/local/scripts/gpu-nvidia-driver.sh`` at boot time to:
 - Load the ``nvidia`` kernel module;
 - Create several *device nodes* in ``/dev/``.
 
-The NVIDIA device driver is currently version 384.81.
+The NVIDIA device driver is currently version 390.30.
 
 CUDA 9.1.85
 ^^^^^^^^^^^
 
-#. Installed with :download:`install.sh </sharc/software/install_scripts/libs/CUDA/install.sh>` with ``9.1.85_387.26`` as the sole argument.
+#. Installed with :download:`install.sh </sharc/software/install_scripts/libs/CUDA/install.sh>` with ``9.1.85_387.26`` as the sole argument. 
+   This installs the toolkit and three NVIDIA-recommended patches.
 #. :download:`Modulefile </sharc/software/modulefiles/libs/CUDA/9.1.85/binary>` was installed as ``/usr/local/modulefiles/libs/CUDA/9.1.85/binary``
 
 CUDA 8.0.44

--- a/sharc/software/libs/cuda.rst
+++ b/sharc/software/libs/cuda.rst
@@ -108,17 +108,17 @@ The NVIDIA device driver is currently version 384.81.
 CUDA 9.1.85
 ^^^^^^^^^^^
 
-#. Installed with :download:`install.sh </sharc/software/install_scripts/libs/CUDA/install.sh>` with 8. with ``9.1.85_387.26`` as the sole argument.
+#. Installed with :download:`install.sh </sharc/software/install_scripts/libs/CUDA/install.sh>` with ``9.1.85_387.26`` as the sole argument.
 #. :download:`Modulefile </sharc/software/modulefiles/libs/CUDA/9.1.85/binary>` was installed as ``/usr/local/modulefiles/libs/CUDA/9.1.85/binary``
 
 CUDA 8.0.44
 ^^^^^^^^^^^
 
-#. Installed with :download:`install.sh </sharc/software/install_scripts/libs/CUDA/install.sh>` with 8. with ``8.0.44`` as the sole argument.
+#. Installed with :download:`install.sh </sharc/software/install_scripts/libs/CUDA/install.sh>` with ``8.0.44`` as the sole argument.
 #. :download:`This modulefile </sharc/software/modulefiles/libs/CUDA/8.0.44/binary>` was installed as ``/usr/local/modulefiles/libs/CUDA/8.0.44/binary``
 
 CUDA 7.5.18
 ^^^^^^^^^^^
 
-#. Installed with :download:`install.sh </sharc/software/install_scripts/libs/CUDA/install.sh>` with 8. with ``7.5.18`` as the sole argument.
+#. Installed with :download:`install.sh </sharc/software/install_scripts/libs/CUDA/install.sh>` with ``7.5.18`` as the sole argument.
 #. :download:`This modulefile </sharc/software/modulefiles/libs/CUDA/7.5.18/binary>` was installed as ``/usr/local/modulefiles/libs/CUDA/7.5.18/binary``

--- a/sharc/software/libs/cuda.rst
+++ b/sharc/software/libs/cuda.rst
@@ -15,12 +15,9 @@ There are several versions of the CUDA library available. As with many libraries
 
 **See** :ref:`GPUComputing_sharc` **for more information on how to request a GPU-enabled node for an interactive session or job submission.** 
 
-The latest version CUDA is loaded with the command: ::
+Load a specific version with one of the following: ::
 
-        module load libs/CUDA
-
-Alternatively, you can load a specific version with one of the following: ::
-
+        module load libs/CUDA/9.1.85/binary
         module load libs/CUDA/8.0.44/binary
         module load libs/CUDA/7.5.18/binary
 
@@ -48,17 +45,17 @@ You do not need to be using a GPU-enabled node to compile the sample programs bu
 In a `qrsh` session ::
 
         # Load modules
-        module load libs/CUDA/8.0.44/binary
+        module load libs/CUDA/9.1.85/binary
         module load dev/gcc/4.9.4
 
         # Copy CUDA samples to a local directory
-        # It will create a directory called NVIDIA_CUDA-8.0_Samples/
+        # It will create a directory called NVIDIA_CUDA-9.1_Samples/
         mkdir cuda_samples
         cd cuda_samples
         cp -r $CUDA_SDK .
 
         # Compile (this will take a while)
-        cd NVIDIA_CUDA-8.0_Samples/
+        cd NVIDIA_CUDA-9.1_Samples/
         make
 
 A basic test is to run one of the resulting binaries, ``deviceQuery``.
@@ -108,25 +105,20 @@ This service runs ``/usr/local/scripts/gpu-nvidia-driver.sh`` at boot time to:
 
 The NVIDIA device driver is currently version 384.81.
 
+CUDA 9.1.85
+^^^^^^^^^^^
+
+#. Installed with :download:`install.sh </sharc/software/install_scripts/libs/CUDA/install.sh>` with 8. with ``9.1.85_387.26`` as the sole argument.
+#. :download:`Modulefile </sharc/software/modulefiles/libs/CUDA/9.1.85/binary>` was installed as ``/usr/local/modulefiles/libs/CUDA/9.1.85/binary``
+
 CUDA 8.0.44
 ^^^^^^^^^^^
 
-#. The CUDA toolkit binaries and samples were installed using a binary ``.run`` file: ::
-
-        cuda_vers="8.0.44"
-        prefix="/usr/local/packages/libs/CUDA/${cuda_vers}/binary"
-        mkdir -m 2775 -p $prefix
-        chown ${USER}:app-admins $prefix
-        cd /usr/local/media/nvidia/
-        chmod +x cuda_${cuda_vers}_linux.run
-        ./cuda_${cuda_vers}_linux.run --toolkit --toolkitpath=${prefix}/cuda \
-                                      --samples --samplespath=${prefix}/samples \
-                                      --no-opengl-libs -silent
-
+#. Installed with :download:`install.sh </sharc/software/install_scripts/libs/CUDA/install.sh>` with 8. with ``8.0.44`` as the sole argument.
 #. :download:`This modulefile </sharc/software/modulefiles/libs/CUDA/8.0.44/binary>` was installed as ``/usr/local/modulefiles/libs/CUDA/8.0.44/binary``
 
 CUDA 7.5.18
 ^^^^^^^^^^^
 
-#. The CUDA toolkit binaries and samples were installed using a binary ``.run`` file as per version 8.0.44.
+#. Installed with :download:`install.sh </sharc/software/install_scripts/libs/CUDA/install.sh>` with 8. with ``7.5.18`` as the sole argument.
 #. :download:`This modulefile </sharc/software/modulefiles/libs/CUDA/7.5.18/binary>` was installed as ``/usr/local/modulefiles/libs/CUDA/7.5.18/binary``

--- a/sharc/software/libs/cudnn.rst
+++ b/sharc/software/libs/cudnn.rst
@@ -20,7 +20,8 @@ Usage
 
 Load the appropriate cuDNN version (**and implicitly load a specific CUDA version**) with one of the following commands: ::
 
-    module load libs/cudnn/6.0/binary-cuda-8.0.44
+    module load libs/cudnn/7.0/binary-cuda-9.1.85
+    module load libs/cudnn/7.0/binary-cuda-8.0.44
     module load libs/cudnn/5.1/binary-cuda-8.0.44
     module load libs/cudnn/5.1/binary-cuda-7.5.18
 
@@ -30,6 +31,13 @@ Installation notes
 This section is primarily for administrators of the system.
 
 The cuDNN library is only available to download through the `developer portal <https://developer.nvidia.com/cudnn>`_.  Installation ``.tgz`` files are located in ``/usr/local/media/protected/cudnn``.
+
+Version 7.0
+^^^^^^^^^^^
+
+- Install script: :download:`install_cudnn7.0_for_cuda8.0_cuda9.1.sh </sharc/software/install_scripts/libs/cudnn/install_7.0_for_cuda_8.0_cuda_9.1.sh>`
+- :download:`Module file for CUDA 9.1 </sharc/software/modulefiles/libs/cudnn/7.0/binary-cuda-9.1.85>`
+- :download:`Module file for CUDA 8.0 </sharc/software/modulefiles/libs/cudnn/7.0/binary-cuda-8.0.44>`
 
 Version 6.0
 ^^^^^^^^^^^

--- a/sharc/software/libs/cudnn.rst
+++ b/sharc/software/libs/cudnn.rst
@@ -22,6 +22,7 @@ Load the appropriate cuDNN version (**and implicitly load a specific CUDA versio
 
     module load libs/cudnn/7.0/binary-cuda-9.1.85
     module load libs/cudnn/7.0/binary-cuda-8.0.44
+    module load libs/cudnn/6.0/binary-cuda-8.0.44
     module load libs/cudnn/5.1/binary-cuda-8.0.44
     module load libs/cudnn/5.1/binary-cuda-7.5.18
 

--- a/sharc/software/modulefiles/libs/CUDA/9.1.85/binary
+++ b/sharc/software/modulefiles/libs/CUDA/9.1.85/binary
@@ -1,0 +1,29 @@
+#%Module1.0#####################################################################
+##
+## cuda 9.1.85 module file
+##
+################################################################################
+
+## Module file logging
+source /usr/local/etc/module_logging.tcl
+
+proc ModulesHelp { } {
+        global vers
+        puts stderr "	Adds `Nvidia Cuda-$vers' to your PATH environment variable and necessary libraries"
+}
+
+set vers      9.1.85
+set shortvers 9.1
+
+
+module-whatis   "Loads the necessary `cuda-$vers' library paths"
+
+set prefix /usr/local/packages/libs/CUDA/$vers/binary
+
+setenv       CUDA_DIR        $prefix/cuda
+setenv       CUDA_HOME       $prefix/cuda
+setenv	     CUDA_SDK	     [format "%s/samples/NVIDIA_CUDA-%s_Samples" $prefix $shortvers]
+
+prepend-path PATH            $prefix/cuda/bin
+prepend-path LD_LIBRARY_PATH $prefix/cuda/lib
+prepend-path LD_LIBRARY_PATH $prefix/cuda/lib64

--- a/sharc/software/modulefiles/libs/cudnn/7.0/binary-cuda-8.0.44
+++ b/sharc/software/modulefiles/libs/cudnn/7.0/binary-cuda-8.0.44
@@ -1,0 +1,30 @@
+#%Module1.0#####################################################################
+##
+## cuDNN 7.0 module file for CUDA 8.0.44
+##
+################################################################################
+
+## Module file logging
+source /usr/local/etc/module_logging.tcl
+##
+
+proc ModulesHelp { } {
+        global version
+
+        puts stderr "	Adds `Nvidia cuDNN-$cudnnvers and CUDA $cudavers' to your PATH environment variable 
+}
+
+set cudnnvers 7.0
+set cudavers  8.0.44
+
+module-whatis   "loads the necessary `cuDNN-$cudnnvers and CUDA $cudavers' library paths"
+
+module load libs/CUDA/$cudavers/binary
+
+set CUDNN_DIR /usr/local/packages/libs/cudnn/$cudnnvers/binary-cuda-$cudavers/cuda
+
+prepend-path C_INCLUDE_PATH $CUDNN_DIR/include/
+prepend-path CPLUS_INCLUDE_PATH $CUDNN_DIR/include/
+prepend-path LD_LIBRARY_PATH $CUDNN_DIR/lib64/
+prepend-path CPATH $CUDNN_DIR/include/
+prepend-path LIBRARY_PATH $CUDNN_DIR/lib64/

--- a/sharc/software/modulefiles/libs/cudnn/7.0/binary-cuda-8.0.44
+++ b/sharc/software/modulefiles/libs/cudnn/7.0/binary-cuda-8.0.44
@@ -9,19 +9,21 @@ source /usr/local/etc/module_logging.tcl
 ##
 
 proc ModulesHelp { } {
-        global version
+        global cudnnvers
+        global cudavers
 
         puts stderr "	Adds `Nvidia cuDNN-$cudnnvers and CUDA $cudavers' to your PATH environment variable 
 }
 
 set cudnnvers 7.0
 set cudavers  8.0.44
+set cudashortvers  8.0
 
 module-whatis   "loads the necessary `cuDNN-$cudnnvers and CUDA $cudavers' library paths"
 
 module load libs/CUDA/$cudavers/binary
 
-set CUDNN_DIR /usr/local/packages/libs/cudnn/$cudnnvers/binary-cuda-$cudavers/cuda
+set CUDNN_DIR /usr/local/packages/libs/cudnn/$cudnnvers/binary-cuda-$cudashortvers/cuda
 
 prepend-path C_INCLUDE_PATH $CUDNN_DIR/include/
 prepend-path CPLUS_INCLUDE_PATH $CUDNN_DIR/include/

--- a/sharc/software/modulefiles/libs/cudnn/7.0/binary-cuda-9.1.85
+++ b/sharc/software/modulefiles/libs/cudnn/7.0/binary-cuda-9.1.85
@@ -1,0 +1,30 @@
+#%Module1.0#####################################################################
+##
+## cuDNN 7.0 module file for CUDA 9.1.85
+##
+################################################################################
+
+## Module file logging
+source /usr/local/etc/module_logging.tcl
+##
+
+proc ModulesHelp { } {
+        global version
+
+        puts stderr "	Adds `Nvidia cuDNN-$cudnnvers and CUDA $cudavers' to your PATH environment variable 
+}
+
+set cudnnvers 7.0
+set cudavers  9.1.85
+
+module-whatis   "loads the necessary `cuDNN-$cudnnvers and CUDA $cudavers' library paths"
+
+module load libs/CUDA/$cudavers/binary
+
+set CUDNN_DIR /usr/local/packages/libs/cudnn/$cudnnvers/binary-cuda-$cudavers/cuda
+
+prepend-path C_INCLUDE_PATH $CUDNN_DIR/include/
+prepend-path CPLUS_INCLUDE_PATH $CUDNN_DIR/include/
+prepend-path LD_LIBRARY_PATH $CUDNN_DIR/lib64/
+prepend-path CPATH $CUDNN_DIR/include/
+prepend-path LIBRARY_PATH $CUDNN_DIR/lib64/

--- a/sharc/software/modulefiles/libs/cudnn/7.0/binary-cuda-9.1.85
+++ b/sharc/software/modulefiles/libs/cudnn/7.0/binary-cuda-9.1.85
@@ -9,19 +9,21 @@ source /usr/local/etc/module_logging.tcl
 ##
 
 proc ModulesHelp { } {
-        global version
+        global cudnnvers
+        global cudavers
 
         puts stderr "	Adds `Nvidia cuDNN-$cudnnvers and CUDA $cudavers' to your PATH environment variable 
 }
 
 set cudnnvers 7.0
 set cudavers  9.1.85
+set cudashortvers  9.1
 
 module-whatis   "loads the necessary `cuDNN-$cudnnvers and CUDA $cudavers' library paths"
 
 module load libs/CUDA/$cudavers/binary
 
-set CUDNN_DIR /usr/local/packages/libs/cudnn/$cudnnvers/binary-cuda-$cudavers/cuda
+set CUDNN_DIR /usr/local/packages/libs/cudnn/$cudnnvers/binary-cuda-$cudashortvers/cuda
 
 prepend-path C_INCLUDE_PATH $CUDNN_DIR/include/
 prepend-path CPLUS_INCLUDE_PATH $CUDNN_DIR/include/


### PR DESCRIPTION
Install CUDA 9.1, CuDNN 7.0 for CUDA 9.1 and for CUDA 8.0:
- [x] write install scripts
- [x] write modulefiles
- [x] update docs
- [x] test - built and ran several CUDA example progs 
- [x] deploy

Also, 
- [x] note which versions of CUDA require which versions of GCC.
- [x] ensure that CUDA module files on ShARC are mutually exclusive.