### PR TITLE
Fixes mistake in CUDA architecture docs

### DIFF
--- a/bessemer/software/libs/cuda.rst
+++ b/bessemer/software/libs/cuda.rst
@@ -114,13 +114,13 @@ allows for 'fatbinary' executables that are optimised for multiple device archit
 Each ``-gencode`` argument requires two values, 
 the *virtual architecture* and *real architecture*, 
 for use in NVCC's `two-stage compilation <https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#virtual-architectures>`_.
-I.e. ``-gencode=arch=compute_60,code=sm_60`` specifies a virtual architecture of ``compute_60`` and real architecture ``sm_60``.
+I.e. ``-gencode=arch=compute_70,code=sm_70`` specifies a virtual architecture of ``compute_70`` and real architecture ``sm_70``.
 
 To support future hardware of higher compute capability, 
 an additional ``-gencode`` argument can be used to enable Just in Time (JIT) compilation of embedded intermediate PTX code. 
 This argument should use the highest virtual architecture specified in other gencode arguments 
 for both the ``arch`` and ``code``
-i.e. ``-gencode=arch=compute_60,code=sm_60``.
+i.e. ``-gencode=arch=compute_70,code=compute_70``.
 
 The minimum specified virtual architecture must be less than or equal to the `Compute Capability <https://developer.nvidia.com/cuda-gpus>`_ of the GPU used to execute the code.
 

--- a/iceberg/software/libs/cuda.rst
+++ b/iceberg/software/libs/cuda.rst
@@ -106,7 +106,7 @@ To support future hardware of higher compute capability,
 an additional ``-gencode`` argument can be used to enable Just in Time (JIT) compilation of embedded intermediate PTX code. 
 This argument should use the highest virtual architecture specified in other gencode arguments 
 for both the ``arch`` and ``code``
-i.e ``-gencode=arch=compute_20,code=sm_20``.
+i.e ``-gencode=arch=compute_20,code=compute_20``.
 
 The minimum specified virtual architecture must be less than or equal to the `Compute Capability <https://developer.nvidia.com/cuda-gpus>`_ of the GPU used to execute the code.
 

--- a/sharc/software/libs/cuda.rst
+++ b/sharc/software/libs/cuda.rst
@@ -107,7 +107,7 @@ To support future hardware of higher compute capability,
 an additional ``-gencode`` argument can be used to enable Just in Time (JIT) compilation of embedded intermediate PTX code. 
 This argument should use the highest virtual architecture specified in other gencode arguments 
 for both the ``arch`` and ``code``
-i.e. ``-gencode=arch=compute_60,code=sm_60``.
+i.e. ``-gencode=arch=compute_60,code=compute_60``.
 
 The minimum specified virtual architecture must be less than or equal to the `Compute Capability <https://developer.nvidia.com/cuda-gpus>`_ of the GPU used to execute the code.
 


### PR DESCRIPTION
Fixes a small mistake in the CUDA documentation pages for enabling JIT compilation for higher compute capability architectures.

Also updates the example code for bessemer gencodes to only refer to compute capabaility 70, to reduce the chance of confusion