### PR TITLE
documentation for cctools - used to provide access to cvmfs

### DIFF
--- a/iceberg/software/apps/cctools.rst
+++ b/iceberg/software/apps/cctools.rst
@@ -1,0 +1,59 @@
+.. _cctools-iceberg:
+
+cctools
+=======
+
+.. sidebar:: cctools
+
+   :Latest Version: 6.2.10
+   :URL: http://ccl.cse.nd.edu/software/download
+
+The Cooperative Computing Tools (cctools) contains Parrot, Chirp, Makeflow, Work Queue, SAND, and other software.
+
+Interactive Usage
+-----------------
+After connecting to Iceberg (see :ref:`ssh`), start an interactive session with the `qrsh` or `qrshx` command.
+
+The default version of cctools is made available with the command ::
+
+        module load apps/binapps/cctools
+
+Alternatively, you can explicitly load a specific version using::
+
+       module load apps/binapps/cctools/6.2.10
+
+
+Accessing CernVM-FS
+-------------------
+
+`parrot_run` provided by cctools can be used to provide access to `CernVM-FS <http://cernvm.cern.ch/portal/filesystem/parrot>`_ 
+
+e.g. to access the Atlas CernVM-FS repo ::
+
+ parrot_run bash
+
+ ls /cvmfs/atlas.cern.ch/repo
+
+ LibCvmfs version 2.4, revision 25
+
+ ATLASLocalRootBase  benchmarks  conditions  containers  dev  images  sw  tools
+
+The environment variable ``PARROT_CVMFS_ALIEN_CACHE`` is used to specify the location for the CVMFS cache.
+
+By default the cctools module will set ``PARROT_CVMFS_ALIEN_CACHE`` to your ``/data`` directory.  You can override this behavior by setting ``PARROT_CVMFS_ALIEN_CACHE`` to another location.  
+
+The environment variable ``PARROT_CVMFS_REPO`` can be used to add other repositories.
+
+For more info on using the parrot connector see `CernVM-FS documentation <http://cernvm.cern.ch/portal/filesystem/parrot>`_ 
+
+
+Installation notes
+------------------
+These are primarily for administrators of the system.
+
+**cctools 6.2.10**
+
+#. Download the cctools tarball (``cctools-6.2.10-x86_64-redhat6.tar.gz``)  `from CCL <http://ccl.cse.nd.edu/software/download>`_.
+#. Save this file to ``/usr/local/media/cctools/6.2.10/``
+#. Install cctools using :download:`this script </iceberg/software/install_scripts/apps/cctools/6.2.10/binary/install.sh>`
+#. Install :download:`this modulefile </iceberg/software/modulefiles/apps/binapps/cctools/6.2.10>` as ``/usr/local/modulefiles/apps/binapps/cctools/6.2.10``

--- a/iceberg/software/install_scripts/apps/cctools/6.2.10/binary/install.sh
+++ b/iceberg/software/install_scripts/apps/cctools/6.2.10/binary/install.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Install script used to install cctools on Iceberg
+# Requires tar file to be available in /usr/local/media/cctools
+
+###############
+# Set variables
+###############
+VERS=6.2.10
+
+MEDIA_DIR="/usr/local/media/cctools/${VERS}"
+TARBALL_FNAME="cctools-${VERS}-x86_64-redhat6.tar.gz"
+TARBALL_FPATH="${MEDIA_DIR}/${TARBALL_FNAME}"
+
+INSTALL_DIR="/usr/local/packages6/cctools/${VERS}/binary"
+
+################
+# Error handling
+################
+handle_error () {
+    errcode=$? # save the exit code as the first thing done in the trap function 
+    echo "error $errorcode" 
+    echo "the command executing at the
+    time of the error was" echo "$BASH_COMMAND" 
+    echo "on line ${BASH_LINENO[0]}"
+    # do some error handling, cleanup, logging, notification $BASH_COMMAND
+    # contains the command that was being executed at the time of the trap
+    # ${BASH_LINENO[0]} contains the line number in the script of that command
+    # exit the script or return to try again, etc.
+    exit $errcode  # or use some other value or do return instead 
+}
+trap handle_error ERR
+
+if [[ ! -f $TARBALL_FPATH ]]; then
+    echo "Could not find cctools tarball at: ${TARBALL_FPATH}; exiting." 2>&1 
+    exit -1
+fi
+
+mkdir -m 2775 -p $INSTALL_DIR
+chown -R ${USER}:app-admins $INSTALL_DIR
+cd $INSTALL_DIR
+
+if [[ ! -f bin/parrot_run ]]; then
+    tar -zxf $TARBALL_FPATH
+    mv cctools-${VERS}-x86_64-redhat6/* .
+    rmdir cctools-${VERS}-x86_64-redhat6
+fi
+
+chmod -R g+w $INSTALL_DIR

--- a/iceberg/software/modulefiles/apps/binapps/cctools/6.2.10
+++ b/iceberg/software/modulefiles/apps/binapps/cctools/6.2.10
@@ -1,0 +1,25 @@
+#%Module10.2#####################################################################
+
+## Module file logging
+source /usr/local/etc/module_logging.tcl
+##
+
+
+proc ModulesHelp { } {
+    global helpmsg
+    puts stderr "\t$helpmsg\n"
+}
+
+
+set version 6.2.10
+set installpath /usr/local/packages6/cctools/$version/binary
+set user $::env(USER)
+
+module-whatis "Provides cctools version $version"
+set helpmsg "cctools version $version"
+prepend-path PATH $installpath/bin
+prepend-path MANPATH $installpath/share/man
+
+if {![info exists ::env(PARROT_CVMFS_ALIEN_CACHE)] } {
+setenv PARROT_CVMFS_ALIEN_CACHE /data/$user/cvmfs_cache
+}


### PR DESCRIPTION
Docs, install script and module file for cctools on Iceberg.