### PR TITLE
Update for Openfoam v2012 on Bessemer.

### DIFF
--- a/bessemer/software/apps/openfoam.rst
+++ b/bessemer/software/apps/openfoam.rst
@@ -3,15 +3,22 @@ OpenFOAM
 
 .. sidebar:: OpenFOAM
 
-   :Versions: 8.0
-   :URL: https://openfoam.org/
+   :Versions: 8.0,v2012
+   :URL: https://openfoam.org/ or https://www.openfoam.com/
    :Dependencies: Easybuild foss/2020a toolchain, NCurses 6.2, METIS 5.1.0, SCOTCH 6.0.9, CGAL 4.14.3 and Paraview 5.8.0
 
-OpenFOAM is leading software for computational fluid dynamics (CFD). It is licensed free and open source only under the GNU General Public Licence (GPL) by the OpenFOAM Foundation.
+OpenFOAM is leading software for computational fluid dynamics (CFD). It is licensed free and open source only under the GNU General Public Licence (GPL) by the OpenFOAM Foundation. Different versions of OpenFOAM supplied from different projects exist so choose your module carefully.
 
 Usage
 -----
-OpenFOAM can be used in an interactive or batch job. OpenFOAM 8.0 can be activated using the module file and sourcing the OpenFOAM environment script::
+
+There are two OpenFOAM modules, choose one and load it with either: ::
+
+    module load OpenFOAM/8-foss-2020a
+    module load OpenFOAM/v2012-foss-2020a
+
+
+OpenFOAM can be used in an interactive or batch job. Both OpenFOAM modules can be activated using the module file and sourcing the OpenFOAM environment script e.g.::
 
     module load OpenFOAM/8-foss-2020a
     source $FOAM_BASH
@@ -21,7 +28,7 @@ OpenFOAM can be used in an interactive or batch job. OpenFOAM 8.0 can be activat
 Interactive Usage
 --------------------
 
-The following is an example interactive session running the pitzDaily example model.
+The following is an example single core interactive session running the pitzDaily example model.
 
 After connecting to Bessemer (see :ref:`ssh`), you can start an `interactive graphical session <https://docs.hpc.shef.ac.uk/en/latest/hpc/scheduler/submit.html#interactive-sessions>`_. ::
 
@@ -45,7 +52,7 @@ The following is an example batch job running the pitzDaily example model:
 
 .. note::
 
-    You will need to supply a `decomposeParDict <https://cfd.direct/openfoam/user-guide/v8-running-applications-parallel/>`_ in the system subdirectory of the case :
+    You will need to supply a `decomposeParDict <https://cfd.direct/openfoam/user-guide/v8-running-applications-parallel/>`_ in the system subdirectory of the case - check the installation script for an example using the EOF method to add it :
 
 ::
 
@@ -65,6 +72,7 @@ The following is an example batch job running the pitzDaily example model:
     source $FOAM_BASH
     cp -r $FOAM_TUTORIALS/incompressible/simpleFoam/pitzDaily .
     chmod 700 -R pitzDaily && cd pitzDaily
+    cp /home/$USER/openfoam/my_custom_decomposeParDict system/decomposeParDict #You must supply you own copy or see the example modified test script below.
     srun --export=ALL blockMesh
     srun --export=ALL decomposePar
     srun --export=ALL simpleFoam -parallel
@@ -74,81 +82,29 @@ The following is an example batch job running the pitzDaily example model:
 Installation note for Administrators:
 -------------------------------------
 
+OpenFOAM v2012
+^^^^^^^^^^^^^^
 
+OpenFOAM v2012 has been installed using Easybuild with all third party modules  (NCurses 6.2, METIS 5.1.0, SCOTCH 6.0.9, CGAL 4.14.3 and Paraview 5.8.0)
+
+Installation was tested as follows as above with the :download:`example batch script  </bessemer/software/modulefiles/OpenFOAM/test_OpenFOAMv2012_parallel.sbatch>` modified to load **OpenFOAM/v2012-foss-2020a** (Getting Started example from https://openfoam.org/download/8-source/) with the below decomposeParDict:
+
+ https://openfoamwiki.net/index.php/DecomposePar
+
+ The module file is available below:
+
+ - :download:`/usr/local/modulefiles/live/eb/all/OpenFOAM/v2012-foss-2020a </bessemer/software/modulefiles/OpenFOAM/v2012-foss-2020a>`
+
+OpenFOAM 8
+^^^^^^^^^^
 
 OpenFOAM 8 has been installed using Easybuild with all third party modules (NCurses 6.2, METIS 5.1.0, SCOTCH 6.0.9, CGAL 4.14.3 and Paraview 5.8.0)
 
-Installation was tested as follows as above with the :download:`example batch script modified </bessemer/software/modulefiles/OpenFOAM/test_OpenFOAM_parallel.sbatch>` (Getting Started example from https://openfoam.org/download/8-source/) with the below decomposeParDict.
+Installation was tested as follows as above with the :download:`example batch script modified </bessemer/software/modulefiles/OpenFOAM/test_OpenFOAM_parallel.sbatch>` (Getting Started example from https://openfoam.org/download/8-source/) with the below decomposeParDict:
 
-Using the provided decomposeParDict from https://openfoamwiki.net/index.php/DecomposePar ::
-
-    /*---------------------------------------------------------------------------*\
-    | =========                 |                                                 |
-    | \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
-    |  \\    /   O peration     | Version:  1.3                                   |
-    |   \\  /    A nd           | Web:      http://www.openfoam.org               |
-    |    \\/     M anipulation  |                                                 |
-    \*---------------------------------------------------------------------------*/
-
-    FoamFile
-    {
-        version         2.0;
-        format          ascii;
-
-        root            "";
-        case            "";
-        instance        "";
-        local           "";
-
-        class           dictionary;
-        object          decomposeParDict;
-    }
-
-    // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+https://openfoamwiki.net/index.php/DecomposePar
 
 
-    numberOfSubdomains 4;
-
-    method          simple;
-
-    simpleCoeffs
-    {
-        n               (1 4 1);
-        delta           0.001;
-    }
-
-    hierarchicalCoeffs
-    {
-        n               (1 1 1);
-        delta           0.001;
-        order           xyz;
-    }
-
-    metisCoeffs
-    {
-        processorWeights
-        (
-            1
-            1
-            1
-        );
-    }
-
-    manualCoeffs
-    {
-        dataFile        "";
-    }
-
-    distributed     no;
-
-    roots
-    (
-    );
-
-
-    // ************************************************************************* //
-
-
-Module files are available below:
+The module file is available below:
 
 - :download:`/usr/local/modulefiles/live/eb/all/OpenFOAM/8-foss-2020a </bessemer/software/modulefiles/OpenFOAM/8-foss-2020a>`

--- a/bessemer/software/modulefiles/OpenFOAM/test_OpenFOAMv2012_parallel.sbatch
+++ b/bessemer/software/modulefiles/OpenFOAM/test_OpenFOAMv2012_parallel.sbatch
@@ -1,0 +1,97 @@
+#!/bin/bash
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=4
+#SBATCH --mem=8000
+#SBATCH --job-name=name_OpenFOAM_smp_4
+#SBATCH --output=output_OpenFOAM_smp_4
+#SBATCH --time=01:00:00
+#SBATCH --mail-user=joe.bloggs@sheffield.ac.uk
+#SBATCH --mail-type=ALL
+
+rm -r /fastdata/$USER/tests/openfoam/run/
+
+mkdir -p /fastdata/$USER/tests/openfoam/run
+
+cd /fastdata/$USER/tests/openfoam/run
+
+module load OpenFOAM/v2012-foss-2020a
+
+source $FOAM_BASH
+
+cp -r $FOAM_TUTORIALS/incompressible/simpleFoam/pitzDaily .
+
+chmod 700 -R pitzDaily && cd pitzDaily
+
+
+cat <<EOF > system/decomposeParDict
+/*---------------------------------------------------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  1.3                                   |
+|   \\  /    A nd           | Web:      http://www.openfoam.org               |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+
+FoamFile
+{
+    version         2.0;
+    format          ascii;
+
+    root            "";
+    case            "";
+    instance        "";
+    local           "";
+
+    class           dictionary;
+    object          decomposeParDict;
+}
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+
+numberOfSubdomains 4;
+
+method          simple;
+
+simpleCoeffs
+{
+    n               (1 4 1);
+    delta           0.001;
+}
+
+hierarchicalCoeffs
+{
+    n               (1 1 1);
+    delta           0.001;
+    order           xyz;
+}
+
+metisCoeffs
+{
+    processorWeights
+    (
+        1
+        1
+        1
+    );
+}
+
+manualCoeffs
+{
+    dataFile        "";
+}
+
+distributed     no;
+
+roots
+(
+);
+
+
+// ************************************************************************* //
+EOF
+
+
+srun --export=ALL blockMesh
+srun --export=ALL decomposePar
+srun --export=ALL simpleFoam -parallel

--- a/bessemer/software/modulefiles/OpenFOAM/v2012-foss-2020a
+++ b/bessemer/software/modulefiles/OpenFOAM/v2012-foss-2020a
@@ -1,0 +1,75 @@
+#%Module
+proc ModulesHelp { } {
+    puts stderr {
+
+Description
+===========
+OpenFOAM is a free, open source CFD software package.
+ OpenFOAM has an extensive range of features to solve anything from complex fluid flows
+ involving chemical reactions, turbulence and heat transfer,
+ to solid dynamics and electromagnetics.
+
+
+More information
+================
+ - Homepage: https://www.openfoam.com/
+    }
+}
+
+module-whatis {Description: OpenFOAM is a free, open source CFD software package.
+ OpenFOAM has an extensive range of features to solve anything from complex fluid flows
+ involving chemical reactions, turbulence and heat transfer,
+ to solid dynamics and electromagnetics.}
+module-whatis {Homepage: https://www.openfoam.com/}
+module-whatis {URL: https://www.openfoam.com/}
+
+set root /usr/local/packages/live/eb/OpenFOAM/v2012-foss-2020a
+
+conflict OpenFOAM
+
+if { ![ is-loaded foss/2020a ] } {
+    module load foss/2020a
+}
+
+if { ![ is-loaded libreadline/8.0-GCCcore-9.3.0 ] } {
+    module load libreadline/8.0-GCCcore-9.3.0
+}
+
+if { ![ is-loaded ncurses/6.2-GCCcore-9.3.0 ] } {
+    module load ncurses/6.2-GCCcore-9.3.0
+}
+
+if { ![ is-loaded METIS/5.1.0-GCCcore-9.3.0 ] } {
+    module load METIS/5.1.0-GCCcore-9.3.0
+}
+
+if { ![ is-loaded SCOTCH/6.0.9-gompi-2020a ] } {
+    module load SCOTCH/6.0.9-gompi-2020a
+}
+
+if { ![ is-loaded CGAL/4.14.3-gompi-2020a-Python-3.8.2 ] } {
+    module load CGAL/4.14.3-gompi-2020a-Python-3.8.2
+}
+
+if { ![ is-loaded ParaView/5.8.0-foss-2020a-Python-3.8.2-mpi ] } {
+    module load ParaView/5.8.0-foss-2020a-Python-3.8.2-mpi
+}
+
+if { ![ is-loaded gnuplot/5.2.8-GCCcore-9.3.0 ] } {
+    module load gnuplot/5.2.8-GCCcore-9.3.0
+}
+
+prepend-path	CMAKE_PREFIX_PATH		$root
+setenv	EBROOTOPENFOAM		"$root"
+setenv	EBVERSIONOPENFOAM		"v2012"
+setenv	EBDEVELOPENFOAM		"$root/easybuild/OpenFOAM-v2012-foss-2020a-easybuild-devel"
+
+setenv	WM_COMPILE_OPTION		"Opt"
+setenv	WM_PROJECT_VERSION		"v2012"
+setenv	FOAM_INST_DIR		"/usr/local/packages/live/eb/OpenFOAM/v2012-foss-2020a"
+setenv	WM_COMPILER		"Gcc"
+setenv	WM_MPLIB		"EASYBUILDMPI"
+setenv	FOAM_BASH		"/usr/local/packages/live/eb/OpenFOAM/v2012-foss-2020a/OpenFOAM-v2012/etc/bashrc"
+setenv	FOAM_CSH		"/usr/local/packages/live/eb/OpenFOAM/v2012-foss-2020a/OpenFOAM-v2012/etc/cshrc"
+setenv	WM_LABEL_SIZE		"32"
+# Built with EasyBuild version 4.3.4


### PR DESCRIPTION
- Amended the decomposepardictsection as not needed when direct link is there.
- Clarification on the need for decomposepardict in the batch script.
- Amended descriptions for different versions.