### PR TITLE
Document ShARC rse-interactive.q

### DIFF
--- a/sharc/groupnodes/big_mem_nodes.rst
+++ b/sharc/groupnodes/big_mem_nodes.rst
@@ -17,42 +17,55 @@ Requesting Access
 
 The nodes are managed by the `RSE group <http://rse.shef.ac.uk>`_ and are available by request to all research groups belonging to the Computer Science Department.
 
-To use the nodes you must join the ``rse`` Grid Engine (scheduler) *Access Control List* (ACL i.e. user group) and submit jobs using the ``rse`` Grid Engine Project.
+To use the nodes you must 
+
+#. Be made a member of the ``rse`` Grid Engine (scheduler) *Access Control List* (ACL i.e. user group);
+#. Submit jobs using the ``rse`` Grid Engine *Project*;
+#. Start interactive jobs in ``rse-interactive.q`` Grid Engine *Cluster Queue*;
+#. Start batch jobs in the ``rse.q`` Grid Engine *Cluster Queue*;
 
 To join this ACL please email `RSE enquiries <rse@shef.ac.uk>`_.
 
-Requesting a node
------------------
+Running an interactive session
+------------------------------
 
 Once you have obtained permission to use the nodes you can request an interactive session on one of the nodes using:
 
 .. code-block:: bash
 
-	qrshx -P rse 
+	qrshx -P rse -q rse-interactive.q
 
 Here ``-P rse`` specifies that you want to use the ``rse`` project for your session, 
 which gives you access to these big memory nodes and 
-ensures that your interactive session runs in the ``rse.q`` job queue 
+ensures that your interactive session can run in the ``rse-interactive.q`` job queue 
 (as can be seen if you subsequently run ``qstat -u $USER`` from within your session).
 
-Submitting jobs
----------------
+The ``rse-interactive.q`` job queue has a maximum job runtime (``h_rt``) of four hours, 
+as is standard for interactive jobs on SHARC.
 
-Jobs can be submitted to the nodes by adding the ``-P rse`` parameter. For example, create a job script named ``my_job_script.sh`` with the contents:
+Submitting batch jobs
+---------------------
+
+Jobs can be submitted to the nodes by adding the ``-P rse`` and ``-q rse.q`` parameters. 
+For example, create a job script named ``my_job_script.sh`` with the contents:
 
 .. code-block:: bash
 
 	#!/bin/bash
 	#$ -P rse 
+	#$ -q rse.q
 
 	echo "Hello world"
 
-You can of course add more options to the script such as a request for additional RAM (e.g. `` $# -l rmem=10G``).
+You can of course add more options to the script such as a request for additional RAM (e.g. ``$# -l rmem=10G``).
 
-Run your script with the ``qsub`` command ::
+Run your script with the ``qsub`` command:
+
+.. code-block:: bash
 
 	qsub my_job_script.sh
 
-You can use the ``qstat`` command to check the status of your current job. An output file is created in your home directory that captures your script's outputs.
+You can use the ``qstat`` command to check the status of your current job. 
+An output file is created in your home directory that captures your script's outputs.
 
 See :ref:`sge-queue` for more information on job submission and the Sun Grid Engine scheduler.

--- a/sharc/groupnodes/dgx-1.rst
+++ b/sharc/groupnodes/dgx-1.rst
@@ -19,32 +19,37 @@ The node managed by the `RSE group <http://rse.shef.ac.uk>`_ and is available by
 
 To use the DGX-1 you must join the computer science RSE group and submit jobs to the RSE queue. To join this group please email `Twin Karmakharm <t.karmakharm@sheffield.ac.uk>`_  or `RSE enquiries <rse@shef.ac.uk>`_.
 
-Requesting a DGX-1 node
------------------------
+Starting an interactive session
+-------------------------------
 
 Once you have obtained permission to use the node, to request an interactive DGX-1 node, type: ::
 
-	qrshx -l gpu=1 -P rse -q rse.q
+	qrshx -l gpu=1 -P rse -q rse-interactive.q
 
-You will then be placed in a special RSE queue that has the DGX-1. The parameter ``-l gpu=1`` determines the number of GPUs that will be used in the job (maximum of 8), ``-P rse -q rse.q`` then denotes that you run the job under the ``rse`` project with the ``rse.q`` queue.  Note that the parameter ``-l gpu=`` is required otherwise you will be placed on a different node without a GPU (big memory node).
+You will then be placed in a special RSE queue that has the DGX-1. The parameter ``-l gpu=1`` determines the number of GPUs that will be used in the job (maximum of 8), ``-P rse -q rse.q`` then denotes that you run the job under the ``rse`` project with the ``rse-interactive.q`` queue (which is for interactive jobs that can run for up to 8 hours).  Note that the parameter ``-l gpu=`` is required otherwise you will be placed on a one of the RSE team's CPU-only nodes.
 
-Submitting jobs
----------------
+Submitting batch jobs
+---------------------
 
-Jobs can be submitted to the DGX-1 by adding the ``-l gpu=1 -P rse -q rse.q`` parameters. For example, create a job script named ``my_job_script.sh`` with the contents: ::
+Batch Jobs can be submitted to the DGX-1 by adding the ``-l gpu=1 -P rse -q rse.q`` parameters (note the different argument to ``-q``). 
+For example, create a job script named ``my_job_script.sh`` with the contents: ::
 
 	#!/bin/bash
-	#$ -l gpu=1 -P rse -q rse.q
+	#$ -l gpu=1 
+        #$ -P rse 
+        #$ -q rse.q
 
 	echo "Hello world"
 
-In the second line of the script ``#$ -l gpu=1`` you can add more options such as memory request ``-l rmem=10G`` or to be put on the DGX-1 queue ``-P rse -q rse.q``.
+You can add additional lines beneath ``#$ -q rse.q`` to request addtional resources e.g. ``-l rmem=10G``  to request 10GB RAM per CPU core rather than the default.
 
 Run your script with the ``qsub`` command ::
 
 	qsub my_job_script.sh
 
 You can use ``qstat`` command to check the status of your current job. An output file is created in your home directory that captures your script's outputs.
+
+Note that the maximum run-time for jobs submitted to the (batch job only) ``rse.q`` is four days, as is standard for batch jobs on ShARC.
 
 See :ref:`sge-queue` for more information on job submission and the Sun Grid Engine scheduler.
 


### PR DESCRIPTION
I've created a separate RSE job queue so that we can have one queue for short (`h_rt=08:00:00`) interactive jobs (`rse-interactive.q) and another queue for longer (`h_rt=96:00:00`) batch jobs (`rse.q`).  Having two cluster queues is necessary as Grid Engine doesn't allow for the `h_rt` associated with a single cluster queue to vary depending on whether a batch or interactive job has been submitted.   