### PR TITLE
Deprecate older NAG compilers on ShARC 

### DIFF
--- a/sharc/software/modulefiles/dev/NAG/6.0
+++ b/sharc/software/modulefiles/dev/NAG/6.0
@@ -1,20 +1,26 @@
 #%Module1.0#####################################################################
-##
-## NAG Fortran Compiler module file
-##
+#
+# NAG Fortran Compiler module file
+#
 
 # Module file logging
 source /usr/local/etc/module_logging.tcl
 
 proc ModulesHelp { } {
         global nagvers
-        puts stderr "Makes the NAG Fortran Compiler vnagvers available"
+        puts stderr "Makes the NAG Fortran Compiler $nagvers available"
 }
+
+conflict dev/NAG
 
 set nagvers 6.0
 set nagroot /usr/local/packages/dev/NAG/$nagvers
 
 module-whatis   "Makes the NAG Fortran Compiler v$nagvers available"
+
+if { [ module-info mode load ] } {
+    puts stderr "Note: '$curMod' is deprecated on this system."
+}
 
 prepend-path PATH $nagroot/bin
 prepend-path MANPATH $nagroot/man

--- a/sharc/software/modulefiles/dev/NAG/6.0
+++ b/sharc/software/modulefiles/dev/NAG/6.0
@@ -18,8 +18,9 @@ set nagroot /usr/local/packages/dev/NAG/$nagvers
 
 module-whatis   "Makes the NAG Fortran Compiler v$nagvers available"
 
+set curMod [module-info name]
 if { [ module-info mode load ] } {
-    puts stderr "Note: '$curMod' is deprecated on this system."
+     puts stderr "Note: '$curMod' is deprecated on this system."
 }
 
 prepend-path PATH $nagroot/bin

--- a/sharc/software/modulefiles/dev/NAG/6.1
+++ b/sharc/software/modulefiles/dev/NAG/6.1
@@ -8,13 +8,19 @@ source /usr/local/etc/module_logging.tcl
 
 proc ModulesHelp { } {
         global nagvers
-        puts stderr "Makes the NAG Fortran Compiler vnagvers available"
+        puts stderr "Makes the NAG Fortran Compiler $nagvers available"
 }
+
+conflict dev/NAG
 
 set nagvers 6.1
 set nagroot /usr/local/packages/dev/NAG/$nagvers
 
 module-whatis   "Makes the NAG Fortran Compiler v$nagvers available"
+
+if { [ module-info mode load ] } {
+    puts stderr "Note: '$curMod' is deprecated on this system."
+}
 
 prepend-path PATH $nagroot/bin
 prepend-path MANPATH $nagroot/man

--- a/sharc/software/modulefiles/dev/NAG/6.1
+++ b/sharc/software/modulefiles/dev/NAG/6.1
@@ -18,8 +18,9 @@ set nagroot /usr/local/packages/dev/NAG/$nagvers
 
 module-whatis   "Makes the NAG Fortran Compiler v$nagvers available"
 
+set curMod [module-info name]
 if { [ module-info mode load ] } {
-    puts stderr "Note: '$curMod' is deprecated on this system."
+     puts stderr "Note: '$curMod' is deprecated on this system."
 }
 
 prepend-path PATH $nagroot/bin

--- a/sharc/software/modulefiles/dev/NAG/6.2
+++ b/sharc/software/modulefiles/dev/NAG/6.2
@@ -8,8 +8,10 @@ source /usr/local/etc/module_logging.tcl
 
 proc ModulesHelp { } {
         global nagvers
-        puts stderr "Makes the NAG Fortran Compiler vnagvers available"
+        puts stderr "Makes the NAG Fortran Compiler $nagvers available"
 }
+
+conflict dev/NAG
 
 set nagvers 6.2
 set nagroot /usr/local/packages/dev/NAG/$nagvers


### PR DESCRIPTION
* Warn users at 'module load' time that older NAG Fortran Compilers are deprecated (currently unlicensed).  
* Prevent multiple modules under `dev/NAG` from being loaded simultaneously.