### PR TITLE
Update tensorflow to reflect memory requirements on ShARC.

### DIFF
--- a/sharc/software/apps/tensorflow.rst
+++ b/sharc/software/apps/tensorflow.rst
@@ -27,7 +27,9 @@ Installation in Home Directory - CPU Version
 
 In order to to install to your home directory, Conda is used to create a virtual python environment for installing your local version of Tensorflow.
 
-First request an interactive session, e.g. with :ref:`qrshx`.
+First request an interactive session with 4GB of memory via the :ref:`qrshx` command: ::
+
+	qrshx -l rmem=4G
 
 Then Tensorflow can be installed by the following ::
 


### PR DESCRIPTION
Install process for tensorflow will require around 2.5GB of memory - giving some headroom.

Tested 26/08/2020 - documentation for installation followed.

i.e.

``` #Load the conda module
module load apps/python/conda

#Create an conda virtual environment called 'tensorflow'
conda create -n tensorflow python=3.6

#Activate the 'tensorflow' environment
source activate tensorflow

pip install tensorflow 
```

Resulted in:

`usage         1:            cpu=00:05:38, mem=41.49889 GB s, io=6.16813 GB, vmem=1.461G, maxvmem=2.565G`