### PR TITLE
ShARC R GCC (not Intel) documentation update for R 4.0.0.

### DIFF
--- a/sharc/software/apps/R.rst
+++ b/sharc/software/apps/R.rst
@@ -208,7 +208,7 @@ This was a set of scripted installs. It was compiled from source with gcc 8.2.0 
 
 * Install log-files, including the output of the ``make check`` tests are available on the system at ``/usr/local/packages/apps/R/4.0.0/gcc-8.2.0/install_logs/`` and ``/usr/local/packages/apps/R/4.0.0/gcc-10.1/install_logs/``
 
-
+* PCRE2 was compiled as a dependency with the appropriate compilers for each.
 
 
 Version 3.6.3

--- a/sharc/software/apps/R.rst
+++ b/sharc/software/apps/R.rst
@@ -7,6 +7,7 @@ R
 
    :URL: https://www.r-project.org/
    :Documentation: https://www.r-project.org/
+   :Versions: 3.3.2, 3.3.3, 3.4.0, 3.5.1, 3.6.3, 4.0.0
 
 R is a statistical computing language.
 
@@ -14,12 +15,10 @@ Interactive Usage
 -----------------
 After connecting to ShARC, start an :ref:`interactive session <submit-interactive>`.
 
-The latest version of R can be loaded with: ::
-
-   module load apps/R
-
-Alternatively, you can load a specific version of R using one of the following: ::
+You can load a specific version of R using one of the following: ::
         
+   module load apps/R/4.0.0/gcc-10.1.0
+   module load apps/R/4.0.0/gcc-8.2.0
    module load apps/R/3.6.3/gcc-8.2.0
    module load apps/R/3.5.1/gcc-4.8.5
    module load apps/R/3.4.0/gcc-4.8.5
@@ -192,6 +191,25 @@ For more details see :ref:`Intel R (Sharc)`
 Installation Notes
 ------------------
 These notes are primarily for administrators of the system.
+
+Version 4.0.0
+^^^^^^^^^^^^^
+
+* `What's new in R version 4.0.0 <https://stat.ethz.ch/pipermail/r-announce/2020/000653.html>`_ 
+
+This was a set of scripted installs. It was compiled from source with gcc 8.2.0 / gcc 10.1.0 with ``--with-blas --with-lapack --enable-R-shlib --with-tcltk`` enabled. It was run in installed with an interactive session mode.
+
+* :download:`install-R4.0-gcc-8.2.0.sh </sharc/software/install_scripts/apps/R/4.0.0/gcc-8.2.0/install-R4.0-gcc-8.2.0.sh>` Downloads, compiles, tests and installs R 4.0.0 and the ``Rmath`` library.
+
+* :download:`install-R4.0-gcc-10.1.0.sh </sharc/software/install_scripts/apps/R/4.0.0/gcc-10.1.0/install-R4.0-gcc-10.1.0.sh>` Downloads, compiles, tests and installs R 4.0.0 and the ``Rmath`` library.
+
+* :download:`R 4.0.0 GCC 8.2.0 Modulefile </sharc/software/modulefiles/apps/R/4.0.0/gcc-8.2.0>` located on the system at ``/usr/local/modulefiles/apps/R/4.0.0/``
+* :download:`R 4.0.0 GCC 10.1.0 Modulefile </sharc/software/modulefiles/apps/R/4.0.0/gcc-10.1.0>` located on the system at ``/usr/local/modulefiles/apps/R/4.0.0/``
+
+* Install log-files, including the output of the ``make check`` tests are available on the system at ``/usr/local/packages/apps/R/4.0.0/gcc-8.2.0/install_logs/`` and ``/usr/local/packages/apps/R/4.0.0/gcc-10.1/install_logs/``
+
+
+
 
 Version 3.6.3
 ^^^^^^^^^^^^^

--- a/sharc/software/install_scripts/apps/R/4.0.0/gcc-10.1.0/install-R4.0-gcc-10.1.0.sh
+++ b/sharc/software/install_scripts/apps/R/4.0.0/gcc-10.1.0/install-R4.0-gcc-10.1.0.sh
@@ -1,0 +1,44 @@
+##!/bin/bash -e
+##$ -l rmem=40G
+
+#Set up environment variables and create directories
+version=4.0.0
+install_dir=/usr/local/packages/apps/R/$version/gcc-10.1/
+build_dir=~/R-$version-build
+mkdir -p $build_dir
+mkdir -p $install_dir
+module load dev/gcc/10.1
+cd $build_dir
+
+#Download the installer
+wget https://cran.r-project.org/src/base/R-4/R-$version.tar.gz
+tar -xzf ./R-$version.tar.gz
+cd R-$version
+
+tcl_config=/usr/local/packages/apps/tcl/8.6.10/gcc-10.1/lib/tclConfig.sh
+tk_config=/usr/local/packages/apps/tk/8.6.10/gcc-10.1/lib/tkConfig.sh
+
+#Configure and build
+./configure --prefix $install_dir --with-tcltk --with-tcl-config=$tcl_config \
+ --with-tk-config=$tk_config --with-blas --with-lapack \
+--enable-R-shlib 2>&1 | tee config-R-$version.log
+make 2>&1 | tee make-R-$version.log
+
+#Check
+make check 2>&1 | tee make_check-R-$version.log
+
+#Install test directory
+make install-tests
+
+#Install
+make install
+
+#Build libRmath.so
+cd $build_dir/R-$version/src/nmath/standalone
+make 
+mv libRmath.* $install_dir/lib64/R/lib
+
+#Copy install,configure and test log files
+mkdir -p $install_dir/install_logs
+cd $build_dir/R-$version
+mv ./*.log $install_dir/install_logs

--- a/sharc/software/install_scripts/apps/R/4.0.0/gcc-10.1.0/install-R4.0-gcc-10.1.0.sh
+++ b/sharc/software/install_scripts/apps/R/4.0.0/gcc-10.1.0/install-R4.0-gcc-10.1.0.sh
@@ -8,6 +8,7 @@ build_dir=~/R-$version-build
 mkdir -p $build_dir
 mkdir -p $install_dir
 module load dev/gcc/10.1
+module load libs/pcre2/10.36/gcc-10.1
 cd $build_dir
 
 #Download the installer

--- a/sharc/software/install_scripts/apps/R/4.0.0/gcc-8.2.0/install-R4.0-gcc-8.2.0.sh
+++ b/sharc/software/install_scripts/apps/R/4.0.0/gcc-8.2.0/install-R4.0-gcc-8.2.0.sh
@@ -8,6 +8,7 @@ build_dir=~/R-$version-build
 mkdir -p $build_dir
 mkdir -p $install_dir
 module load dev/gcc/8.2
+module load libs/pcre2/10.36/gcc-8.2.0 
 cd $build_dir
 
 #Download the installer

--- a/sharc/software/install_scripts/apps/R/4.0.0/gcc-8.2.0/install-R4.0-gcc-8.2.0.sh
+++ b/sharc/software/install_scripts/apps/R/4.0.0/gcc-8.2.0/install-R4.0-gcc-8.2.0.sh
@@ -1,0 +1,44 @@
+##!/bin/bash -e
+##$ -l rmem=40G
+
+#Set up environment variables and create directories
+version=4.0.0
+install_dir=/usr/local/packages/apps/R/$version/gcc-8.2.0/
+build_dir=~/R-$version-build
+mkdir -p $build_dir
+mkdir -p $install_dir
+module load dev/gcc/8.2
+cd $build_dir
+
+#Download the installer
+wget https://cran.r-project.org/src/base/R-4/R-$version.tar.gz
+tar -xzf ./R-$version.tar.gz
+cd R-$version
+
+tcl_config=/usr/local/packages/apps/tcl/8.6.10/gcc-8.2.0/lib/tclConfig.sh
+tk_config=/usr/local/packages/apps/tk/8.6.10/gcc-8.2.0/lib/tkConfig.sh
+
+#Configure and build
+./configure --prefix $install_dir --with-tcltk --with-tcl-config=$tcl_config \
+ --with-tk-config=$tk_config --with-blas --with-lapack \
+--enable-R-shlib 2>&1 | tee config-R-$version.log
+make 2>&1 | tee make-R-$version.log
+
+#Check
+make check 2>&1 | tee make_check-R-$version.log
+
+#Install test directory
+make install-tests
+
+#Install
+make install
+
+#Build libRmath.so
+cd $build_dir/R-$version/src/nmath/standalone
+make 
+mv libRmath.* $install_dir/lib64/R/lib
+
+#Copy install,configure and test log files
+mkdir -p $install_dir/install_logs
+cd $build_dir/R-$version
+mv ./*.log $install_dir/install_logs

--- a/sharc/software/install_scripts/apps/tcl/install_tcl.sh
+++ b/sharc/software/install_scripts/apps/tcl/install_tcl.sh
@@ -1,0 +1,28 @@
+##!/bin/bash -e
+##$ -l rmem=40G
+
+#Set up environment variables and create directories
+version=8.6.10
+install_dir=/usr/local/packages/apps/tcl/$version/gcc-10.1/
+build_dir=~/builds/tcl-$version-build
+mkdir -p $build_dir
+mkdir -p $install_dir
+module load dev/gcc/10.1
+cd $build_dir
+
+#Download the installer
+wget https://sourceforge.net/projects/tcl/files/Tcl/$version/tcl$version-src.tar.gz
+tar -xzf ./tcl$version-src.tar.gz
+cd tcl$version/unix
+
+#Configure and build
+./configure --prefix $install_dir --enable-threads 2>&1 | tee config-tcl-$version.log
+make 2>&1 | tee make-tcl-$version.log
+
+#Install
+make install
+
+#Copy install,configure and test log files
+mkdir -p $install_dir/install_logs
+cd $build_dir/tcl$version/unix
+mv ./*.log $install_dir/install_logs

--- a/sharc/software/install_scripts/apps/tk/install_tk.sh
+++ b/sharc/software/install_scripts/apps/tk/install_tk.sh
@@ -1,0 +1,29 @@
+##!/bin/bash -e
+##$ -l rmem=40G
+
+#Set up environment variables and create directories
+version=8.6.10
+install_dir=/usr/local/packages/apps/tk/$version/gcc-10.1/
+build_dir=~/builds/tk-$version-build
+tcl_dir=/usr/local/packages/apps/tcl/8.6.10/gcc-10.1/lib #This is looking for tclConfig.sh
+mkdir -p $build_dir
+mkdir -p $install_dir
+module load dev/gcc/10.1
+cd $build_dir
+
+#Download the installer
+wget https://sourceforge.net/projects/tcl/files/Tcl/$version/tk$version-src.tar.gz
+tar -xzf ./tk$version-src.tar.gz
+cd tk$version/unix
+
+#Configure and build
+./configure --prefix $install_dir --with-tcl=$tcl_dir --enable-threads 2>&1 | tee config-tk-$version.log
+make 2>&1 | tee make-tk-$version.log
+
+#Install
+make install
+
+#Copy install,configure and test log files
+mkdir -p $install_dir/install_logs
+cd $build_dir/tk$version/unix
+mv ./*.log $install_dir/install_logs

--- a/sharc/software/install_scripts/libs/pcre/install_pcre.sh
+++ b/sharc/software/install_scripts/libs/pcre/install_pcre.sh
@@ -1,0 +1,31 @@
+##!/bin/bash -e
+##$ -l rmem=40G
+
+#Set up environment variables and create directories
+version=8.44
+install_dir=/usr/local/packages/libs/pcre/$version/gcc-8.2.0/
+build_dir=~/builds/pcre-$version-build
+mkdir -p $build_dir
+mkdir -p $install_dir
+module load dev/gcc/8.2
+cd $build_dir
+
+#Download the installer
+wget https://ftp.pcre.org/pub/pcre/pcre-$version.tar.gz      
+tar -xzf ./pcre-$version.tar.gz
+cd pcre-$version
+
+#Configure and build
+./configure --prefix $install_dir  2>&1 | tee config-pcre-$version.log
+make 2>&1 | tee make-pcre-$version.log
+
+#Install
+make install
+
+#Check
+make check 2>&1 | tee make_check-R-$version.log
+
+#Copy install,configure and test log files
+mkdir -p $install_dir/install_logs
+cd $build_dir/pcre-$version
+mv ./*.log $install_dir/install_logs

--- a/sharc/software/install_scripts/libs/pcre2/install_pcre2.sh
+++ b/sharc/software/install_scripts/libs/pcre2/install_pcre2.sh
@@ -1,0 +1,31 @@
+##!/bin/bash -e
+##$ -l rmem=40G
+
+#Set up environment variables and create directories
+version=10.36
+install_dir=/usr/local/packages/libs/pcre2/$version/gcc-8.2.0/
+build_dir=~/builds/pcre2-$version-build
+mkdir -p $build_dir
+mkdir -p $install_dir
+module load dev/gcc/8.2
+cd $build_dir
+
+#Download the installer
+wget https://ftp.pcre.org/pub/pcre/pcre2-$version.tar.gz      
+tar -xzf ./pcre2-$version.tar.gz
+cd pcre2-$version
+
+#Configure and build
+./configure --prefix $install_dir  2>&1 | tee config-pcre2-$version.log
+make 2>&1 | tee make-pcre2-$version.log
+
+#Install
+make install
+
+#Check
+make check 2>&1 | tee make_check-R-$version.log
+
+#Copy install,configure and test log files
+mkdir -p $install_dir/install_logs
+cd $build_dir/pcre2-$version
+mv ./*.log $install_dir/install_logs

--- a/sharc/software/modulefiles/apps/R/4.0.0/gcc-10.1.0
+++ b/sharc/software/modulefiles/apps/R/4.0.0/gcc-10.1.0
@@ -1,0 +1,21 @@
+#%Module10.2#####################################################################
+
+## Module file logging
+source /usr/local/etc/module_logging.tcl
+##
+
+proc ModulesHelp { } {
+      global helpmsg
+      puts stderr "\t$helpmsg\n"
+}
+
+set version 4.0.0
+module load dev/gcc/10.1
+module load libs/pcre2/10.36/gcc-10.1
+set R_DIR /usr/local/packages/apps/R/$version/gcc-10.1
+
+prepend-path PATH $R_DIR/bin
+prepend-path LD_LIBRARY_PATH $R_DIR/lib64/R/lib/
+
+setenv TK_LIBRARY /usr/local/packages/apps/tk/8.6.10/gcc-10.1/lib/tk8.6
+setenv TCL_LIBRARY /usr/local/packages/apps/tcl/8.6.10/gcc-10.1/lib/tcl8.6

--- a/sharc/software/modulefiles/apps/R/4.0.0/gcc-8.2.0
+++ b/sharc/software/modulefiles/apps/R/4.0.0/gcc-8.2.0
@@ -1,0 +1,23 @@
+#%Module10.2#####################################################################
+
+## Module file logging
+source /usr/local/etc/module_logging.tcl
+##
+
+proc ModulesHelp { } {
+      global helpmsg
+      puts stderr "\t$helpmsg\n"
+}
+
+set version 4.0.0
+
+module load dev/gcc/8.2
+module load libs/pcre2/10.36/gcc-8.2.0
+
+set R_DIR /usr/local/packages/apps/R/$version/gcc-8.2.0
+
+prepend-path PATH $R_DIR/bin
+prepend-path LD_LIBRARY_PATH $R_DIR/lib64/R/lib/
+
+setenv TK_LIBRARY /usr/local/packages/apps/tk/8.6.10/gcc-8.2.0/lib/tk8.6
+setenv TCL_LIBRARY /usr/local/packages/apps/tcl/8.6.10/gcc-8.2.0/lib/tcl8.6

--- a/sharc/software/modulefiles/apps/tcl/8.6.10/gcc-10.1
+++ b/sharc/software/modulefiles/apps/tcl/8.6.10/gcc-10.1
@@ -1,0 +1,22 @@
+#%Module1.0#####################################################################
+##
+## tcl 8.6.10 lib / binary  module file
+##
+
+## Module file logging
+source /usr/local/etc/module_logging.tcl
+##
+
+proc ModulesHelp { } {
+        puts stderr "Makes the tcl 8.6.10 binaries and libraries available"
+}
+
+
+set TCL_DIR /usr/local/packages/apps/tcl/8.6.10/gcc-10.1
+
+prepend-path PATH $TCL_DIR/bin
+prepend-path LD_LIBRARY_PATH $TCL_DIR/lib
+prepend-path CPATH $TCL_DIR/include
+prepend-path PKG_CONFIG_PATH $TCL_DIR/lib/pkgconfig
+
+setenv TCL_LIBRARY $TCL_DIR/lib/tcl8.6

--- a/sharc/software/modulefiles/apps/tcl/8.6.10/gcc-8.2.0
+++ b/sharc/software/modulefiles/apps/tcl/8.6.10/gcc-8.2.0
@@ -1,0 +1,22 @@
+#%Module1.0#####################################################################
+##
+## tcl 8.6.10 lib / binary  module file
+##
+
+## Module file logging
+source /usr/local/etc/module_logging.tcl
+##
+
+proc ModulesHelp { } {
+        puts stderr "Makes the tcl 8.6.10 binaries and libraries available"
+}
+
+
+set TCL_DIR /usr/local/packages/apps/tcl/8.6.10/gcc-8.2.0
+
+prepend-path PATH $TCL_DIR/bin
+prepend-path LD_LIBRARY_PATH $TCL_DIR/lib
+prepend-path CPATH $TCL_DIR/include
+prepend-path PKG_CONFIG_PATH $TCL_DIR/lib/pkgconfig
+
+setenv TCL_LIBRARY $TCL_DIR/lib/tcl8.6

--- a/sharc/software/modulefiles/apps/tk/8.6.10/gcc-10.1
+++ b/sharc/software/modulefiles/apps/tk/8.6.10/gcc-10.1
@@ -1,0 +1,22 @@
+#%Module1.0#####################################################################
+##
+## tk 8.6.10 lib / binary  module file
+##
+
+## Module file logging
+source /usr/local/etc/module_logging.tcl
+##
+
+proc ModulesHelp { } {
+        puts stderr "Makes the tk 8.6.10 binaries and libraries available"
+}
+
+
+set TK_DIR /usr/local/packages/apps/tk/8.6.10/gcc-10.1
+
+prepend-path PATH $TK_DIR/bin
+prepend-path LD_LIBRARY_PATH $TK_DIR/lib
+prepend-path CPATH $TK/include
+prepend-path PKG_CONFIG_PATH $TK_DIR/lib/pkgconfig
+
+setenv TK_LIBRARY $TK_DIR/lib/tk8.6

--- a/sharc/software/modulefiles/apps/tk/8.6.10/gcc-10.1
+++ b/sharc/software/modulefiles/apps/tk/8.6.10/gcc-10.1
@@ -16,7 +16,7 @@ set TK_DIR /usr/local/packages/apps/tk/8.6.10/gcc-10.1
 
 prepend-path PATH $TK_DIR/bin
 prepend-path LD_LIBRARY_PATH $TK_DIR/lib
-prepend-path CPATH $TK/include
+prepend-path CPATH $TK_DIR/include
 prepend-path PKG_CONFIG_PATH $TK_DIR/lib/pkgconfig
 
 setenv TK_LIBRARY $TK_DIR/lib/tk8.6

--- a/sharc/software/modulefiles/apps/tk/8.6.10/gcc-8.2.0
+++ b/sharc/software/modulefiles/apps/tk/8.6.10/gcc-8.2.0
@@ -16,7 +16,7 @@ set TK_DIR /usr/local/packages/apps/tk/8.6.10/gcc-8.2.0
 
 prepend-path PATH $TK_DIR/bin
 prepend-path LD_LIBRARY_PATH $TK_DIR/lib
-prepend-path CPATH $TK/include
+prepend-path CPATH $TK_DIR/include
 prepend-path PKG_CONFIG_PATH $TK_DIR/lib/pkgconfig
 
 setenv TK_LIBRARY $TK_DIR/lib/tk8.6

--- a/sharc/software/modulefiles/apps/tk/8.6.10/gcc-8.2.0
+++ b/sharc/software/modulefiles/apps/tk/8.6.10/gcc-8.2.0
@@ -1,0 +1,22 @@
+#%Module1.0#####################################################################
+##
+## tk 8.6.10 lib / binary  module file
+##
+
+## Module file logging
+source /usr/local/etc/module_logging.tcl
+##
+
+proc ModulesHelp { } {
+        puts stderr "Makes the tk 8.6.10 binaries and libraries available"
+}
+
+
+set TK_DIR /usr/local/packages/apps/tk/8.6.10/gcc-8.2.0
+
+prepend-path PATH $TK_DIR/bin
+prepend-path LD_LIBRARY_PATH $TK_DIR/lib
+prepend-path CPATH $TK/include
+prepend-path PKG_CONFIG_PATH $TK_DIR/lib/pkgconfig
+
+setenv TK_LIBRARY $TK_DIR/lib/tk8.6

--- a/sharc/software/modulefiles/libs/pcre2/10.36/gcc-10.1
+++ b/sharc/software/modulefiles/libs/pcre2/10.36/gcc-10.1
@@ -1,0 +1,20 @@
+#%Module1.0#####################################################################
+##
+## pcre 10.36 module file
+##
+
+## Module file logging
+source /usr/local/etc/module_logging.tcl
+##
+
+proc ModulesHelp { } {
+        puts stderr "Makes the pcre 10.36 library available"
+}
+
+module-whatis   "Makes the pcre 10.36 library available"
+
+set PCRE_DIR /usr/local/packages/libs/pcre2/10.36/gcc-10.1/
+
+prepend-path LD_LIBRARY_PATH $PCRE_DIR/lib
+prepend-path CPATH $PCRE_DIR/include
+prepend-path PATH $PCRE_DIR/bin

--- a/sharc/software/modulefiles/libs/pcre2/10.36/gcc-8.2.0
+++ b/sharc/software/modulefiles/libs/pcre2/10.36/gcc-8.2.0
@@ -1,0 +1,20 @@
+#%Module1.0#####################################################################
+##
+## pcre 10.36 module file
+##
+
+## Module file logging
+source /usr/local/etc/module_logging.tcl
+##
+
+proc ModulesHelp { } {
+        puts stderr "Makes the pcre 10.36 library available"
+}
+
+module-whatis   "Makes the pcre 10.36 library available"
+
+set PCRE_DIR /usr/local/packages/libs/pcre2/10.36/gcc-8.2.0/
+
+prepend-path LD_LIBRARY_PATH $PCRE_DIR/lib
+prepend-path CPATH $PCRE_DIR/include
+prepend-path PATH $PCRE_DIR/bin


### PR DESCRIPTION
Install scripts, module files added.

Slight modification to the docs to remove latest version can be loaded with section to avoid people using incorrect versions.

.version file added to the R module top directory to ping this at version 3.6.4 to keep using this version while version 4.0.0 modules are tested by end users.

Important to note that R 4.0.0 now requires the use of PCRE2 which was also compiled and added to the cluster.