### PR TITLE
Update Tensorflow page to specify an older version of tensorflow

### DIFF
--- a/sharc/software/apps/tensorflow.rst
+++ b/sharc/software/apps/tensorflow.rst
@@ -14,7 +14,7 @@ About Tensorflow on ShARC
 
 **A GPU-enabled worker node must be requested in order to use the GPU version of this software. See** :ref:`GPUComputing_sharc` **for more information.**
 
-Tensorlfow is available on ShARC as both Singularity images and by local installation.
+Tensorflow is available on ShARC as both Singularity images and by local installation.
 
 As Tensorflow and all its dependencies are written in Python, it can be installed locally in your home directory. The use of Anaconda (:ref:`sharc-python-conda`) is recommended as it is able to create a virtual environment in your home directory, allowing the installation of new Python packages without admin permission.
 
@@ -25,7 +25,7 @@ This software and documentation is maintained by the `RSES group <http://rse.she
 Installation in Home Directory - CPU Version
 --------------------------------------------
 
-In order to to install to your home directory, Conda is used to create a virtual python enviroment for installing your local version of Tensorflow.
+In order to to install to your home directory, Conda is used to create a virtual python environment for installing your local version of Tensorflow.
 
 First request an interactive session, e.g. with :ref:`qrshx`.
 
@@ -111,14 +111,14 @@ Which gives the following results ::
 CUDA and CUDNN Import Errors
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Tensorflow releases depend on specific versions of both CUDA and CUDNN. If the wrong CUDNN module is loaded, you may recieve an :code:`ImportError` runtime errors such as: 
+Tensorflow releases depend on specific versions of both CUDA and CUDNN. If the wrong CUDNN module is loaded, you may receive an :code:`ImportError` runtime errors such as: 
 
 .. code-block :: python
 
    ImportError: libcublas.so.10.0: cannot open shared object file: No such file or directory
 
 
-This indicates that Tensorflow was expecting to find CUDA 10.0 (and an appropraite version of CUDNN) but was unable to do so.
+This indicates that Tensorflow was expecting to find CUDA 10.0 (and an appropriate version of CUDNN) but was unable to do so.
 
 The following table shows the which module to load for the various versions of Tensorflow, based on the `tested build configurations <https://www.tensorflow.org/install/source#linux>`_. Newer versions may require more recent CUDA and CUDNN releases. 
 

--- a/sharc/software/apps/tensorflow.rst
+++ b/sharc/software/apps/tensorflow.rst
@@ -64,7 +64,7 @@ Then GPU version of Tensorflow can be installed by the following ::
   module load apps/python/conda
 
   #Load the CUDA and cuDNN module
-  module load libs/cudnn/7.3.1.20/binary-cuda-9.0.176
+  module load libs/cudnn/7.5.0.56/binary-cuda-10.0.130
 
   #Create an conda virtual environment called 'tensorflow-gpu'
   conda create -n tensorflow-gpu python=3.6
@@ -75,6 +75,7 @@ Then GPU version of Tensorflow can be installed by the following ::
   #Install GPU version of Tensorflow
   pip install tensorflow-gpu
 
+If you wish to use an older version of tensorflow-gpu, you can do so using :code:`pip install tensorflow-gpu==<version_number>`
 
 **Every Session Afterwards and in Your Job Scripts**
 
@@ -107,6 +108,31 @@ Which gives the following results ::
 	[[ 22.  28.]
 	 [ 49.  64.]]
 
+CUDA and CUDNN Import Errors
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Tensorflow releases depend on specific versions of both CUDA and CUDNN. If the wrong CUDNN module is loaded, you may recieve an :code:`ImportError` runtime errors such as: 
+
+.. code-block :: python
+
+   ImportError: libcublas.so.10.0: cannot open shared object file: No such file or directory
+
+
+This indicates that Tensorflow was expecting to find CUDA 10.0 (and an appropraite version of CUDNN) but was unable to do so.
+
+The following table shows the which module to load for the various versions of Tensorflow, based on the `tested build configurations <https://www.tensorflow.org/install/source#linux>`_. Newer versions may require more recent CUDA and CUDNN releases. 
+
++------------+------+--------+--------------------------------------------+
+| Tensorflow | CUDA | CUDNN  | Module                                     | 
++============+======+========+============================================+
+| >= 1.13.1  | 10.0 | >= 7.4 | `libs/cudnn/7.5.0.56/binary-cuda-10.0.130` |
++------------+------+--------+--------------------------------------------+
+| >= 1.5.0   |  9.0 | 7      | `libs/cudnn/7.3.1.20/binary-cuda-9.0.176`  |
++------------+------+--------+--------------------------------------------+
+| >= 1.3.0   |  8.0 | 6      | `libs/cudnn/6.0/binary-cuda-8.0.44`        |
++------------+------+--------+--------------------------------------------+
+| >= 1.0.0   |  8.0 | 5.1    | `libs/cudnn/5.1/binary-cuda-8.0.44`        |
++------------+------+--------+--------------------------------------------+
 
 
 

--- a/themes/tuos/static/iceberg.css
+++ b/themes/tuos/static/iceberg.css
@@ -34,6 +34,10 @@ cite {
     background-color: #ecf0f1;
     font-family: monospace;
 }
+/* Do not change the background colour of citations / code snippets within admonitions which change backround and text colour. There are many of these (note, warning etc) so this is the simplest fix */
+.admonition cite {
+    background: inherit;
+}
 
 .note {
     background-color: #333132;


### PR DESCRIPTION
Tensorflow >= 1.13.0 require CUDA 10.0 and CUDNN >= 7.4.1. CUDNN is not yet available, so installation instructions are modified to use the working verison.

Additionally a small CSS change is made, to produce legible text when using inline-code within an admonition (i.e. warning, note etc).