### PR TITLE
Fix typo in conda pkg name

### DIFF
--- a/hpc/jupyterhub/conda.rst
+++ b/hpc/jupyterhub/conda.rst
@@ -114,7 +114,7 @@ R:
 
 .. code-block:: sh
 
-   conda create -n example-r-env python=3.6 r-irkernel jupyter_client libiconf
+   conda create -n example-r-env python=3.6 r-irkernel jupyter_client libiconv
 
 Python from the `Intel Python Distribution <https://software.intel.com/en-us/distribution-for-python>`__:
 


### PR DESCRIPTION
Conda pkg name is `iconv`, not `iconf`.  Referenced in docs on Jupyter+ShARC