### PR TITLE
flock now enabled by default on all Lustre clients

### DIFF
--- a/bessemer/software/libs/cuda.rst
+++ b/bessemer/software/libs/cuda.rst
@@ -148,13 +148,11 @@ Documentation
 Profiling using nvprof
 ----------------------
 
-Note that ``nvprof``, NVIDIA's CUDA profiler,
-cannot write output to the ``/fastdata`` filesystem.
+Prior to September 2020 ``nvprof``, NVIDIA's CUDA profiler, could write its `SQLite <https://www.sqlite.org/>`__ database outputs to the ``/fastdata`` filesystem.
+This was because SQLite requires a filesystem that supports file locking
+but file locking was not previously enabled on the (`Lustre <http://lustre.org/>`__) filesystem mounted on ``/fastdata``.
 
-This is because the profiler's output is a `SQLite <https://www.sqlite.org/>`__ database
-and SQLite requires a filesystem that supports file locking
-but file locking is not enabled on the (`Lustre <http://lustre.org/>`__) filesystem mounted on ``/fastdata``
-(for performance reasons).
+``nvprof`` can now write output data to any user-accessible filesystem including ``/fastdata``.
 
 CUDA Training
 -------------

--- a/hpc/filestore.rst
+++ b/hpc/filestore.rst
@@ -170,9 +170,9 @@ For example, to find files 50 or more days old ::
 File locking
 ^^^^^^^^^^^^
 
-POSIX file locking is not enabled on these Lustre filesystems, 
-which can cause issues for certain applications that require/expect it
-(e.g. programs that create/use SQLite databases).
+As of September 2020 POSIX file locking is enabled on all Lustre filesystems. 
+Prior to this the lack of file locking support on the University's Lustre filesystems caused problems for certain workflows/applications
+(e.g. for programs that create/use SQLite databases).
 
 .. _shared_dir:
 

--- a/sharc/software/libs/cuda.rst
+++ b/sharc/software/libs/cuda.rst
@@ -142,13 +142,11 @@ Documentation
 Profiling using nvprof
 ----------------------
 
-Note that ``nvprof``, NVIDIA's CUDA profiler, 
-cannot write output to the ``/fastdata`` filesystem.
+Prior to September 2020 ``nvprof``, NVIDIA's CUDA profiler, could write its `SQLite <https://www.sqlite.org/>`__ database outputs to the ``/fastdata`` filesystem.
+This was because SQLite requires a filesystem that supports file locking
+but file locking was not previously enabled on the (`Lustre <http://lustre.org/>`__) filesystem mounted on ``/fastdata``.
 
-This is because the profiler's output is a `SQLite <https://www.sqlite.org/>`__ database 
-and SQLite requires a filesystem that supports file locking
-but file locking is not enabled on the (`Lustre <http://lustre.org/>`__) filesystem mounted on ``/fastdata`` 
-(for performance reasons). 
+``nvprof`` can now write output data to any user-accessible filesystem including ``/fastdata``.
 
 CUDA Training
 -------------


### PR DESCRIPTION
 - [x] Note that file locking enabled on all TUOS Lustres.
 - [x] Note that nvprof can now write output SQLite databases to Lustre
 - [ ] Abaqus still needs `BAS_DISABLE_FILE_LOCKING=1` if using dir on Lustre as working dir? **N/A -> handled via PR** #1148


PR should close Issue #1049 