### PR TITLE
Fix fluent 21.1

### DIFF
--- a/bessemer/software/apps/ansys/fluent.rst
+++ b/bessemer/software/apps/ansys/fluent.rst
@@ -41,7 +41,7 @@ Fluent Journal files
 ^^^^^^^^^^^^^^^^^^^^
 
 A Fluent journal file is effectively a sequence of TUI and/or Scheme commands that you’ll supply to Fluent instead of using the GUI / TUI.
-A more thorough explanation anmd tutorial on how to make a Fluent journal file can be found on the following page:  :ref:`Writing Fluent journal files. <writing-fluent-journal-files>`
+A more thorough explanation and tutorial on how to make a Fluent journal file can be found on the following page:  :ref:`Writing Fluent journal files. <writing-fluent-journal-files>`
 
 .. important::
 
@@ -64,8 +64,9 @@ Sample SMP Fluent Scheduler Job Script
 
 .. hint::
 
-    * **$SLURM_NTASKS** is a SLURM scheduler variable which will return the requested number of tasks.
-    * **-gu** and **-driver null** instructs Fluent that it will be running with no GUI to avoid errors caused by plot / figure export.
+    * The ``2ddp`` argument is used to specify a 2D double precision simulation. Valid values include: ``2d``, ``2ddp``, ``3d`` and ``3ddp``
+    * The argument ``$SLURM_NTASKS`` is a SLURM scheduler variable which will return the requested number of tasks.
+    * The arguments ``-gu`` and ``-driver null`` instruct Fluent that it will be running with no GUI to avoid errors caused by plot / figure export.
 
 
 .. code-block:: bash

--- a/bessemer/software/apps/ansys/mechanical.rst
+++ b/bessemer/software/apps/ansys/mechanical.rst
@@ -43,11 +43,11 @@ Sample SMP MAPDL Scheduler Job Script
 """""""""""""""""""""""""""""""""""""""""""""
 
 ``Mapdl mechanical``: the following is an example batch submission script, ``mech_job.sh``, to run the mechanical executable ``mapdl`` with input file ``CrankSlot_Flexible.inp``, and carry out a mechanical simulation.
-The script requests 2 cores using the OpenMP parallel environment with a runtime of 60 mins and 2 GB of real memory per core.
+The script requests 2 cores using the SMP parallel environment with a runtime of 60 mins and 2 GB of real memory per core.
 
 .. hint::
 
-    * **$SLURM_NTASKS** is a SLURM scheduler variable which will return the requested number of tasks.
+    * The argument ``$SLURM_NTASKS`` is a SLURM scheduler variable which will return the requested number of tasks.
 
 
 .. code-block:: bash

--- a/referenceinfo/ANSYS/fluent/export-fluent-plots-while-using-batch-jobs.rst
+++ b/referenceinfo/ANSYS/fluent/export-fluent-plots-while-using-batch-jobs.rst
@@ -17,7 +17,7 @@ i.e. for a **ShARC** batch job:
 
 .. code-block:: bash
 
-  fluent 2ddp -i test.jou -gu -t$NSLOTS -mpi=intel -rsh -sgepe mpi-rsh -sge -driver null
+  fluent 2ddp -i test.jou -gu -t$NSLOTS -rsh -mpi=intel -pib.infinipath -driver null
 
 for a **Bessemer** batch job:
 

--- a/sharc/software/apps/ansys/fluent.rst
+++ b/sharc/software/apps/ansys/fluent.rst
@@ -77,6 +77,7 @@ The script requests 8 cores using the MPI parallel environment ``mpi-rsh`` with 
     * The argument ``-mpi=intel`` instructs Fluent to use the in-built Intel MPI communications - important for using the high performance :ref:`Omnipath networking <sharc-network-specs>` between nodes.
     * The argument ``-pib.infinipath`` instructs Fluent to use the high performance Omnipath networking. :ref:`Omnipath networking <sharc-network-specs>` This will not work on version 18.2 and earlier.
     * The arguments ``-gu`` and ``-driver null`` instruct Fluent that it will be running with no GUI to avoid errors caused by plot / figure export.
+    * The arguments ``-sgepe mpi-rsh -sge`` are not required and will cause issues if used with Fluent 21.1.
 
 .. code-block:: bash
 

--- a/sharc/software/apps/ansys/fluent.rst
+++ b/sharc/software/apps/ansys/fluent.rst
@@ -48,7 +48,7 @@ Fluent Journal files
 ^^^^^^^^^^^^^^^^^^^^
 
 A Fluent journal file is effectively a sequence of TUI and/or Scheme commands that you’ll supply to Fluent instead of using the GUI / TUI.
-A more thorough explanation anmd tutorial on how to make a Fluent journal file can be found on the following page:  :ref:`Writing Fluent journal files. <writing-fluent-journal-files>`
+A more thorough explanation and tutorial on how to make a Fluent journal file can be found on the following page:  :ref:`Writing Fluent journal files. <writing-fluent-journal-files>`
 
 .. important::
 
@@ -72,13 +72,11 @@ The script requests 8 cores using the MPI parallel environment ``mpi-rsh`` with 
 
     * Use of the ``#$ -V`` SGE option will instruct SGE to import your current terminal environment variables to be imported - **CAUTION** - this may not be desirable.
     * Use of the ``mpi-rsh`` parallel environment to run MPI parallel jobs for Ansys is required if using more than 16 cores on ShARC.
-    * **$NSLOTS** is a Sun of Grid Engine variable which will return the requested number of cores.
-    * **-mpi=intel** instructs Fluent to use the in-built Intel MPI communications - important for using the high performance :ref:`Omnipath networking <sharc-network-specs>` between nodes.
-    * **-rsh** tells Fluent to use RSH instead of SSH.
-    * **-sge** forces Fluent to recognise job submission via SGE.
-    * **-sgepe** selects the *mpi-rsh* SGE parallel environment.
-    * **-pib.infinipath** instructs Fluent to use the high performance Omnipath networking. :ref:`Omnipath networking <sharc-network-specs>`
-    * **-gu** and **-driver null** instructs Fluent that it will be running with no GUI to avoid errors caused by plot / figure export.
+    * The ``2ddp`` argument is used to specify a 2D double precision simulation. Valid values include: ``2d``, ``2ddp``, ``3d`` and ``3ddp``
+    * The argument ``$NSLOTS`` is a Sun of Grid Engine variable which will return the requested number of cores.
+    * The argument ``-mpi=intel`` instructs Fluent to use the in-built Intel MPI communications - important for using the high performance :ref:`Omnipath networking <sharc-network-specs>` between nodes.
+    * The argument ``-pib.infinipath`` instructs Fluent to use the high performance Omnipath networking. :ref:`Omnipath networking <sharc-network-specs>` This will not work on version 18.2 and earlier.
+    * The arguments ``-gu`` and ``-driver null`` instruct Fluent that it will be running with no GUI to avoid errors caused by plot / figure export.
 
 .. code-block:: bash
 
@@ -94,7 +92,7 @@ The script requests 8 cores using the MPI parallel environment ``mpi-rsh`` with 
 
     module load apps/ansys/20.2/binary
 
-    fluent 2ddp -i test.jou -gu -t$NSLOTS -mpi=intel -rsh -sgepe mpi-rsh -sge -pib.infinipath -driver null
+    fluent 2ddp -i test.jou -gu -t$NSLOTS -rsh -mpi=intel -pib.infinipath -driver null
 
 -----------------------
 
@@ -117,7 +115,7 @@ The following is an example batch submission script, ``cfd_job.sh``, to run the 
 
     module load apps/ansys/20.2/binary
 
-    fluent 2ddp -i test.jou -g -t$NSLOTS -mpi=intel -rsh -sgepe smp -sge -driver null
+    fluent 2ddp -i test.jou -gu -t$NSLOTS -driver null
 
 
 Further details about how to construct batch jobs can be found on the :ref:`batch submission guide <submit-batch>` page
@@ -131,3 +129,13 @@ The job is submitted to the queue by typing:
 ----------------
 
 .. include:: ../../../../referenceinfo/ANSYS/fluent/export-fluent-plots-while-using-batch-jobs.rst
+
+
+Notes
+-------
+
+The previous options below have been removed due to a bug in Fluent 21.1 which results in incorrect job rewriting and resubmission to the scheduler. All versions have been tested and should automatically detect SGE correctly.
+
+* **-rsh** tells Fluent to use RSH instead of SSH.
+* **-sge** forces Fluent to recognise job submission via SGE.
+* **-sgepe** selects the *mpi-rsh* SGE parallel environment.

--- a/sharc/software/apps/ansys/mechanical.rst
+++ b/sharc/software/apps/ansys/mechanical.rst
@@ -49,11 +49,11 @@ The script requests 4 cores using the MPI parallel environment with a runtime of
 
     * Use of the ``#$ -V`` SGE option will instruct SGE to import your current terminal environment variables to be imported - **CAUTION** - this may not be desirable.
     * Use of the ``mpi-rsh`` parallel environment to run MPI parallel jobs for Ansys is required if using more than 16 cores on ShARC.
-    * **$NSLOTS** is a Sun of Grid Engine variable which will return the requested number of cores.
-    * **-mpi=INTELMPI** instructs MAPDL to use the in-built Intel MPI communications - important for using the high performance :ref:`Omnipath networking <sharc-network-specs>` between nodes.
-    * **-rsh** tells MAPDL to use RSH instead of SSH.
-    * **-sge** forces MAPDL to recognise job submission via SGE.
-    * **-sgepe** selects the *mpi-rsh* SGE parallel environment.
+    * The argument ``$NSLOTS`` is a Sun of Grid Engine variable which will return the requested number of cores.
+    * The argument ``-mpi=INTELMPI`` instructs MAPDL to use the in-built Intel MPI communications - important for using the high performance :ref:`Omnipath networking <sharc-network-specs>` between nodes.
+    * The argument ``-rsh`` tells MAPDL to use RSH instead of SSH.
+    * The argument ``-sge`` forces MAPDL to recognise job submission via SGE.
+    * The argument ``-sgepe`` selects the *mpi-rsh* SGE parallel environment.
 
 .. code-block:: bash
 
@@ -75,7 +75,7 @@ Sample SMP MAPDL Scheduler Job Script
 """"""""""""""""""""""""""""""""""""""""""""
 
 The following is an example batch submission script, ``mech_job.sh``, to run the mechanical executable ``mapdl`` with input file ``CrankSlot_Flexible.inp``, and carry out a mechanical simulation.
-The script requests 4 cores using the OpenMP (``single node shared memory``) parallel environment with a runtime of 10 mins and 2 GB of real memory per core:
+The script requests 4 cores using the SMP (``single node shared memory``) parallel environment with a runtime of 10 mins and 2 GB of real memory per core:
 
 .. code-block:: bash
 


### PR DESCRIPTION
Amended bold arguments to use proper red highlighting. Ln 75
Corrected the Fluent SMP job script on ShARC. Ln 120.
Added further explanation of fluent dimension options. Ln 75 / 67.
Clarified Omnipath incompatibility. Ln 78.
Amended job scripts for ShARC MPI to avoid Fluent 21.1 error. Ln Various.
Various corrections to typos.

Will merge immediately since this contains a correction to the Fluent commands for 21.1 / all versions indirectly.