### PR TITLE
Travis config: do not test that can build a PDF; remove mention of PDF from README

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,11 @@
 language: python
 cache: pip
-
 sudo: false
-
-addons:
-    apt:
-        packages:
-            - texlive
-            - texlive-full
-            - dvipng
-            - graphviz
-            - pandoc
-
-env:
-  matrix:
-    - BUILD_CMD='html'
-    - BUILD_CMD='latexpdf'
-            
 python:
     - 3.6
-
 virtualenv:
      system_site_packages: false
-
 install:
     - pip install -r requirements.txt
-
 script:
-    - mkdir -p _build/latex/
-    - bash get_newfloat.sty.sh ./_build/latex/
-    - make $BUILD_CMD
+    - make html

--- a/README.rst
+++ b/README.rst
@@ -12,10 +12,7 @@ For a guide on the rst file format see `this <http://thomas-cokelaer.info/tutori
 
 Rendered Documentation
 ----------------------
-Two versions of the documentation are currently automatically built from this repository:
-
-* `A website <https://docs.hpc.shef.ac.uk/en/latest/>`_.
-* `A .pdf document <https://readthedocs.org/projects/iceberg/downloads/pdf/latest/>`_.
+`This website <https://docs.hpc.shef.ac.uk/en/latest/>`_  is currently automatically built from this repository.
 
 How to Contribute
 -----------------
@@ -52,17 +49,6 @@ Building the documentation on a local Windows machine
    Or if you don't have the ``make`` utility installed on your machine then build with *sphinx* directly: ::
 
     sphinx-build . ./html
-
-#. If you want to build the PDF documentation you will need:
-
-    * `GNU Make <http://gnuwin32.sourceforge.net/packages/make.htm>`_
-    * `MikTeX <http://miktex.org/download>`_
-
-   Then from the command line, the following will build the ``.pdf`` file: ::
-
-    make latexpdf
-
-   On first run, MikTeX will prompt you to install various extra LaTeX packages.
 
 Building the documentation on a local Linux machine
 ###################################################


### PR DESCRIPTION
PDF version of docs is of limited value and most of the runtime of our CI jobs is spent downloading and installing LaTeX then building the PDF.

Can revert this commit if we later decide we really want PDF builds of the docs.