### PR TITLE
Clarify the /fastdata quota to be even more obvious

### DIFF
--- a/hpc/filestore.rst
+++ b/hpc/filestore.rst
@@ -111,9 +111,9 @@ An example of how slow it can be for large numbers of small files is detailed `h
 +----------+---------------------+--------+----------------+---------------------+-------------------------+---------------------------+
 | System   | Path                | Type   | Quota per user | Filesystem capacity | Shared between systems? | Network bandwith per link |
 +==========+=====================+========+================+=====================+=========================+===========================+
-| Bessemer | ``/fastdata``       | Lustre | None           | 460 TB              | No                      | 25Gb/s Ethernet           |
+| Bessemer | ``/fastdata``       | Lustre | No limits      | 460 TB              | No                      | 25Gb/s Ethernet           |
 +----------+---------------------+--------+----------------+---------------------+-------------------------+---------------------------+
-| ShARC    | ``/fastdata``       | Lustre | None           | 669 TB              | No                      | 100Gb/s (*Omni-Path*)     |
+| ShARC    | ``/fastdata``       | Lustre | No limits      | 669 TB              | No                      | 100Gb/s (*Omni-Path*)     |
 +----------+---------------------+--------+----------------+---------------------+-------------------------+---------------------------+
 
 Snapshotting and mirrored backups


### PR DESCRIPTION
Proposing this on the basis of making it even more clear that you can store as much as you like in fastdata even with the other caveats.

Had a few queries recently who've said they read the docs but didn't capture that fact that /fastdata has no storage limits.