### PR TITLE
Update FLAME GPU library information to reflect FLAME GPU 1.5.0

### DIFF
--- a/iceberg/software/libs/FLAMEGPU.rst
+++ b/iceberg/software/libs/FLAMEGPU.rst
@@ -22,9 +22,9 @@ To install FLAME GPU you should checkout the latest master branch of the code wh
 
     git clone https://github.com/FLAMEGPU/FLAMEGPU.git
 
-To compile the FLAME GPU examples you will need to be on a GPU node. You can start an interactive session using ::
+To run the FLAME GPU examples you will need to be on a GPU node. You can start an interactive session using ::
 
-    qsh -l gpu=1 --l gpu_arch=nvidia-k40m -l rmem=13G
+    qrshx -l gpu=1 -l gpu_arch=nvidia-k40m -l rmem=13G
 
 You will then need to load the relevant modules ::
 
@@ -37,7 +37,7 @@ You can now navigate to the FLAME GPU examples folder and build the examples. e.
     cd FLAMEGPU/examples
     make console
 
-or to build a single example in console mode ::
+Building the full suite of examples can take a while, instead you may wish to build individual examples. eg. to build a single example in console mode ::
 
     cd FLAMEGPU/examples/GameOfLife
     make console

--- a/iceberg/software/libs/FLAMEGPU.rst
+++ b/iceberg/software/libs/FLAMEGPU.rst
@@ -1,4 +1,6 @@
-.. _flamegpu_iceberg:
+.. _flamegpu_sharc:
+
+.. highlight:: bash
 
 FLAMEGPU
 ========
@@ -6,6 +8,8 @@ FLAMEGPU
 .. sidebar:: FLAME GPU
 
    :URL: http://www.flamegpu.com/
+   :Docs: http://docs.flamegpu.com/
+   :GitHub: https://github.com/FLAMEGPU/FLAMEGPU
 
 `FLAMEGPU <http://www.flamegpu.com>`_ is a multi agent simulation framework developed at the University of Sheffield.
 It uses GPUs to accelerate the simulation of multiagent systems but abstracts the GPU architecture away from users so that they can write models using a high level of abstraction (without having to write GPU code).
@@ -13,7 +17,6 @@ It uses GPUs to accelerate the simulation of multiagent systems but abstracts th
 
 Installing FLAMEGPU on Iceberg
 ------------------------------
-
 
 To install FLAME GPU you should checkout the latest master branch of the code which has Linux support ::
 
@@ -25,24 +28,40 @@ To compile the FLAME GPU examples you will need to be on a GPU node. You can sta
 
 You will then need to load the relevant modules ::
 
-    module load libs/cuda/7.5.18
+    module load libs/cuda/8.0.44
     module load compilers/gcc/4.9.2
 
-FLAMEGPU allows you to specify a ``CUDA_PATH`` environment variable so that you can change the CUDA version easily. To set this for the CUDA 7.5 module use ::
 
-    export CUDA_PATH=/usr/local/packages6/libs/binlibs/CUDA/7.5.18/cuda
-
-You can now navigate to the FLAME GPU examples folder and build the examples. e.g. ::
+You can now navigate to the FLAME GPU examples folder and build the examples. e.g. to build all the examples in console mode ::
 
     cd FLAMEGPU/examples
-    make
+    make console
 
-You can now run the console versions of the example models by navigating to ``FLAMEGPU/bin/x64`` and calling the appropriate shell script. e.g. ::
+or to build a single example in console mode ::
 
-    cd ../..
-    cd bin/x64
-    ./Boids_BruteForce_console.sh
+    cd FLAMEGPU/examples/GameOfLife
+    make console
+
+You can now run the console versions of the example models by navigating to ``FLAMEGPU/bin/x64`` and calling the appropriate shell script. e.g. from the ``FLAMEGPU/examples/GameOfLife`` directory ::
+
+    ../../bin/linux-x64/GameOfLife_console.sh
+
+or by manually running the executable with the appropriate command line arguments. e.g. from the ``FLAMEGPU/examples/GameOfLife`` directory ::
+
+   ../../bin/linux-x64/Release_Console/GameOfLife iterations/0.xml 1
+
+
 
 FLAME GPU will run the example for one iteration and output the model state to a file ``1.xml`` in the model's iterations directory.
 
-Visualisation currently does not work with X forwarding as FLAME GPU uses complex rendering techniques which are not supported. A solution using VirtualGL is in progress.
+Visualisation currently does not work with X forwarding as FLAME GPU uses complex rendering techniques which are not supported.
+
+
+For more information please see the `FLAME GPU Documentation <http://docs.flamegpu.com>`_. 
+Additional information on compiling FLAME GPU examples can be found via :: 
+    
+    make help
+
+And additional information on the command line arguments via :: 
+
+    ../../bin/linux-x64/Release_Console/GameOfLife --help

--- a/sharc/software/libs/FLAMEGPU.rst
+++ b/sharc/software/libs/FLAMEGPU.rst
@@ -1,11 +1,16 @@
 .. _flamegpu_sharc:
 
+.. highlight:: bash
+
 FLAMEGPU
 ========
 
 .. sidebar:: FLAME GPU
 
    :URL: http://www.flamegpu.com/
+   :Docs: http://docs.flamegpu.com/
+   :GitHub: https://github.com/FLAMEGPU/FLAMEGPU
+
 
 `FLAMEGPU <http://www.flamegpu.com>`_ is a multi agent simulation framework developed at the University of Sheffield.
 It uses GPUs to accelerate the simulation of multiagent systems but abstracts the GPU architecture away from users so that they can write models using a high level of abstraction (without having to write GPU code).
@@ -24,24 +29,40 @@ To compile the FLAME GPU examples you will need to be on a GPU node. You can sta
 
 You will then need to load the relevant modules ::
 
-    module load libs/CUDA/8.0.44/binary
+    module load libs/CUDA/9.1.85/binary
     module load dev/gcc/4.9.4
 
-FLAMEGPU allows you to specify a ``CUDA_PATH`` environment variable so that you can change the CUDA version easily. To set this for the CUDA 8.0.44 module use ::
 
-    export CUDA_PATH=/usr/local/packages/libs/CUDA/8.0.44/binary/cuda
-
-You can now navigate to the FLAME GPU examples folder and build the examples. e.g. ::
+You can now navigate to the FLAME GPU examples folder and build the examples. e.g. to build all the examples in console mode ::
 
     cd FLAMEGPU/examples
-    make
+    make console
 
-You can now run the console versions of the example models by navigating to ``FLAMEGPU/bin/x64`` and calling the appropriate shell script. e.g. ::
+or to build a single example in console mode ::
 
-    cd ../..
-    cd bin/x64
-    ./Boids_BruteForce_console.sh
+    cd FLAMEGPU/examples/GameOfLife
+    make console
+
+You can now run the console versions of the example models by navigating to ``FLAMEGPU/bin/x64`` and calling the appropriate shell script. e.g. from the ``FLAMEGPU/examples/GameOfLife`` directory ::
+
+    ../../bin/linux-x64/GameOfLife_console.sh
+
+or by manually running the executable with the appropriate command line arguments. e.g. from the ``FLAMEGPU/examples/GameOfLife`` directory ::
+
+   ../../bin/linux-x64/Release_Console/GameOfLife iterations/0.xml 1
+
+
 
 FLAME GPU will run the example for one iteration and output the model state to a file ``1.xml`` in the model's iterations directory.
 
-Visualisation currently does not work with X forwarding as FLAME GPU uses complex rendering techniques which are not supported. A solution using VirtualGL is in progress.
+Visualisation currently does not work with X forwarding as FLAME GPU uses complex rendering techniques which are not supported.
+
+
+For more information please see the `FLAME GPU Documentation <http://docs.flamegpu.com>`_. 
+Additional information on compiling FLAME GPU examples can be found via :: 
+    
+    make help
+
+And additional information on the command line arguments via :: 
+
+    ../../bin/linux-x64/Release_Console/GameOfLife --help

--- a/sharc/software/libs/FLAMEGPU.rst
+++ b/sharc/software/libs/FLAMEGPU.rst
@@ -23,7 +23,7 @@ To install FLAME GPU you should checkout the latest master branch of the code wh
 
     git clone https://github.com/FLAMEGPU/FLAMEGPU.git
 
-To compile the FLAME GPU examples you will need to be on a GPU node. You can start an interactive session using ::
+To run the FLAME GPU examples you will need to be on a GPU node. You can start an interactive session using ::
 
     qrshx -l gpu=1 -P gpu -l rmem=15G
 
@@ -38,7 +38,7 @@ You can now navigate to the FLAME GPU examples folder and build the examples. e.
     cd FLAMEGPU/examples
     make console
 
-or to build a single example in console mode ::
+Building the full suite of examples can take a while, instead you may wish to build individual examples. eg. to build a single example in console mode ::
 
     cd FLAMEGPU/examples/GameOfLife
     make console


### PR DESCRIPTION
FLAME GPU 1.5.0 has been released with (relatively) significant changes to linux compilation, hence an update of the documentation to reflect this is worthwhile. 