### PR TITLE
Fix links to RSE blog posts

### DIFF
--- a/iceberg/software/apps/maple.rst
+++ b/iceberg/software/apps/maple.rst
@@ -43,7 +43,7 @@ For general information on how to submit batch jobs refer to :ref:`submit-batch`
 
 Tutorials
 ---------
-* `High Performance Computing with Maple <https://rse.shef.ac.uk/blog/HPC-Maple-1/>`_ A tutorial from the Sheffield Research Software Engineering group on how to use Maple in a High Performance Computing environment
+* `High Performance Computing with Maple <https://rse.shef.ac.uk/blog/hpc-maple-1/>`_ A tutorial from the Sheffield Research Software Engineering group on how to use Maple in a High Performance Computing environment
 
 Installation notes
 ------------------

--- a/sharc/software/apps/intel_r.rst
+++ b/sharc/software/apps/intel_r.rst
@@ -13,7 +13,7 @@ This version of R is built using the :ref:`Intel compilers <iceberg_intel_compil
 the Intel Math Kernel Library. 
 This combination can result in significantly faster runtimes in certain circumstances.
 For more details of what is made faster, 
-see `this blog post <https://rse.shef.ac.uk/blog/intel-R-iceberg/>`_ 
+see `this blog post <https://rse.shef.ac.uk/blog/intel-r-iceberg/>`_
 which was written back when we built this version of R for the first time on Sheffield's old HPC system, Iceberg.
 
 Most R extensions are written and tested for the gcc suite of compilers so 

--- a/sharc/software/apps/maple.rst
+++ b/sharc/software/apps/maple.rst
@@ -42,7 +42,7 @@ For general information on how to submit batch jobs refer to :ref:`submit-batch`
 
 Tutorials
 ---------
-* `High Performance Computing with Maple <https://rse.shef.ac.uk/blog/HPC-Maple-1/>`_ A tutorial from the Sheffield Research Software Engineering group on how to use Maple in a High Performance Computing environment
+* `High Performance Computing with Maple <https://rse.shef.ac.uk/blog/hpc-maple-1/>`_ A tutorial from the Sheffield Research Software Engineering group on how to use Maple in a High Performance Computing environment
 
 Installation notes
 ------------------


### PR DESCRIPTION
A maple user pointed out the link to the tutorial on the RSE blog was incorrect. 

I have fixed the three incorrect links.

This is likely due to the RSE blog migrating form nikola to jekyll (which is case sensitive or only uses lower case slugs)