### PR TITLE
Fix ansys modulefiles on Iceberg so do not load custom GL lib

### DIFF
--- a/iceberg/software/apps/ansys.rst
+++ b/iceberg/software/apps/ansys.rst
@@ -17,7 +17,8 @@ The Ansys suite of programs can be used to numerically simulate a large variety 
 
 Interactive usage
 -----------------
-After connecting to iceberg (see :ref:`ssh`),  start an interactive sesssion with the ``qsh`` command. Alternatively, if you require more memory, for example 16 GB, use the command ``qsh -l rmem=16G``.
+
+After connecting to iceberg (see :ref:`ssh`),  start an interactive sesssion with the ``qrshx`` command. Alternatively, if you require more memory, for example 16 GB, use the command ``qrshx -l rmem=16G``.
 
 To make the **default** version of ANSYS available (currently **version 16.1**), run the following: ::
 
@@ -59,7 +60,7 @@ Or the same for Fluent: ::
 The ``runfluent`` and ``runansys`` commands submit a Fluent journal or ANSYS input file into the batch system and can take a number of different parameters, according to your requirements. 
 
 runfluent command
-#################
+^^^^^^^^^^^^^^^^^
 
 Just typing ``runfluent`` will display information on how to use it: ::
 
@@ -164,3 +165,14 @@ Just typing ``runansys`` will display information on how to use it: ::
            runansys test1.dat -time 00:30:00 -mem 8G -rmem=3G -mail j.bloggs@shef.ac.uk
 
 **Note that the option** ``mem`` **has been deprecated and is no longer required.**
+
+Installation notes
+------------------
+
+None available.
+
+Module files
+^^^^^^^^^^^^
+
+* :download:`/usr/local/modulefiles/apps/ansys/17.2 </iceberg/software/modulefiles/apps/ansys/17.2>`.
+* :download:`/usr/local/modulefiles/apps/ansys/16.1 </iceberg/software/modulefiles/apps/ansys/16.1>`.

--- a/iceberg/software/modulefiles/apps/ansys/16.1
+++ b/iceberg/software/modulefiles/apps/ansys/16.1
@@ -1,0 +1,25 @@
+#%Module1.0#####################################################################
+# ANSYS 16.1 module file
+# 
+#  By Deniz Savas on  February 2015
+################################################################################
+
+# Module file logging
+source /usr/local/etc/module_logging.tcl
+
+proc ModulesHelp { } {
+    global vers
+    puts stderr "   Makes ANSYS $vers available for use"
+}
+
+set vers 16.1
+set shortvers 161
+set localroot     /usr/local/packages6/shef/ansys/batch:/usr/local/packages6/shef/ansys/
+set ANSYS_DIR     /usr/local/packages6/ansys/ansys_inc/v$shortvers
+
+module-whatis   "Makes ANSYS $vers available for use"
+
+setenv ANSYSROOT $ANSYS_DIR
+setenv ANSYSVER $shortvers
+setenv ANSWBCOMMAND $ANSYS_DIR/Framework/bin/Linux64/runwb2
+prepend-path PATH $localroot:$ANSYS_DIR/ansys/bin:$ANSYS_DIR/Framework/bin/Linux64/:$ANSYS_DIR/fluent/bin:$ANSYS_DIR/CFD-Post/bin:$ANSYS_DIR/CFX/bin:$ANSYS_DIR/Icepak/bin:$ANSYS_DIR/TurboGrid/bin:$ANSYS_DIR/polyflow/bin:$ANSYS_DIR/ansys/bin

--- a/iceberg/software/modulefiles/apps/ansys/17.2
+++ b/iceberg/software/modulefiles/apps/ansys/17.2
@@ -1,0 +1,26 @@
+#%Module1.0#####################################################################
+# ANSYS 17.2 module file
+# 
+#  By Deniz Savas on  October 2016
+################################################################################
+
+# Module file logging
+source /usr/local/etc/module_logging.tcl
+
+proc ModulesHelp { } {
+    global vers
+    puts stderr "   Makes ANSYS $vers available for use"
+}
+
+set vers 17.2
+set shortvers 172
+set localroot     /usr/local/packages6/shef/ansys/batch:/usr/local/packages6/shef/ansys/
+set ANSYS_DIR     /usr/local/packages6/ansys$shortvers/v$shortvers
+
+module-whatis   "Makes ANSYS $vers available for use"
+
+setenv ANSYSROOT $ANSYS_DIR
+setenv ANSYSVER $shortvers
+setenv ANSWBCOMMAND $ANSYS_DIR/Framework/bin/Linux64/runwb2
+setenv ICEM_ACN $ANSYS_DIR/icemcfd/linux64_amd
+prepend-path PATH $localroot:$ANSYS_DIR/ansys/bin:$ANSYS_DIR/Framework/bin/Linux64/:$ANSYS_DIR/fluent/bin:$ANSYS_DIR/CFD-Post/bin:$ANSYS_DIR/CFX/bin:$ANSYS_DIR/Icepak/bin:$ANSYS_DIR/TurboGrid/bin:$ANSYS_DIR/polyflow/bin:$ANSYS_DIR/Electronics/Linux64

--- a/sharc/software/apps/ansys.rst
+++ b/sharc/software/apps/ansys.rst
@@ -23,7 +23,7 @@ Ansys can be activated using the module files::
     module load apps/ansys/18.2/binary
     module load apps/ansys/19.0/binary
 
-The Ansys Workbench GUI executable is ``ansyswb``. ``ansyswb`` can be launched during an interactive session with X Window support (e.g. an interactive ``qsh`` session).
+The Ansys Workbench GUI executable is ``ansyswb``. ``ansyswb`` can be launched during an interactive session with X Window support (e.g. an interactive ``qrshx`` session).
 The Ansys exectuable is ``ansys`` and ``fluent`` is the executable for Fluent. Typing ``ansys -g`` or ``fluent -g -help`` will display a list of usage options.
 
 


### PR DESCRIPTION
Attempts to run Ansys 16.1 and 17.2 on Iceberg using X forwarding or TigerVNC + VirtualGL fail with something like

```
ICEM_ACN is "/usr/local/packages6/ansys/ansys_inc/v161/icemcfd/linux64_amd".
args =
Window information: depth = 24
                    class = 4
visual depth = 24 class = 4
Xlib:  extension "NV-GLX" missing on display "iceberg-login3.shef.ac.uk:10.0".
X Error of failed request:  BadValue (integer parameter out of range for operation)
  Major opcode of failed request:  149 (GLX)
  Minor opcode of failed request:  3 (X_GLXCreateContext)
  Value in failed request:  0x0
  Serial number of failed request:  4834
  Current serial number in output stream:  4835
Exit from ICEM CFD
```

*Not* prepending `LD_LIBRARY_PATH` with a custom GL lib addresses the issue.