### PR TITLE
Bessemer: add 2019b editions of foss, fosscuda and intel EasyBuild toolchains

### DIFF
--- a/bessemer/software/development/cmake.rst
+++ b/bessemer/software/development/cmake.rst
@@ -8,13 +8,16 @@ CMake is a build tool commonly used when compiling other libraries.
 Usage
 -----
 
-CMake can be loaded with: ::
+CMake can be loaded with one of: ::
 
-    module load CMake/3.13.3-GCCcore-8.2.0
+   module load CMake/3.15.3-GCCcore-8.3.0  # compatible with foss-2019b toolchain
+   module load CMake/3.13.3-GCCcore-8.2.0  # compatible with foss-2019a toolchain
+   module load CMake/3.11.4-GCCcore-7.3.0  # compatible with foss-2018b toolchain
+   module load CMake/3.12.1-GCCcore-7.3.0  # compatible with foss-2018b toolchain
+   module load CMake/3.9.5-GCCcore-6.4.0
 
-
-CMake has a run-time dependency on `libstdc++` so the above also needs to
-(and does) load the :ref:`GCC compiler <gcc_bessemer>` version 8.2.0,
+CMake has a run-time dependency on `libstdc++` so the cmake module files 
+depend on and load particular versions of the :ref:`GCC compiler <gcc_bessemer>`,
 plus versions of the ncurses, zlib, bzip2 and cURL libraries.
 
 Usage of CMake often involves: 

--- a/bessemer/software/development/gcc.rst
+++ b/bessemer/software/development/gcc.rst
@@ -14,8 +14,9 @@ After connecting to Bessemer,  start an interactive sessson: ::
 then choose the version of the compiler you wish to use
 by running *one* of the following lines: ::
 
-   module load GCC/8.2.0-2.31.1
-   module load GCC/7.3.0-2.30  
+   module load GCC/8.3.0  # part of the foss-2019b toolchain
+   module load GCC/8.2.0-2.31.1  # part of the foss-2019a toolchain
+   module load GCC/7.3.0-2.30  # part of the foss-2018b toolchain
 
 Confirm that you've loaded the version of gcc you wanted using ``gcc -v``.
 

--- a/bessemer/software/development/icc_ifort.rst
+++ b/bessemer/software/development/icc_ifort.rst
@@ -5,31 +5,23 @@ Intel Compilers
 
 Intel has compilers for C (icc), C++ (icpc) and Fortran (ifort).
 
-To activate icc/icpc, 
-first connect to Bessemer, 
-start an interactive session: ::
+To activate *both* the C/C++ and Fortran compilers use one of: ::
 
-   srun --pty bash -i
+   module load iccifort/2019.5.281  # subset of intel-2019b EasyBuild toolchain
+   module load iccifort/2019.1.144-GCC-8.2.0-2.31.1  # subset of intel-2019a toolchain
 
-then run: :: 
+Which implicitly also load versions of the :ref:`GCC <gcc_bessemer>` compiler.
 
-   module load icc/2019.1.144-GCC-8.2.0-2.31.1
+For older versions of the ``intel`` EasyBuild toolchain you can also load icc/icpc and ifort independently using one of: ::
 
-which implicitly loads :ref:`GCC <gcc_bessemer>` 8.2.0, which is a dependency.
+   module load icc/2019.1.144-GCC-8.2.0-2.31.1  # subset of intel-2019a toolchain
+   module load ifort/2019.1.144-GCC-8.2.0-2.31.1  # subset of intel-2019a toolchain
+
+Again, versions of the :ref:`GCC <gcc_bessemer>` compiler are implicitly loaded.
 
 Confirm that you've loaded the version of icc/icpc you require: ::
 
    icc -v
-
-To instead activate ifort you need the following ``module load`` command: ::
-
-   module load ifort/2019.1.144-GCC-8.2.0-2.31.1
-
-which also implicitly loads :ref:`GCC <gcc_bessemer>` 8.2.0.
-
-To load *both* icc/icpc *and* ifort: ::
-
-   module load iccifort/2019.1.144-GCC-8.2.0-2.31.1
 
 Documentation
 -------------

--- a/bessemer/software/development/toolchains.rst
+++ b/bessemer/software/development/toolchains.rst
@@ -32,7 +32,9 @@ Dependency versions for toolchains
 See the `EasyBuild documentation for dependency versions for foss and intel <https://easybuild.readthedocs.io/en/latest/Common-toolchains.html#overview-of-common-toolchains>`__
 
 ``fosscuda-2019a`` has the same dependencies as ``foss-2019a`` plus 
-CUDA 10.1
+CUDA 10.1.
+``fosscuda-2019b`` has the same dependencies as ``foss-2019b`` plus 
+CUDA 10.1 update 1.
 
 Sub-toolchains
 --------------

--- a/bessemer/software/libs/cuda.rst
+++ b/bessemer/software/libs/cuda.rst
@@ -31,13 +31,15 @@ As with much software installed on the cluster,
 versions of CUDA are activated via the :ref:`'module load' command<env_modules>`.
 
 To load CUDA 10.1 plus 
-the :ref:`GCC <gcc_bessemer>` 8.2.0 compiler, OpenMPI, OpenBLAS, SCALAPACK and FFTW: ::
+the :ref:`GCC <gcc_bessemer>` 8.x compiler, OpenMPI, OpenBLAS, SCALAPACK and FFTW: ::
 
+   module load fosscuda/2019b  
    module load fosscuda/2019a  
 
-To load *just* CUDA and :ref:`GCC <gcc_bessemer>` 8.2.0: ::
+To load *just* CUDA and :ref:`GCC <gcc_bessemer>` 8.x: ::
 
-   module load CUDA/10.1.105-GCC-8.2.0-2.31.1
+   module load CUDA/10.1.243-GCC-8.3.0  # subset of the fosscuda-2019b toolchain
+   module load CUDA/10.1.105-GCC-8.2.0-2.31.1  # subset of the fosscuda-2019a toolchain
 
 To load *just* CUDA 10.0: ::
 

--- a/bessemer/software/libs/fftw.rst
+++ b/bessemer/software/libs/fftw.rst
@@ -6,7 +6,7 @@ fftw
 .. sidebar:: fftw
 
    :Latest version: 3.3.8
-   :URL: http://www.fftw.org/
+   :URL: https://www.fftw.org/
 
 FFTW is a C subroutine library for
 computing the discrete Fourier transform (DFT)
@@ -18,16 +18,17 @@ i.e. the discrete cosine/sine transforms or DCT/DST).
 
 Usage
 -----
-To make this library available, run one the following.
+To make this library available, run one the following: ::
 
-To load FFTW plus the :ref:`gompi-2019a <bessemer_eb_toolchains>` toolchain: ::
-
+   module load FFTW/3.3.8-gompi-2019b
    module load FFTW/3.3.8-gompi-2019a
-
-To load FFTW plus the :ref:`gompic-2019a <bessemer_eb_toolchains>` toolchain: ::
-
-   module load FFTW/3.3.8-gompic-2019a
-
-To load FFTW plus the :ref:`gompi-2018b <bessemer_eb_toolchains>` toolchain: ::
-
    module load FFTW/3.3.8-gompi-2018b
+   module load FFTW/3.3.8-gompic-2019b
+   module load FFTW/3.3.8-gompic-2019a
+   module load FFTW/3.3.8-intel-2019a
+
+- `gompi` versions are a subset of the :ref:`foss toolchain <bessemer_eb_toolchains>`
+  and also load GCC and OpenMPI
+- `gompic` versions are a subset of the :ref:`fosscuda toolchain <bessemer_eb_toolchains>`
+  and also load GCC, OpenMPI and CUDA.
+- `intel` versions use an ``intel`` toolchain and load the Intel compilers and Intel MPI.

--- a/bessemer/software/libs/gsl.rst
+++ b/bessemer/software/libs/gsl.rst
@@ -5,7 +5,7 @@ GSL
 
 .. sidebar:: GSL
    
-   :Version: 2.5
+   :Version: 2.6
    :URL: https://www.gnu.org/software/gsl/
    :Documentation: https://www.gnu.org/software/gsl/doc/html/index.html
 
@@ -16,11 +16,13 @@ See `here <https://www.gnu.org/software/gsl/doc/html/intro.html>`__ for the type
 Usage
 -----
 
-The GSL library can be loaded activate: ::
+The GSL library can be loaded by running one of: ::
 
+   module load GSL/2.6-GCC-8.3.0
    module load GSL/2.5-GCC-8.2.0-2.31.1
 
-if you also want to activate or have already activated :ref:`GCC <gcc_bessemer>` 8.2.0, *or*: ::
+which will also load a particular :ref:`GCC <gcc_bessemer>`,
+*or*: ::
 
    module load GSL/2.5-iccifort-2019.1.144-GCC-8.2.0-2.31.1
 

--- a/bessemer/software/libs/hdf5.rst
+++ b/bessemer/software/libs/hdf5.rst
@@ -17,5 +17,6 @@ the :ref:`gompi or iimpi toolchain<bessemer_eb_toolchains>`
 (and the zlib and Szip libraries)
 run *one* of the following: ::
 
+   module load HDF5/1.10.5-gompi-2019b
    module load HDF5/1.10.5-gompi-2019a
    module load HDF5/1.10.5-iimpi-2019a

--- a/bessemer/software/libs/imkl.rst
+++ b/bessemer/software/libs/imkl.rst
@@ -19,8 +19,10 @@ FFTW functions from other math libraries.
 Usage
 -----
 
-The Intel MKL can be activated using: ::
+The Intel MKL can be activated using one of the following: ::
 
-   module load imkl/2019.1.144-iimpi-2019a
+   module load imkl/2019.5.281-iimpi-2019b  # subset of intel-2019b EasyBuild toolchain
+   module load imkl/2019.1.144-iimpi-2019a  # subset of intel-2019b EasyBuild toolchain
 
-which also loads the :ref:`iimpi-2019a <bessemer_eb_toolchains>` toolchain.
+which also implicitly loads a version of the :ref:`iimpi <bessemer_eb_toolchains>` toolchain, 
+itself being a subset of the ``intel`` toolchain.

--- a/bessemer/software/libs/openblas.rst
+++ b/bessemer/software/libs/openblas.rst
@@ -14,8 +14,10 @@ It also provides some optimised LAPACK routines.
 Usage
 -----
 
-OpenBLAS can be activated using: ::
+OpenBLAS can be activated using one of: ::
 
-   module load OpenBLAS/0.3.5-GCC-8.2.0-2.31.1
+   module load OpenBLAS/0.3.7-GCC-8.3.0  # foss-2019b toolchain
+   module load OpenBLAS/0.3.5-GCC-8.2.0-2.31.1  # foss-2019a toolchain
+   module load OpenBLAS/0.3.1-GCC-7.3.0-2.30  # foss-2018b toolchain
 
-which also loads :ref:`GCC <gcc_bessemer>` 8.2.0.
+which also loads a version of the :ref:`GCC <gcc_bessemer>` compiler.

--- a/bessemer/software/libs/scalapack.rst
+++ b/bessemer/software/libs/scalapack.rst
@@ -29,6 +29,10 @@ To load ScaLAPACK plus
 
 run *one* of the following: ::
 
+   module load ScaLAPACK/2.0.2-gompi-2019b
    module load ScaLAPACK/2.0.2-gompi-2019a-OpenBLAS-0.3.5
    module load ScaLAPACK/2.0.2-gompi-2018b-OpenBLAS-0.3.1
-   module load ScaLAPACK/2.0.2-gompic-2019a-OpenBLAS-0.3.5:
+   module load ScaLAPACK/2.0.2-gompic-2019b
+   module load ScaLAPACK/2.0.2-gompic-2019a-OpenBLAS-0.3.5
+
+Note that all load OpenBLAS, despite the change in the module naming convention for more recent toolchains.

--- a/bessemer/software/parallel/impi.rst
+++ b/bessemer/software/parallel/impi.rst
@@ -15,11 +15,12 @@ perform better on HPC clusters based on Intel® processors."
 Versions
 --------
 
-You can load a specific version using: ::
+You can load a specific version using one of the following: ::
 
-    module load impi/2018.4.274-iccifort-2019.1.144-GCC-8.2.0-2.31.1 
+   module use impi/2018.5.288-iccifort-2019.5.281  # subset of intel 2019b EasyBuild toolchain
+   module use impi/2018.4.274-iccifort-2019.1.144-GCC-8.2.0-2.31.1  # subset of intel 2019a EasyBuild toolchain
 
-which explicitly loads versions of icc, ifort (and GCC).
+which implicitly load versions of icc, ifort (and GCC).
 
 Example
 -------

--- a/bessemer/software/parallel/openmpi.rst
+++ b/bessemer/software/parallel/openmpi.rst
@@ -5,18 +5,22 @@ OpenMPI
 
 .. sidebar:: OpenMPI
 
-   :Latest Version: 3.1.3
+   :Latest Version: 3.1.4
    :Dependancies: gcc
-   :URL: http://www.open-mpi.org/
+   :URL: https://www.open-mpi.org/
 
-The Open MPI Project is an open source Message Passing Interface implementation that is developed and maintained by a consortium of academic, research, and industry partners. Open MPI is therefore able to combine the expertise, technologies, and resources from all across the High Performance Computing community in order to build the best MPI library available. Open MPI offers advantages for system and software vendors, application developers and computer science researchers.
+The OpenMPI Project is an open source Message Passing Interface implementation that is developed and maintained by a consortium of academic, research, and industry partners. OpenMPI is therefore able to combine the expertise, technologies, and resources from all across the High Performance Computing community in order to build the best MPI library available. OpenMPI offers advantages for system and software vendors, application developers and computer science researchers.
 
 Versions
 --------
 
-You can load a specific version using: ::
+You can load a specific version using one of the following: ::
 
-    module load OpenMPI/3.1.3-GCC-8.2.0-2.31.1
+   module load OpenMPI/3.1.1-GCC-7.3.0-2.30  # part of the foss-2018b toolchain
+   module load OpenMPI/3.1.3-GCC-8.2.0-2.31.1  # part of the foss-2019a toolchain
+   module load OpenMPI/3.1.3-gcccuda-2019a  # part of the fosscuda-2019a toolchain
+   module load OpenMPI/3.1.4-GCC-8.3.0  # part of the foss-2019b toolchain
+   module load OpenMPI/3.1.4-gcccuda-2019b  # part of the fosscuda-2019b toolchain
 
 See `here <https://mail-archive.com/announce@lists.open-mpi.org/msg00118.html>`__ for a brief guide to the new features in OpenMPI 3.x and `here <https://raw.githubusercontent.com/open-mpi/ompi/v3.1.x/NEWS>`__ for a detailed view of the changes between OpenMPI versions.
 


### PR DESCRIPTION
Currently deployed in the staging area.  