### PR TITLE
DGX-1: update access and resource limit info

### DIFF
--- a/sharc/groupnodes/big_mem_nodes.rst
+++ b/sharc/groupnodes/big_mem_nodes.rst
@@ -20,19 +20,26 @@ Specifications
 Requesting Access
 -----------------
 
-The nodes are managed by the `RSE group <https://rse.shef.ac.uk>`_ and 
-are available by request to all research groups belonging to the Computer Science Department 
-plus their collaborators.
+Access to the node is managed by the `RSE team <https://rse.shef.ac.uk>`_. Access policy:
 
-To use the nodes you must 
+* PhD students, researchers and staff in Computer Science can all request access to the nodes.
+* Access to others who are collaborating on projects with some Computer Science / RSE involvement
+  can be made on a case-by-case basis.
+* Access to Computer Science MSc students
+  can be made on a case-by-case basis.
+
+A number of other users were granted access before this policy was developed.
+
+To request access complete `this Google Form <https://docs.google.com/forms/d/19j8enPCALohamEWk-jkjnwYRiLbI2DMMWMqSJhAbE_I/edit>`__
+and someone within the RSE team will then respond with further information.
+
+To use the nodes you must:
 
 #. Be made a member of the ``rse`` Grid Engine (scheduler) *Access Control List* (ACL i.e. user group);
 #. Submit jobs using the ``rse`` Grid Engine *Project*;
 #. Start interactive jobs in ``rse-interactive.q`` Grid Engine *Cluster Queue*;
 #. Start batch jobs in the ``rse.q`` Grid Engine *Cluster Queue*;
-
-To join this ACL please complete `this Google Form <https://docs.google.com/forms/d/19j8enPCALohamEWk-jkjnwYRiLbI2DMMWMqSJhAbE_I/>`_.
-
+   
 Running an interactive session
 ------------------------------
 

--- a/sharc/groupnodes/dgx-1.rst
+++ b/sharc/groupnodes/dgx-1.rst
@@ -3,7 +3,12 @@
 Nvidia DGX-1 [COM]
 ==================
 
-The Nvidia DGX-1 is the world's first Deep Learning supercomputer. It is equipped with 8 Tesla P100 GPUs connected together with NVLink technology to provide super fast inter-GPU communication. Capable of performing 170 Teraflops of computation, it can provide up to 75 times speed up on training deep neural networks compared to the latest Intel Xeon CPU.
+   The Nvidia DGX-1 is the world's first Deep Learning supercomputer.
+   It is equipped with 8 Tesla P100 GPUs
+   connected together with NVLink technology to provide super fast inter-GPU communication.
+   Capable of performing 170 TeraFLOPs of computation,
+   it can provide up to 75 times speed up on training deep neural networks 
+   compared to the latest Intel Xeon CPU.
 
 DGX-1 Specifications
 --------------------
@@ -12,48 +17,75 @@ DGX-1 Specifications
 * Dual 20-core Intel Xeon E5-2698 v4 2.2 GHz
 * 512 GB System RAM
 
+.. note::
+
+   One GPU is faulty; only 7 GPUs are currently usable.
+
 Requesting Access
 -----------------
 
-The node managed by the `RSE group <https://rse.shef.ac.uk>`_ and is available by request to all research groups belonging to the Computer Science Department.
-
-To use the DGX-1 you must join the computer science RSE group and submit jobs to the RSE queue. To join this group please email `Twin Karmakharm <t.karmakharm@sheffield.ac.uk>`_  or `RSE enquiries <rse@shef.ac.uk>`_.
+Same as per the :ref:`COM big memory nodes <big_mem_com_groupnodes_sharc>`.
 
 Starting an interactive session
 -------------------------------
 
-Once you have obtained permission to use the node, to request an interactive DGX-1 node, type: ::
+Once you have been granted access to the RSE nodes in ShARC, 
+to request an interactive session (interactive job) on the DGX-1 node with a single GPU, 
+type:
 
-	qrshx -l gpu=1 -P rse -q rse-interactive.q
+.. code-block:: sh
 
-You will then be placed in a special RSE queue that has the DGX-1. The parameter ``-l gpu=1`` determines the number of GPUs that will be used in the job (maximum of 8), ``-P rse -q rse.q`` then denotes that you run the job under the ``rse`` project with the ``rse-interactive.q`` queue (which is for interactive jobs that can run for up to 8 hours).  Note that the parameter ``-l gpu=`` is required otherwise you will be placed on a one of the RSE team's CPU-only nodes.
+   qrshx -l gpu=1 -P rse -q rse-interactive.q
+
+* ``-l gpu=1`` denotes the number of GPUs that will be used in the job (maximum of 7), 
+  This is required otherwise the job will be placed on a one of the RSE team's CPU-only nodes.
+* ``-P rse -q rse.q`` denotes that the job will be submitted under the ``rse`` Project and 
+  you want it to only run in the ``rse-interactive.q`` job queue,
+  which is for interactive jobs that can run for up to 8 hours.
+
+.. note::
+
+   You are limited to at most 1 GPU over all your jobs on the DGX-1 that do not run in the ``rse.q`` (batch-job-only) job queue.
+   This is to encourage users to prefer batch jobs over interactive sessions on the DGX-1, 
+   as batch jobs make more efficient use of resources.
 
 Submitting batch jobs
 ---------------------
 
-Batch Jobs can be submitted to the DGX-1 by adding the ``-l gpu=1 -P rse -q rse.q`` parameters (note the different argument to ``-q``). 
-For example, create a job script named ``my_job_script.sh`` with the contents: ::
+Batch jobs can be submitted to the DGX-1 by 
+adding lines containing ``-l gpu``, ``-P rse`` and ``-q rse.q`` 
+to your job submission script (note the different argument to ``-q``). 
 
-	#!/bin/bash
-	#$ -l gpu=1 
-        #$ -P rse 
-        #$ -q rse.q
+For example, create a job script named ``my_job_script.sh`` with the contents:
 
-	echo "Hello world"
+.. code-block:: sh
 
-You can add additional lines beneath ``#$ -q rse.q`` to request addtional resources e.g. ``-l rmem=10G``  to request 10GB RAM per CPU core rather than the default.
+   #!/bin/bash
+   #$ -l gpu=1 
+   #$ -P rse 
+   #$ -q rse.q
 
-Run your script with the ``qsub`` command ::
+   echo "Hello world"
 
-	qsub my_job_script.sh
+You can add additional lines beneath ``#$ -q rse.q`` to request additional resources 
+e.g. ``-l rmem=10G``  to request 10GB RAM per CPU core rather than the default.
 
-You can use ``qstat`` command to check the status of your current job. An output file is created in your home directory that captures your script's outputs.
+Run your script with the ``qsub`` command:
 
-Note that the maximum run-time for jobs submitted to the (batch job only) ``rse.q`` is four days, as is standard for batch jobs on ShARC.
+.. code-block:: sh
+
+   qsub my_job_script.sh
+
+You can use ``qstat`` command to check the status of your current job. 
+An output file is created in your home directory that captures your script's outputs.
+
+Note that the maximum run-time for jobs submitted to the (batch job only) ``rse.q`` is four days, 
+as is standard for batch jobs on ShARC.
 
 See :ref:`submit-queue` for more information on job submission and the Sun Grid Engine scheduler.
 
 Deep Learning on the DGX-1
 --------------------------
 
-Many popular Deep Learning packages are available to use on the DGX-1 and the ShARC cluster. Please see :ref:`DeepLearning_sharc` for more information.
+Many popular Deep Learning packages are available to use on the DGX-1 and the ShARC cluster. 
+Please see :ref:`DeepLearning_sharc` for more information.


### PR DESCRIPTION
Need to make users aware that now at most 1 GPU can be reserved per user across all jobs running on the node *not* in the (batch only) `rse.q`. 