### PR TITLE
Correction to Tesla K80 node total GPU memory

### DIFF
--- a/sharc/cluster_specs.rst
+++ b/sharc/cluster_specs.rst
@@ -60,7 +60,7 @@ Two nodes are publicly available (not exclusive to research groups):
 * Local storage: 800 GiB SATA SSD
 * GPUs: 8 x `NVIDIA Tesla K80`_
 
-  * 24 GiB of GDDR5 memory (12 GiB per GPU; 192 GiB per node)
+  * 24 GiB of GDDR5 memory (12 GiB per GPU; 96 GiB per node)
   * Up to 2.91 Teraflops of double precision performance with NVIDIA GPU Boost
   * Up to 8.74 Teraflops of single precision performance with NVIDIA GPU Boost
 

--- a/sharc/cluster_specs.rst
+++ b/sharc/cluster_specs.rst
@@ -58,11 +58,11 @@ Two nodes are publicly available (not exclusive to research groups):
 * CPUs: 2 x Intel Xeon E5-2630 v3 (2.40GHz)
 * RAM: 64 GB (i.e. 4 GiB / core); 1866 MHz; DDR4
 * Local storage: 800 GiB SATA SSD
-* GPUs: 8 x `NVIDIA Tesla K80`_
+* GPUs: 8 x `NVIDIA Tesla K80`_ (4x dual-GPU accelerators)
 
-  * 24 GiB of GDDR5 memory (12 GiB per GPU; 96 GiB per node)
-  * Up to 2.91 Teraflops of double precision performance with NVIDIA GPU Boost
-  * Up to 8.74 Teraflops of single precision performance with NVIDIA GPU Boost
+  * 12 GiB of GDDR5 memory per GPU (24 GiB per accelerator; 96 GiB per node)
+  * Up to 1.46 Teraflops of double precision performance with NVIDIA GPU Boost per GPU (2.91 TFLOPS per accelerator)
+  * Up to 4.37 Teraflops of single precision performance with NVIDIA GPU Boost per GPU (8.74 TFLOPS per accelerator)
 
 Hardware-accellerated visualisation nodes
 -----------------------------------------


### PR DESCRIPTION
Each K80 PCI-e device contains 2 GPUs, each with 12GB of memory.
The public K80 nodes each contain 4 phyiscal devices, corresponding to 8 GPUs and 96GiB total device memory, rather than 192 as previously stated.

This can be seen via `nvidia-smi` (which reports 11441 MiB of usable device memory per GPU)

```
Thu Oct 18 16:19:50 2018       
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 396.37                 Driver Version: 396.37                    |
|-------------------------------+----------------------+----------------------+
| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
|===============================+======================+======================|
|   0  Tesla K80           Off  | 00000000:06:00.0 Off |                    0 |
| N/A   38C    P0    62W / 149W |      0MiB / 11441MiB |      0%      Default |
+-------------------------------+----------------------+----------------------+
|   1  Tesla K80           Off  | 00000000:07:00.0 Off |                    0 |
| N/A   46C    P0    73W / 149W |      0MiB / 11441MiB |      0%      Default |
+-------------------------------+----------------------+----------------------+
|   2  Tesla K80           Off  | 00000000:0A:00.0 Off |                    0 |
| N/A   35C    P0    61W / 149W |      0MiB / 11441MiB |      0%      Default |
+-------------------------------+----------------------+----------------------+
|   3  Tesla K80           Off  | 00000000:0B:00.0 Off |                    0 |
| N/A   43C    P0    76W / 149W |      0MiB / 11441MiB |      0%      Default |
+-------------------------------+----------------------+----------------------+
|   4  Tesla K80           Off  | 00000000:86:00.0 Off |                    0 |
| N/A   45C    P0    83W / 149W |  10920MiB / 11441MiB |     59%      Default |
+-------------------------------+----------------------+----------------------+
|   5  Tesla K80           Off  | 00000000:87:00.0 Off |                    0 |
| N/A   50C    P0    75W / 149W |      0MiB / 11441MiB |      0%      Default |
+-------------------------------+----------------------+----------------------+
|   6  Tesla K80           Off  | 00000000:8A:00.0 Off |                    0 |
| N/A   35C    P0    61W / 149W |      0MiB / 11441MiB |      0%      Default |
+-------------------------------+----------------------+----------------------+
|   7  Tesla K80           Off  | 00000000:8B:00.0 Off |                    0 |
| N/A   42C    P0    74W / 149W |      0MiB / 11441MiB |     97%      Default |
+-------------------------------+----------------------+----------------------+

```