### PR TITLE
ShARC: ensure BOOST_ROOT set in Boost modulefile

### DIFF
--- a/sharc/software/modulefiles/libs/boost/1.64.0/gcc-4.9.4
+++ b/sharc/software/modulefiles/libs/boost/1.64.0/gcc-4.9.4
@@ -24,6 +24,7 @@ module-whatis puts stderr "Makes the Boost $vers library (plus $compiler $compil
 
 set BOOST_DIR /usr/local/packages/libs/boost/$vers/$compiler-$compilervers
 
+setenv BOOST_ROOT $BOOST_DIR
 prepend-path LD_LIBRARY_PATH $BOOST_DIR/lib
 prepend-path CPLUS_INCLUDE_PATH $BOOST_DIR/include
 prepend-path LIBRARY_PATH $BOOST_DIR/lib


### PR DESCRIPTION
Backstory:

User: "I am trying to run make for a program that requires boost. I have the boost module loaded but I still get this error from cmake":

```
CMake Error at /usr/local/packages/dev/cmake/3.7.1/gcc-4.9.4/share/cmake-3.7/Modules/FindBoost.cmake:1793 (message):
  Unable to find the requested Boost libraries.

  Unable to find the Boost header files.  Please set BOOST_ROOT to the root
  directory containing Boost or BOOST_INCLUDEDIR to the directory containing
  Boost's headers.
```
Me:  "CMake doesn't seem to pick up the location of the Boost headers from
`CPLUS_INCLUDE_PATH` (`CPLUS_INCLUDE_PATH` is prepended to when you load
the `libs/boost/1.64.0/gcc-4.9.4` modulefile).

Try running

```sh
export BOOST_ROOT=/usr/local/packages/libs/boost/1.64.0/gcc-4.9.4/
```

before re-running cmake.  Works for me with the examples in
https://github.com/alexott/boost-asio-examples."
