### PR TITLE
Update for Ansys 20.1 and 20.2

### DIFF
--- a/bessemer/software/apps/ansys.rst
+++ b/bessemer/software/apps/ansys.rst
@@ -85,9 +85,13 @@ The following instruction should be inserted at line 2306 in ``anssh.ini``::
     setenv KMP_AFFINITY compact
 
 	
-Please note ANSYS 20.1 and 20.2 have been installed manually with the GUI in the following directory::
+Please note ANSYS 20.1 and 20.2 have been installed manually with the GUI in the following directories and permissions corrected as follows::
 	
-    /usr/local/packages/manual/ANSYS/
+    /usr/local/packages/manual/ANSYS/20.1/binary/
+    /usr/local/packages/manual/ANSYS/20.2/binary/
+	
+    chmod 775 -R /usr/local/packages/manual/ANSYS/20.1/binary/
+    chmod 775 -R /usr/local/packages/manual/ANSYS/20.2/binary/
 	
 Please follow the same install directory structure.
 

--- a/bessemer/software/apps/ansys.rst
+++ b/bessemer/software/apps/ansys.rst
@@ -3,8 +3,8 @@ ANSYS
 
 .. sidebar:: ANSYS
    
-   :Versions: 19.4 
-   :Dependencies: User subroutines need the GCC/7.3.0-2.30 compiler.
+   :Versions: 19.4, 20.1, 20.2 
+   :Dependencies: UDFs / User subroutines need the GCC/7.3.0-2.30 compiler.
    :URL: http://www.ansys.com 
 
 The ANSYS suite of programs can be used to numerically simulate a large variety of structural and fluid dynamics problems found in many engineering, physics, medical, aeronotics and automative industry applications.
@@ -14,9 +14,9 @@ Interactive usage
 
 After connecting to Bessemer (see :ref:`ssh`),  start an `interactive graphical session <https://docs.hpc.shef.ac.uk/en/latest/hpc/scheduler/submit.html#interactive-sessions>`_.
 
-ANSYS version 19.4 can be activated using the module file::
+ANSYS version 20.2 can be activated using the module file::
 
-    module load ANSYS/19.4
+    module load ANSYS/20.2
 
 and the workbench is launched using::
 
@@ -30,7 +30,7 @@ ANSYS example models
 ANSYS contains a large number of example models which can be used to become familiar with the software.
 The models can be found in::
 
-    /usr/local/packages/live/eb/ANSYS/19.4/v194/ansys/data
+    /usr/local/packages/manual/ANSYS/20.2/binary/v202/ansys/data/
 	
 
 Batch jobs
@@ -47,7 +47,7 @@ The following is an example batch submission script, ``cfd_job.sh``, to run the 
     #SBATCH --time=01:00:00
     #SBATCH --mail-user=joe.bloggs@sheffield.ac.uk
     #SBATCH --mail-type=ALL
-    module load ANSYS/19.4
+    module load ANSYS/20.2
     fluent 2ddp -i subjou.jou -g -t4
 	
 The job is submitted to the queue by typing::
@@ -65,7 +65,7 @@ The following is an example batch submission script, ``mech_job.sh``, to run the
     #SBATCH --time=01:00:00
     #SBATCH --mail-user=joe.bloggs@sheffield.ac.uk
     #SBATCH --mail-type=ALL
-    module load ANSYS/19.4
+    module load ANSYS/20.2
     ANSYS_OPTIONS="-smp -dir $(pwd) -b -np $SLURM_NTASKS -j solution -i"
     mapdl $ANSYS_OPTIONS CrankSlot_Flexible.inp
 
@@ -78,9 +78,23 @@ Installation note for Administrators:
 
 mapdl will not run without modifying the file::
 
-    /usr/local/packages/live/eb/ANSYS/19.4/v194/ansys/bin/anssh.ini
+    /usr/local/packages/manual/ANSYS/20.2/binary/v202/ansys/bin/anssh.ini
 
-The following instruction should be inserted at line 2127 in ``anssh.ini``::
+The following instruction should be inserted at line 2306 in ``anssh.ini``::
 
     setenv KMP_AFFINITY compact
+
+	
+Please note ANSYS 20.1 and 20.2 have been installed manually with the GUI in the following directory::
+	
+    /usr/local/packages/manual/ANSYS/
+	
+Please follow the same install directory structure.
+
+In addition the following software packages are not included with the installations::
+
+
+    "ANSYS Chemkin"
+    "ANSYS Geometry Interfaces".
+	
 

--- a/sharc/software/apps/ansys.rst
+++ b/sharc/software/apps/ansys.rst
@@ -3,8 +3,8 @@ ANSYS
 
 .. sidebar:: ANSYS
    
-   :Versions: 15.0, 16.1, 17.2, 18.0, 18.2, 19.0, 19.1, 19.2, 19.3 & 19.4
-   :Dependencies: No prerequsite modules loaded. However, If using the User Defined Functions (UDF) will also need the following: For ANSYS Mechanical, Workbench, CFX and AutoDYN: Intel 14.0 or above; Compiler For Fluent: GCC 4.6.1 or above
+   :Versions: 15.0, 16.1, 17.2, 18.0, 18.2, 19.0, 19.1, 19.2, 19.3, 19.4, 20.1 &  20.2
+   :Dependencies: No prerequsite modules loaded. However, if using the User Defined Functions (UDF) will also need the following: For ANSYS Mechanical, Workbench, CFX and AutoDYN: Intel 14.0 or above; Compiler For Fluent: GCC 4.6.1 or above
    :URL: http://www.ansys.com 
    :Local URL: https://www.shef.ac.uk/it-services/research/software/fluent
 
@@ -27,12 +27,17 @@ Ansys can be activated using the module files::
     module load apps/ansys/19.2/binary
     module load apps/ansys/19.3/binary
     module load apps/ansys/19.4/binary
+    module load apps/ansys/20.1/binary
+    module load apps/ansys/20.2/binary
 	
 
 The Ansys Workbench GUI executable is ``ansyswb``. ``ansyswb`` can be launched during an interactive session with X Window support (e.g. an interactive ``qrshx`` session).
 The Ansys Mechanical executable is ``ansys-mechanical`` and ``fluent`` is the executable for Fluent.
  
-NOTE: for Ansys versions >= 18.0 using the command ``fluent`` results in an unresponsive fluent launcher. To launch fluent and bypass the launcher use ``fluent dim`` where dim = 2d, 2ddp, 3d or 3ddp.
+NOTE: for Ansys versions >= 18.0 using the command ``fluent`` results in an unresponsive fluent launcher. To launch fluent and bypass the launcher use ``fluent dim`` where dim = 2d, 2ddp, 3d or 3ddp or unset the following environment variables before running the command::
+
+    unset SGE_TASK_ID
+    unset RESTARTED
 
 ANSYS example models
 --------------------
@@ -40,7 +45,7 @@ ANSYS example models
 ANSYS contains a large number of example models which can be used to become familiar with the software.
 The models can be found in::
 
-    /usr/local/packages/live/eb/ANSYS/19.4/v194/ansys/data
+    /usr/local/packages/apps/ansys/20.2/binary/v202/ansys/data
 	
 
 Batch jobs
@@ -49,16 +54,18 @@ Batch jobs
 ``Fluent CFD``: the following is an example batch submission script, ``cfd_job.sh``, to run the executable ``fluent`` with input journal file ``test.jou``, and carry out a 2D double precision CFD simulation. The script requests 8 cores using the MPI parallel environment ``mpi-rsh`` with a runtime of 30 mins and 2 GB of real memory per core. The Fluent input journal file is ``test.jou``. **Note:** Please use the ``mpi-rsh`` parallel environment to run MPI parallel jobs for Ansys/Fluent. ::
 
     #!/bin/bash
+    #$ -V
     #$ -cwd
     #$ -M joe.bloggs@sheffield.ac.uk
     #$ -m abe
     #$ -l h_rt=00:30:00
     #$ -l rmem=2G
     #$ -pe mpi-rsh 8
+    #$ -N JobName
 
-    module load apps/ansys/19.4
+    module load apps/ansys/20.2/binary
 
-    fluent 2ddp -i test.jou -g -t$NSLOTS -sge -mpi=intel -rsh -sgepe mpi-rsh
+    fluent 2ddp -i test.jou -g -t8 -sge -mpi=intel -rsh
 
 The job is submitted to the queue by typing::
 
@@ -67,28 +74,30 @@ The job is submitted to the queue by typing::
 ``Mapdl mechanical``: the following is an example batch submission script, ``mech_job.sh``, to run the mechanical executable ``mapdl`` with input file ``CrankSlot_Flexible.inp``, and carry out a mechanical simulation. The script requests 4 cores using the OpenMP (``single node shared memory``) parallel environment with a runtime of 10 mins and 2 GB of real memory per core. ::
 
     #!/bin/bash
+    #$ -V
     #$ -cwd
-    #$ -N mech_test
+    #$ -N JobName
     #$ -M joe.bloggs@sheffield.ac.uk
     #$ -m abe
     #$ -l h_rt=00:10:00
     #$ -l rmem=2G
     #$ -pe smp 4
-    module load apps/ansys/19.4/binary
-    mapdl -b -np $NSLOTS -smp -i CrankSlot_Flexible.inp
+    module load apps/ansys/20.2/binary
+    mapdl -b -np 4 -smp -i CrankSlot_Flexible.inp
 
 The equivalent batch script for using MPI (``multi-node distributed memory``) parallel environment is ::
 
     #!/bin/bash
+    #$ -V
     #$ -cwd
-    #$ -N mech_test
+    #$ -N JobName
     #$ -M joe.bloggs@sheffield.ac.uk
     #$ -m abe
     #$ -l h_rt=00:10:00
     #$ -l rmem=2G
     #$ -pe mpi 4
-    module load apps/ansys/19.4/binary
-    mapdl -i CrankSlot_Flexible.inp -b -np $NSLOTS -sge -mpi=INTELMPI -rsh -sgepe mpi-rsh 
+    module load apps/ansys/20.2/binary
+    mapdl -i CrankSlot_Flexible.inp -b -np 4 -sge -mpi=INTELMPI -rsh
 
 		
 Installation notes
@@ -144,12 +153,19 @@ Ansys 19.4 was installed using the
 file is
 :download:`/usr/local/modulefiles/apps/ansys/19.4/binary </sharc/software/modulefiles/apps/ansys/19.4/binary>`.
 
+Ansys 20.1 and 20.2 were installed using the GUI installer and then permissions were corrected as follows::
+
+    chmod 775 -R /usr/local/packages/apps/ansys/20.1/binary
+    chmod 775 -R /usr/local/packages/apps/ansys/20.2/binary
+	
+Please follow the same install directory structure.
+
 The ``mpi-rsh`` tight-integration parallel environment is required to run Ansys/Fluent using MPI due to 
 SSH access to worker nodes being prohibited for most users.
 
-For versions 19.3 & 19.4 mapdl will not run without modifying the file::
+For versions 19.3 & 19.4 and onward mapdl will not run without modifying the file::
 
-    /usr/local/packages/live/eb/ANSYS/19.4/v194/ansys/bin/anssh.ini
+    /usr/local/packages/apps/ansys/19.4/binary/v194/ansys/bin/anssh.ini
 
 The following instruction should be inserted at line 2127 in ``anssh.ini``::
 


### PR DESCRIPTION
Clarified some installation procedure for both, changed the number on the box and fixed up the ShARC fluent submission example - Fluent is SGE aware and the extra flags were causing batch submissions to fail - we can simply let Fluent pull the SGE environment variables and get itself setup.

From Fluent rep: 

``` You only need the sge and t arguments if you run the fluent command directly on the command line. Fluent then uses those arguments to construct a UGE script of its own and run the qsub command with that script. From 2020R1 onwards it explicitly writes out the script it uses to submit to the current working folder.

You do not need any of those arguments if you are already inside a UGE shell, which a qsub script is. You should not need the -t argument either. Fluent extracts all the information it needs from the environment variables that qsub will have set. ```