### PR TITLE
OpenFOAM initial docs commit for Bessemer

### DIFF
--- a/bessemer/software/apps/openfoam.rst
+++ b/bessemer/software/apps/openfoam.rst
@@ -1,0 +1,154 @@
+OpenFOAM
+==========
+
+.. sidebar:: OpenFOAM
+
+   :Versions: 8.0
+   :URL: https://openfoam.org/
+   :Dependencies: Easybuild foss/2020a toolchain, NCurses 6.2, METIS 5.1.0, SCOTCH 6.0.9, CGAL 4.14.3 and Paraview 5.8.0
+
+OpenFOAM is leading software for computational fluid dynamics (CFD). It is licensed free and open source only under the GNU General Public Licence (GPL) by the OpenFOAM Foundation.
+
+Usage
+-----
+OpenFOAM can be used in an interactive or batch job. OpenFOAM 8.0 can be activated using the module file and sourcing the OpenFOAM environment script::
+
+    module load OpenFOAM/8-foss-2020a
+    source $FOAM_BASH
+
+------------
+
+Interactive Usage
+--------------------
+
+The following is an example interactive session running the pitzDaily example model.
+
+After connecting to Bessemer (see :ref:`ssh`), you can start an `interactive graphical session <https://docs.hpc.shef.ac.uk/en/latest/hpc/scheduler/submit.html#interactive-sessions>`_. ::
+
+    module load OpenFOAM/8-foss-2020a
+    source $FOAM_BASH
+    mkdir -p /fastdata/$USER/tests/openfoam/run
+    rm -r /fastdata/$USER/tests/openfoam/run/*
+    cd /fastdata/$USER/tests/openfoam/run
+    cp -r $FOAM_TUTORIALS/incompressible/simpleFoam/pitzDaily .
+    chmod 700 -R pitzDaily && cd pitzDaily
+    srun blockMesh
+    srun simpleFoam
+    srun paraFoam #To view the output.
+
+------------
+
+Batch Usage
+--------------------
+
+The following is an example batch job running the pitzDaily example model:
+
+.. note::
+
+    You will need to supply a `decomposeParDict <https://cfd.direct/openfoam/user-guide/v8-running-applications-parallel/>`_ in the system subdirectory of the case :
+
+::
+
+    #!/bin/bash
+    #SBATCH --nodes=1
+    #SBATCH --ntasks-per-node=4
+    #SBATCH --mem=8000
+    #SBATCH --job-name=name_OpenFOAM_smp_4
+    #SBATCH --output=output_OpenFOAM_smp_4
+    #SBATCH --time=01:00:00
+    #SBATCH --mail-user=joe.bloggs@sheffield.ac.uk
+    #SBATCH --mail-type=ALL
+    mkdir -p /fastdata/$USER/tests/openfoam/run
+    rm -r /fastdata/$USER/tests/openfoam/run/*
+    cd /fastdata/$USER/tests/openfoam/run
+    module load OpenFOAM/8-foss-2020a
+    source $FOAM_BASH
+    cp -r $FOAM_TUTORIALS/incompressible/simpleFoam/pitzDaily .
+    chmod 700 -R pitzDaily && cd pitzDaily
+    srun blockMesh
+    srun decomposePar
+    srun simpleFoam -parallel
+
+------------
+
+Installation note for Administrators:
+-------------------------------------
+
+
+
+OpenFOAM 8 has been installed using Easybuild with all third party modules (NCurses 6.2, METIS 5.1.0, SCOTCH 6.0.9, CGAL 4.14.3 and Paraview 5.8.0)
+
+Installation was tested as follows as above with the :download:`example batch script modified </bessemer/software/modulefiles/OpenFOAM/test_OpenFOAM_parallel.sbatch>` (Getting Started example from https://openfoam.org/download/8-source/) with the below decomposeParDict.
+
+Using the provided decomposeParDict from https://openfoamwiki.net/index.php/DecomposePar ::
+
+    /*---------------------------------------------------------------------------*\
+    | =========                 |                                                 |
+    | \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+    |  \\    /   O peration     | Version:  1.3                                   |
+    |   \\  /    A nd           | Web:      http://www.openfoam.org               |
+    |    \\/     M anipulation  |                                                 |
+    \*---------------------------------------------------------------------------*/
+
+    FoamFile
+    {
+        version         2.0;
+        format          ascii;
+
+        root            "";
+        case            "";
+        instance        "";
+        local           "";
+
+        class           dictionary;
+        object          decomposeParDict;
+    }
+
+    // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+
+    numberOfSubdomains 4;
+
+    method          simple;
+
+    simpleCoeffs
+    {
+        n               (1 4 1);
+        delta           0.001;
+    }
+
+    hierarchicalCoeffs
+    {
+        n               (1 1 1);
+        delta           0.001;
+        order           xyz;
+    }
+
+    metisCoeffs
+    {
+        processorWeights
+        (
+            1
+            1
+            1
+        );
+    }
+
+    manualCoeffs
+    {
+        dataFile        "";
+    }
+
+    distributed     no;
+
+    roots
+    (
+    );
+
+
+    // ************************************************************************* //
+
+
+Module files are available below:
+
+- :download:`/usr/local/modulefiles/live/eb/all/OpenFOAM/8-foss-2020a </bessemer/software/modulefiles/OpenFOAM/8-foss-2020a>`

--- a/bessemer/software/apps/openfoam.rst
+++ b/bessemer/software/apps/openfoam.rst
@@ -27,14 +27,14 @@ After connecting to Bessemer (see :ref:`ssh`), you can start an `interactive gra
 
     module load OpenFOAM/8-foss-2020a
     source $FOAM_BASH
+    rm -r /fastdata/$USER/tests/openfoam/run/
     mkdir -p /fastdata/$USER/tests/openfoam/run
-    rm -r /fastdata/$USER/tests/openfoam/run/*
     cd /fastdata/$USER/tests/openfoam/run
     cp -r $FOAM_TUTORIALS/incompressible/simpleFoam/pitzDaily .
     chmod 700 -R pitzDaily && cd pitzDaily
-    srun blockMesh
-    srun simpleFoam
-    srun paraFoam #To view the output.
+    srun --export=ALL blockMesh
+    srun --export=ALL simpleFoam
+    srun --export=ALL paraFoam #To view the output.
 
 ------------
 
@@ -58,16 +58,16 @@ The following is an example batch job running the pitzDaily example model:
     #SBATCH --time=01:00:00
     #SBATCH --mail-user=joe.bloggs@sheffield.ac.uk
     #SBATCH --mail-type=ALL
+    rm -r /fastdata/$USER/tests/openfoam/run/
     mkdir -p /fastdata/$USER/tests/openfoam/run
-    rm -r /fastdata/$USER/tests/openfoam/run/*
     cd /fastdata/$USER/tests/openfoam/run
     module load OpenFOAM/8-foss-2020a
     source $FOAM_BASH
     cp -r $FOAM_TUTORIALS/incompressible/simpleFoam/pitzDaily .
     chmod 700 -R pitzDaily && cd pitzDaily
-    srun blockMesh
-    srun decomposePar
-    srun simpleFoam -parallel
+    srun --export=ALL blockMesh
+    srun --export=ALL decomposePar
+    srun --export=ALL simpleFoam -parallel
 
 ------------
 

--- a/bessemer/software/modulefiles/OpenFOAM/8-foss-2020a
+++ b/bessemer/software/modulefiles/OpenFOAM/8-foss-2020a
@@ -1,0 +1,71 @@
+#%Module
+proc ModulesHelp { } {
+    puts stderr {
+
+Description
+===========
+OpenFOAM is a free, open source CFD software package.
+ OpenFOAM has an extensive range of features to solve anything from complex fluid flows
+ involving chemical reactions, turbulence and heat transfer,
+ to solid dynamics and electromagnetics.
+
+
+More information
+================
+ - Homepage: https://www.openfoam.org/
+    }
+}
+
+module-whatis {Description: OpenFOAM is a free, open source CFD software package.
+ OpenFOAM has an extensive range of features to solve anything from complex fluid flows
+ involving chemical reactions, turbulence and heat transfer,
+ to solid dynamics and electromagnetics.}
+module-whatis {Homepage: https://www.openfoam.org/}
+module-whatis {URL: https://www.openfoam.org/}
+
+set root /usr/local/packages/live/eb/OpenFOAM/8-foss-2020a
+
+conflict OpenFOAM
+
+if { ![ is-loaded foss/2020a ] } {
+    module load foss/2020a
+}
+
+if { ![ is-loaded libreadline/8.0-GCCcore-9.3.0 ] } {
+    module load libreadline/8.0-GCCcore-9.3.0
+}
+
+if { ![ is-loaded ncurses/6.2-GCCcore-9.3.0 ] } {
+    module load ncurses/6.2-GCCcore-9.3.0
+}
+
+if { ![ is-loaded METIS/5.1.0-GCCcore-9.3.0 ] } {
+    module load METIS/5.1.0-GCCcore-9.3.0
+}
+
+if { ![ is-loaded SCOTCH/6.0.9-gompi-2020a ] } {
+    module load SCOTCH/6.0.9-gompi-2020a
+}
+
+if { ![ is-loaded CGAL/4.14.3-gompi-2020a-Python-3.8.2 ] } {
+    module load CGAL/4.14.3-gompi-2020a-Python-3.8.2
+}
+
+if { ![ is-loaded ParaView/5.8.0-foss-2020a-Python-3.8.2-mpi ] } {
+    module load ParaView/5.8.0-foss-2020a-Python-3.8.2-mpi
+}
+
+prepend-path	CMAKE_PREFIX_PATH		$root
+setenv	EBROOTOPENFOAM		"$root"
+setenv	EBVERSIONOPENFOAM		"8"
+setenv	EBDEVELOPENFOAM		"$root/easybuild/OpenFOAM-8-foss-2020a-easybuild-devel"
+
+setenv	WM_COMPILE_OPTION		"Opt"
+setenv	WM_PROJECT_VERSION		"8"
+setenv	FOAM_INST_DIR		"/usr/local/packages/live/eb/OpenFOAM/8-foss-2020a"
+setenv	WM_COMPILER		"Gcc"
+setenv	WM_MPLIB		"EASYBUILDMPI"
+setenv	FOAM_BASH		"/usr/local/packages/live/eb/OpenFOAM/8-foss-2020a/OpenFOAM-8/etc/bashrc"
+setenv	FOAM_CSH		"/usr/local/packages/live/eb/OpenFOAM/8-foss-2020a/OpenFOAM-8/etc/cshrc"
+setenv	WM_LABEL_SIZE		"32"
+# Built with EasyBuild version 4.3.1

--- a/bessemer/software/modulefiles/OpenFOAM/test_OpenFOAM_parallel.sbatch
+++ b/bessemer/software/modulefiles/OpenFOAM/test_OpenFOAM_parallel.sbatch
@@ -1,0 +1,97 @@
+#!/bin/bash
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=4
+#SBATCH --mem=8000
+#SBATCH --job-name=name_OpenFOAM_smp_4
+#SBATCH --output=output_OpenFOAM_smp_4
+#SBATCH --time=01:00:00
+#SBATCH --mail-user=joe.bloggs@sheffield.ac.uk
+#SBATCH --mail-type=ALL
+
+mkdir -p /fastdata/$USER/tests/openfoam/run
+
+rm -r /fastdata/$USER/tests/openfoam/run/*
+
+cd /fastdata/$USER/tests/openfoam/run
+
+module load OpenFOAM/8-foss-2020a
+
+source $FOAM_BASH
+
+cp -r $FOAM_TUTORIALS/incompressible/simpleFoam/pitzDaily .
+
+chmod 700 -R pitzDaily && cd pitzDaily
+
+
+cat <<EOF > system/decomposeParDict
+/*---------------------------------------------------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  1.3                                   |
+|   \\  /    A nd           | Web:      http://www.openfoam.org               |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+
+FoamFile
+{
+    version         2.0;
+    format          ascii;
+
+    root            "";
+    case            "";
+    instance        "";
+    local           "";
+
+    class           dictionary;
+    object          decomposeParDict;
+}
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+
+numberOfSubdomains 4;
+
+method          simple;
+
+simpleCoeffs
+{
+    n               (1 4 1);
+    delta           0.001;
+}
+
+hierarchicalCoeffs
+{
+    n               (1 1 1);
+    delta           0.001;
+    order           xyz;
+}
+
+metisCoeffs
+{
+    processorWeights
+    (
+        1
+        1
+        1
+    );
+}
+
+manualCoeffs
+{
+    dataFile        "";
+}
+
+distributed     no;
+
+roots
+(
+);
+
+
+// ************************************************************************* //
+EOF
+
+
+srun blockMesh
+srun decomposePar
+srun simpleFoam -parallel

--- a/bessemer/software/modulefiles/OpenFOAM/test_OpenFOAM_parallel.sbatch
+++ b/bessemer/software/modulefiles/OpenFOAM/test_OpenFOAM_parallel.sbatch
@@ -8,9 +8,9 @@
 #SBATCH --mail-user=joe.bloggs@sheffield.ac.uk
 #SBATCH --mail-type=ALL
 
-mkdir -p /fastdata/$USER/tests/openfoam/run
+rm -r /fastdata/$USER/tests/openfoam/run/
 
-rm -r /fastdata/$USER/tests/openfoam/run/*
+mkdir -p /fastdata/$USER/tests/openfoam/run
 
 cd /fastdata/$USER/tests/openfoam/run
 
@@ -92,6 +92,6 @@ roots
 EOF
 
 
-srun blockMesh
-srun decomposePar
-srun simpleFoam -parallel
+srun --export=ALL blockMesh
+srun --export=ALL decomposePar
+srun --export=ALL simpleFoam -parallel


### PR DESCRIPTION
This should be fully functional and good to go - but the live compile of OpenFoam8 appears to have some kind of pathing issue with paraFOAM / paraview as it appears to be unable to find paraview. (Edit: appears to be X11 forwarding issue with screen not module related. TIL.)

As ShARC is updated with OpenFOAM another PR will be made for that.