### PR TITLE
Updating the "Getting and Account" page to reflect the HPC Driving License requirements

### DIFF
--- a/hpc/accounts.rst
+++ b/hpc/accounts.rst
@@ -3,34 +3,64 @@
 Getting an Account
 ==================
 
-Before you can start using the clusters you need to register for an HPC account.
+Before you can start using the clusters you must first request HPC access. HPC access allows usage 
+of all of our clusters (:ref:`Bessemer <bessemer>` and :ref:`ShARC <sharc>`).
 
-An account gives you access to all our clusters (Bessemer and ShARC).
+For Staff
+^^^^^^^^^
 
-Accounts are available for staff by emailing `it-servicedesk@sheffield.ac.uk <it-servicedesk@sheffield.ac.uk>`_.
+HPC access is made available for staff by emailing their request to 
+`it-servicedesk@sheffield.ac.uk <it-servicedesk@sheffield.ac.uk>`_.
 
-The following categories of students can also have an account with
+For Students
+^^^^^^^^^^^^
+
+The following categories of students can also have HPC access with
 the permission of their supervisors:
 
 * Research Postgraduates
-* Taught Postgraduates - project work
-* Undergraduates 3rd & 4th year  - project work
+* Taught Postgraduates - for project work
+* Undergraduates 3rd & 4th year  - for project work
 
-A student's supervisor can request an account for the student by emailing
-`it-servicedesk@sheffield.ac.uk <it-servicedesk@sheffield.ac.uk>`_.
+To be granted HPC access, all students must first pass the 
+`HPC Driving License test <https://infosecurity.shef.ac.uk/>`_. **(The VPN must be connected in order to 
+access.)**
 
-.. note::
+Following this, they should request that their academic supervisor fill in the HPC access 
+request form which can be found at the 
+`IT Service Desk Self Service Portal <https://shef.topdesk.net/tas/public/ssp/>`_ under the option 
+Service Request Forms.
+
+Once you have been granted HPC access by the service desk, you can use your normal 
+Sheffield login credentials to connect to the clusters. 
+
+For further details on how to connect to the clusters please read the 
+section on :ref:`how to connect to the clusters<connecting>`. 
+
+Conditions for HPC access / usage
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+As a multiple user shared system, our clusters have some additional considerations in comparison 
+to other IT Services provided at the University of Sheffield. Although we have strived to ensure 
+that a robust baseline of security is in place suitable for the HPC community, we are aware 
+that regulatory bodies and our research partners are asking for increasingly stringent security 
+controls that the HPC may not have in place.
+
+Extra care should always be taken when dealing with sensitive information; if you are in any doubt about 
+the sensitivity of information, or how it should be handled, then please contact the IT Services 
+`it-servicedesk@sheffield.ac.uk <it-servicedesk@sheffield.ac.uk>`_ for advice.
+
+
+.. warning::
+
+   The High Performance Computing service should not be used to store or process sensitive information.
+   For example: medical records, personal information, financial data, commercially sensitive or 
+   any other form of restricted data without first discussing your requirements with the Research IT Team - 
+   research-it@sheffield.ac.uk 
+
+.. important::
 
    You must not share your account credentials or allow others to run jobs using your account. 
    Any misuse of accounts will be investigated in accordance with 
-   the University of Sheffield's `IT Code of Practice <https://www.sheffield.ac.uk/it-services/codeofpractice/core>`__.
-
-.. note::
-
-   The High Performance Computing service should not be used to store or process sensitive information for 
-   example personal information, financial data, commercially sensitive or any other form of restricted data 
-   without first discussing your requirements with the Research IT Team - research-it@sheffield.ac.uk 
-
-   Extra care should always be taken when dealing with sensitive information; if you are in any doubt about 
-   the sensitivity of information, or how it should be handled, then please contact the IT Services 
-   `it-servicedesk@sheffield.ac.uk <it-servicedesk@sheffield.ac.uk>`_ for advice.
+   the University of Sheffield's 
+   `IT Code of Practice <https://www.sheffield.ac.uk/it-services/codeofpractice/core>`__.

--- a/hpc/accounts.rst
+++ b/hpc/accounts.rst
@@ -6,6 +6,8 @@ Getting an Account
 Before you can start using the clusters you must first request HPC access. HPC access allows usage 
 of all of our clusters (:ref:`Bessemer <bessemer>` and :ref:`ShARC <sharc>`).
 
+--------
+
 For Staff
 ^^^^^^^^^
 
@@ -37,19 +39,24 @@ Sheffield login credentials to connect to the clusters.
 For further details on how to connect to the clusters please read the 
 section on :ref:`how to connect to the clusters<connecting>`. 
 
+--------
+
 Conditions for HPC access / usage
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. important::
+
+   You must not share your account credentials or allow others to run jobs using your account. 
+   Any misuse of accounts will be investigated in accordance with 
+   the University of Sheffield's 
+   `IT Code of Practice <https://www.sheffield.ac.uk/it-services/codeofpractice/core>`__.
+
 
 As a multiple user shared system, our clusters have some additional considerations in comparison 
 to other IT Services provided at the University of Sheffield. Although we have strived to ensure 
 that a robust baseline of security is in place suitable for the HPC community, we are aware 
 that regulatory bodies and our research partners are asking for increasingly stringent security 
 controls that the HPC may not have in place.
-
-Extra care should always be taken when dealing with sensitive information; if you are in any doubt about 
-the sensitivity of information, or how it should be handled, then please contact the IT Services 
-`it-servicedesk@sheffield.ac.uk <it-servicedesk@sheffield.ac.uk>`_ for advice.
-
 
 .. warning::
 
@@ -58,9 +65,10 @@ the sensitivity of information, or how it should be handled, then please contact
    any other form of restricted data without first discussing your requirements with the Research IT Team - 
    research-it@sheffield.ac.uk 
 
-.. important::
+Extra care should always be taken when dealing with sensitive information; if you are in any doubt about 
+the sensitivity of information, or how it should be handled, then please contact IT Services 
+`it-servicedesk@sheffield.ac.uk <it-servicedesk@sheffield.ac.uk>`_ for advice.
 
-   You must not share your account credentials or allow others to run jobs using your account. 
-   Any misuse of accounts will be investigated in accordance with 
-   the University of Sheffield's 
-   `IT Code of Practice <https://www.sheffield.ac.uk/it-services/codeofpractice/core>`__.
+
+
+


### PR DESCRIPTION
-Majorly reworded.
-Reworked in details from https://www.sheffield.ac.uk/it-services/research/hpc-facilities
-Adjusted styling to highlight the warnings.

I'm not 100% happy with this yet as the warning not to share account details seems a little out of place.