### PR TITLE
Update docs to reflect the KMP_Affinity settings

### DIFF
--- a/bessemer/software/apps/ansys.rst
+++ b/bessemer/software/apps/ansys.rst
@@ -101,7 +101,7 @@ The job is submitted to the queue by typing::
 Installation note for Administrators:
 -------------------------------------
 
-MAPDL will not run in ANSYS versions 19.X without modifying the file::
+MAPDL will not run in ANSYS versions 19.X `without modifying <https://github.com/rcgsheffield/sheffield_hpc/issues/1083>`_ the file::
 
     /usr/local/packages/live/noeb/ANSYS/19.4/binary/v194/ansys/bin/anssh.ini
 

--- a/bessemer/software/apps/ansys.rst
+++ b/bessemer/software/apps/ansys.rst
@@ -96,14 +96,16 @@ The job is submitted to the queue by typing::
 
 - ``$SLURM_NTASKS`` is a SLURM variable which will return the requested number of tasks per node.
 
+----------
+
 Installation note for Administrators:
 -------------------------------------
 
-mapdl will not run without modifying the file::
+MAPDL will not run in ANSYS versions 19.X without modifying the file::
 
-    /usr/local/packages/live/noeb/ANSYS/20.2/binary/v202/ansys/bin/anssh.ini
+    /usr/local/packages/live/noeb/ANSYS/19.4/binary/v194/ansys/bin/anssh.ini
 
-The following instruction should be inserted at line 2433 in ``anssh.ini``::
+The following instruction should be inserted at line 2127 in ``anssh.ini``::
 
     setenv KMP_AFFINITY compact
 
@@ -118,6 +120,8 @@ Please note ANSYS 20.1 and 20.2 have been installed manually with the GUI in the
     chmod 775 -R /usr/local/packages/live/noeb/ANSYS/20.2/binary/
 	
 Please follow the same install directory structure.
+
+----------
 
 In addition the following software packages are not included with the installations::
 

--- a/hpc/scheduler/submit.rst
+++ b/hpc/scheduler/submit.rst
@@ -77,7 +77,7 @@ Common Interactive Job Options
 ====================== ======================== ================================================================
 SGE Command            Slurm Command            Description
 ====================== ======================== ================================================================
-``-l h_rt=hh:mm:ss``   | ``-t [min]``           Specify the total maximum wall clock execution time for the job.
+``-l h_rt=hh:mm:ss``   | ``-t [min]``           Specify the total maximum execution time for the job.
                        | ``-t [days-hh:mm:ss]`` The upper limit is 08:00:00.  NB these limits may
                                                 differ for reservations/projects.
 
@@ -223,7 +223,7 @@ Scheduler Options
 ====================== ======================== ====================================================================
 SGE Command            Slurm Command            Description
 ====================== ======================== ====================================================================
-``-l h_rt=hh:mm:ss``   | ``-t [min]``           Specify the total maximum wall clock execution time for the job.
+``-l h_rt=hh:mm:ss``   | ``-t [min]``           Specify the total maximum execution time for the job.
                        | ``-t [days-hh:mm:ss]`` The upper limit is typically 96:00:00 (4 days) on ShARC
                                                 and 168:00:00 (7 days) on Iceberg and Bessemer.  Note that these 
                                                 limits may differ for specific Projects/Queues.  

--- a/hpc/scheduler/submit.rst
+++ b/hpc/scheduler/submit.rst
@@ -77,7 +77,7 @@ Common Interactive Job Options
 ====================== ======================== ================================================================
 SGE Command            Slurm Command            Description
 ====================== ======================== ================================================================
-``-l h_rt=hh:mm:ss``   | ``-t [min]``           Specify the total maximum execution time for the job.
+``-l h_rt=hh:mm:ss``   | ``-t [min]``           Specify the total maximum wall clock execution time for the job.
                        | ``-t [days-hh:mm:ss]`` The upper limit is 08:00:00.  NB these limits may
                                                 differ for reservations/projects.
 
@@ -223,7 +223,7 @@ Scheduler Options
 ====================== ======================== ====================================================================
 SGE Command            Slurm Command            Description
 ====================== ======================== ====================================================================
-``-l h_rt=hh:mm:ss``   | ``-t [min]``           Specify the total maximum execution time for the job.
+``-l h_rt=hh:mm:ss``   | ``-t [min]``           Specify the total maximum wall clock execution time for the job.
                        | ``-t [days-hh:mm:ss]`` The upper limit is typically 96:00:00 (4 days) on ShARC
                                                 and 168:00:00 (7 days) on Iceberg and Bessemer.  Note that these 
                                                 limits may differ for specific Projects/Queues.  

--- a/sharc/software/apps/ansys.rst
+++ b/sharc/software/apps/ansys.rst
@@ -121,7 +121,8 @@ The equivalent batch script for using MPI (``multi-node distributed memory``) pa
     mapdl -i CrankSlot_Flexible.inp -b -np $NSLOTS -sge -mpi=INTELMPI -rsh -sgepe mpi-rsh 
 	#Note $NSLOTS is a Sun Grid Engine variable which will return the requested number of cores.
 
-		
+----------
+	
 Installation notes
 ------------------
 
@@ -175,7 +176,6 @@ ANSYS 19.4 was installed using the
 file is
 :download:`/usr/local/modulefiles/apps/ansys/19.4/binary </sharc/software/modulefiles/apps/ansys/19.4/binary>`.
 
-----------
 
 ANSYS 20.1 and 20.2 were installed using the GUI installer and then permissions were corrected as follows::
 
@@ -184,10 +184,14 @@ ANSYS 20.1 and 20.2 were installed using the GUI installer and then permissions 
 	
 Please follow the same install directory structure.
 
+----------
+
 The ``mpi-rsh`` tight-integration parallel environment is required to run ANSYS/Fluent using MPI due to 
 SSH access to worker nodes being prohibited for most users.
 
-For versions 19.3 & 19.4 and onward mapdl will not run without modifying the file::
+----------
+
+For versions 19.x mapdl `will not run <https://github.com/rcgsheffield/sheffield_hpc/issues/1083>`_  without modifying the file::
 
     /usr/local/packages/apps/ansys/19.4/binary/v194/ansys/bin/anssh.ini
 


### PR DESCRIPTION
Update to clarify/detail why the KMP_Affinity setting is needed only for ANSYS 19.X for both Bessemer and ShARC.

The files on the cluster have been edited to reflect this with the settings removed for ANSYS 20.X

Minor style edits also.