### PR TITLE
Updates for EB Intel 2018b toolchain

### DIFF
--- a/bessemer/software/development/icc_ifort.rst
+++ b/bessemer/software/development/icc_ifort.rst
@@ -9,6 +9,7 @@ To activate *both* the C/C++ and Fortran compilers use one of: ::
 
    module load iccifort/2019.5.281  # subset of intel-2019b EasyBuild toolchain
    module load iccifort/2019.1.144-GCC-8.2.0-2.31.1  # subset of intel-2019a toolchain
+   module load iccifort/2018.3.222-GCC-7.3.0-2.30 # subset of intel-2018b toolchain
 
 Which implicitly also load versions of the :ref:`GCC <gcc_bessemer>` compiler.
 

--- a/bessemer/software/libs/imkl.rst
+++ b/bessemer/software/libs/imkl.rst
@@ -4,7 +4,7 @@ Intel MKL
 =========
 
 .. sidebar:: Intel MKL
-   
+
    :URL: https://software.intel.com/en-us/mkl
    :Documentation: https://software.intel.com/en-us/mkl/documentation/view-all
 
@@ -22,7 +22,8 @@ Usage
 The Intel MKL can be activated using one of the following: ::
 
    module load imkl/2019.5.281-iimpi-2019b  # subset of intel-2019b EasyBuild toolchain
-   module load imkl/2019.1.144-iimpi-2019a  # subset of intel-2019b EasyBuild toolchain
+   module load imkl/2019.1.144-iimpi-2019a  # subset of intel-2019a EasyBuild toolchain
+   module load imkl/2018.3.222-iimpi-2018b  # subset of intel-2018b EasyBuild toolchain
 
-which also implicitly loads a version of the :ref:`iimpi <bessemer_eb_toolchains>` toolchain, 
+which also implicitly loads a version of the :ref:`iimpi <bessemer_eb_toolchains>` toolchain,
 itself being a subset of the ``intel`` toolchain.

--- a/bessemer/software/parallel/impi.rst
+++ b/bessemer/software/parallel/impi.rst
@@ -19,6 +19,7 @@ You can load a specific version using one of the following: ::
 
    module use impi/2018.5.288-iccifort-2019.5.281  # subset of intel 2019b EasyBuild toolchain
    module use impi/2018.4.274-iccifort-2019.1.144-GCC-8.2.0-2.31.1  # subset of intel 2019a EasyBuild toolchain
+   module use impi/2018.3.222-iccifort-2018.3.222-GCC-7.3.0-2.30 # subset of intel 2018b EasyBuild toolchain
 
 which implicitly load versions of icc, ifort (and GCC).
 
@@ -85,7 +86,7 @@ You can request an interactive node with multiple cores (4 in this example) by u
 
     srun --ntasks=4 --pty bash -i
 
-Please note that requesting multiple cores in an interactive node depends on the availability. During peak times, it is unlikely that you can successfully request a large number of cpu cores interactively.  Therefore, it may be a better approach to submit your job non-interactively. 
+Please note that requesting multiple cores in an interactive node depends on the availability. During peak times, it is unlikely that you can successfully request a large number of cpu cores interactively.  Therefore, it may be a better approach to submit your job non-interactively.
 
 
 Non-interactive job submission
@@ -115,6 +116,3 @@ Your output would be something like: ::
     ...
     Hello world from processor bessemer-node003.shef.ac.uk, rank 31 out of 40 processors
     Hello world from processor bessemer-node003.shef.ac.uk, rank 32 out of 40 processors
-
-
-


### PR DESCRIPTION
Module loads for EB Intel 2018b toolchain added. Includes Intel MKL, ICC, IFORT and IMPI.

1 correction in Intel MKL for 2019a toolchain labelled incorrectly as 2019b.

Minor update so as soon as it passes I will merge.