### PR TITLE
Minor correction to V100 memory on interactive GPU examples

### DIFF
--- a/bessemer/GPUComputingBessemer.rst
+++ b/bessemer/GPUComputingBessemer.rst
@@ -35,10 +35,10 @@ As such, it is recommended that you request enough CPU memory to communicate pro
 
 .. code-block:: sh
 
-   # NB Each NVIDIA V100 GPU has 16GB of RAM
-   srun --partition=gpu --qos=gpu --nodes=1 --gpus-per-node=1 --mem=18G --pty bash
+   # NB Each NVIDIA V100 GPU has 32GB of RAM
+   srun --partition=gpu --qos=gpu --nodes=1 --gpus-per-node=1 --mem=34G --pty bash
 
-The above will give you 2GB more CPU RAM than the 16GB of GPU RAM available on the NVIDIA V100.
+The above will give you 2GB more CPU RAM than the 32GB of GPU RAM available on the NVIDIA V100.
 
 
 .. _GPUJobs_bessemer:

--- a/bessemer/GPUComputingBessemer.rst
+++ b/bessemer/GPUComputingBessemer.rst
@@ -40,6 +40,9 @@ As such, it is recommended that you request enough CPU memory to communicate pro
 
 The above will give you 2GB more CPU RAM than the 32GB of GPU RAM available on the NVIDIA V100.
 
+.. note::
+
+   Some private GPU nodes have only 16GB of GPU RAM per GPU; the users of private GPU nodes should check and be aware of how much GPU memory is available.
 
 .. _GPUJobs_bessemer:
 

--- a/bessemer/groupnodes/dcs-acad-gpu-nodes.rst
+++ b/bessemer/groupnodes/dcs-acad-gpu-nodes.rst
@@ -45,6 +45,10 @@ Hardware specifications
    * - Local storage
      - 140 GB of temporary storage under ``/scratch`` (2x SSD RAID1)
 
+.. note::
+
+   Most other GPU nodes in Bessemer have 32GB of GPU memory per GPU.
+
 Requesting access
 -----------------
 


### PR DESCRIPTION
This applies to the V100 node(s) in the gpu and dcs-gpu partitions, but not the 16GB V100s in the dcs-acad partition, which is an special case with limited access.