### PR TITLE
Give scheduler page a more meaningful title.

### DIFF
--- a/hpc/scheduler/index.rst
+++ b/hpc/scheduler/index.rst
@@ -1,7 +1,7 @@
 .. _scheduler:
 
-Scheduler
-=========
+Using interactive sessions / submitting batch jobs
+==================================================
 
 .. toctree::
     :hidden:


### PR DESCRIPTION
At present, it's all too easy to glance over http://docs.hpc.shef.ac.uk/en/latest/hpc/ and not find the links to the pages on starting interactive sessions and submitting batch jobs. Thanks @annakrystalli for pointing this out.