### PR TITLE
repast hpc on sharc: rst file, install script, module file

### DIFF
--- a/sharc/software/apps/repast_hpc.rst
+++ b/sharc/software/apps/repast_hpc.rst
@@ -1,0 +1,58 @@
+Repast HPC
+==========
+
+.. sidebar:: Repast HPC
+
+   :Version: 2.2.0
+   :Dependencies: Modules loaded for GCC 6.2.0 compiler and Open MPI 2.1.1
+   :URL: https://repast.github.io/
+   :Documentation: https://repast.github.io/docs.html
+
+
+The Repast Suite is a family of advanced, free, and open source agent-based modeling and simulation platforms that have collectively been under continuous development for over 15 years:
+Repast for High Performance Computing 2.2.0, released on 30 September 2016, is a lean and expert-focused C++-based modeling system that is designed for use on large computing clusters and supercomputers. 
+
+
+Usage
+-----
+
+Repast HPC 2.2.0 can be activated using the module file::
+
+    module load apps/repast_hpc/2.2.0/gcc-6.2-openmpi-2.1.1
+
+Note that the above module file also loads GCC 6.2.0 and Open MPI 2.1.1.
+
+
+Batch jobs
+----------
+
+Users are encouraged to write their own batch submission scripts. The following is an example batch submission script, ``my_job.sh``, to run the ``zombie_model`` example in parallel and which is submitted to the queue by typing ``qsub my_job.sh``. ::
+
+    #!/bin/bash
+    #$ -cwd
+    #$ -l h_rt=06:00:00
+    #$ -l rmem=2G
+    #$ -pe mpi 4
+
+    module load apps/repast_hpc/2.2.0/gcc-6.2-openmpi-2.1.1
+
+    export repastroot=/usr/local/packages/apps/repast_hpc/2.2.0/gcc-6.2-openmpi-2.1.1
+
+    cp $repastroot/bin/zombie/* .
+
+    mpirun ./zombie_model config.props model.props
+
+The script requests four CPU cores using the MPI parallel environment ``mpi`` with 2 GB of real memory per CPU core. The requested runtime is 6 hours.
+
+
+Installation notes
+------------------
+
+Repast HPC 2.2.0 was installed using the
+:download:`install_repast_hpc.sh </sharc/software/install_scripts/apps/repast_hpc/2.2.0/gcc-6.2-openmpi-2.1.1/install_repast_hpc.sh>` installation script.
+The module file is
+:download:`/usr/local/modulefiles/apps/repast_hpc/2.2.0/gcc-6.2-openmpi-2.1.1 </sharc/software/modulefiles/apps/repast_hpc/2.2.0/gcc-6.2-openmpi-2.1.1>`.
+
+Third-party software required by Repast HPC 2.2.0 (Curl 7.42.1, NetCDF 4.2.1.1, NetCDF-CXX 4.2 and Boost 1.61.0) were installed in ``/usr/local/packages/apps/repast_hpc/2.2.0/third-party`` using the GCC 6.2.0 compiler with Open MPI 2.1.1.
+
+The installation of Repast HPC 2.2.0 was tested by running the example batch submission script (above).

--- a/sharc/software/install_scripts/apps/repast_hpc/2.2.0/gcc-6.2-openmpi-2.1.1/install_repast_hpc.sh
+++ b/sharc/software/install_scripts/apps/repast_hpc/2.2.0/gcc-6.2-openmpi-2.1.1/install_repast_hpc.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+# This is a template script for building and installing software on sharc.
+# You should use it to document how you install things.
+# You will need to configure any module loads the build needs and then 
+# configure the variables for the build.
+# This script will then create the directories you need and download and unzip
+# the source in to the build dir.
+
+
+############################# Module Loads ###################################
+module load mpi/openmpi/2.1.1/gcc-6.2
+
+############################## Variable Setup ################################
+version=2.2.0
+prefix1=/usr/local/packages/apps/repast_hpc/$version/gcc-6.2-openmpi-2.1.1
+prefix2=/usr/local/packages/apps/repast_hpc/$version/third-party
+build_dir=/scratch/$USER/repast_hpc
+
+filename=repast_hpc-2.2.0.tgz
+baseurl=https://github.com/Repast/repast.hpc/releases/download/v2.2.0
+
+# Set this to 'sudo' if you want to create the install dir using sudo.
+#sudo='sudo'
+
+
+##############################################################################
+# This should not need modifying
+##############################################################################
+
+# Create the build dir
+
+if [ ! -d $build_dir ]
+then
+    mkdir -p $build_dir
+fi
+
+cd $build_dir
+
+# Create the install directory
+if [ ! -d $prefix1 ]
+then
+   mkdir -p $prefix1
+   chown $USER:app-admins $prefix1
+fi 
+
+if [ ! -d $prefix2 ]
+then
+   mkdir -p $prefix2
+   chown $USER:app-admins $prefix2
+fi 
+
+# Download the source
+if [ -e $filename ]                                               
+then                                                                            
+  echo "Install tarball exists. Download not required."                         
+else                                                                            
+  echo "Downloading source" 
+  wget $baseurl/$filename
+fi
+
+##############################################################################
+
+##############################################################################
+# Installation (Write the install script here)
+##############################################################################
+
+tar -xvf $filename
+cd repast_hpc-2.2.0/MANUAL_INSTALL
+
+# Edit install.sh so that lines 7, 8 and 9 read as follows
+# BASE_DIR=$prefix2
+# VERSION=$version
+# REPAST_DIR=$prefix1
+
+# Install Curl, NetCDF (incl. NetCDF-CXX) and Boost in third-party dir. $prefix2
+./install.sh curl
+./install.sh netcdf
+./install.sh boost
+# Install Repast HPC in $prefix1
+./install.sh rhpc
+
+chmod -R g+w /usr/local/packages/apps/repast_hpc/$version
+

--- a/sharc/software/modulefiles/apps/repast_hpc/2.2.0/gcc-6.2-openmpi-2.1.1
+++ b/sharc/software/modulefiles/apps/repast_hpc/2.2.0/gcc-6.2-openmpi-2.1.1
@@ -1,0 +1,25 @@
+#%Module1.0#####################################################################
+##
+## Repast HPC 2.2.0 module file
+##
+#  By David M. Rogers March 2018
+#################################################################################
+
+## Module file logging
+source /usr/local/etc/module_logging.tcl
+
+set vers 2.2.0
+
+proc ModulesHelp { } {
+        global vers
+
+        puts stderr "	Adds Repast HPC $vers code to your PATH environment"
+}
+module-whatis "	Adds Repast HPC $vers code to your PATH environment"
+
+module load mpi/openmpi/2.1.1/gcc-6.2
+
+set repastpath /usr/local/packages/apps/repast_hpc/$vers/gcc-6.2-openmpi-2.1.1
+set thirdpartypath /usr/local/packages/apps/repast_hpc/$vers/third-party
+
+prepend-path LD_LIBRARY_PATH $thirdpartypath/Boost/Boost_1.61/lib:$repastpath/lib


### PR DESCRIPTION
Installation of Repast HPC 2.2.0 on Sharc.