### PR TITLE
Cuda + cuDNN ShARC updates

### DIFF
--- a/sharc/software/libs/cuda.rst
+++ b/sharc/software/libs/cuda.rst
@@ -23,6 +23,8 @@ There are several versions of the CUDA library available.
 As with much software installed on the cluster, 
 versions of CUDA are activated via the :ref:`'module load' command<env_modules>`: ::
 
+   module load libs/CUDA/11.3.0/binary
+   module load libs/CUDA/11.2.0/binary
    module load libs/CUDA/11.1.1/binary
    module load libs/CUDA/11.0.2/binary
    module load libs/CUDA/10.2.89/binary
@@ -67,23 +69,24 @@ In a ``qrshx`` session:
 .. code-block:: sh
 
    # Load modules
-   module load libs/CUDA/11.1.1/binary
+   module load libs/CUDA/11.3.0/binary
 
    # Copy CUDA samples to a local directory
-   # It will create a directory called NVIDIA_CUDA-11.1_Samples/
+   # It will create a directory called NVIDIA_CUDA-11.3_Samples/
    mkdir cuda_samples
    cd cuda_samples
    cp -r $CUDA_SDK .
 
-   # Compile (this will take a while)
-   cd NVIDIA_CUDA-11.1_Samples/
+   # Compile
+   cd NVIDIA_CUDA-11.3_Samples/1_Utilities/deviceQuery
    make
 
 The ``make`` command then runs the ``nvcc`` CUDA compiler and
 generates a binary executable that you can then run on a node with
 an NVIDIA GPU installed.
 
-A basic test is to run one of the resulting binaries, ``deviceQuery``.
+A basic test is to run the resulting binary, ``deviceQuery`` on a GPU equipped node to show the GPU 
+characteristics.
 
 GPU Code Generation Options
 ---------------------------
@@ -182,7 +185,20 @@ This service runs ``/usr/local/scripts/gpu-nvidia-driver.sh`` at boot time to:
 - Load the ``nvidia`` kernel module;
 - Create several *device nodes* in ``/dev/``.
 
-CUDA 11.0.2
+CUDA 11.3.0
+^^^^^^^^^^^
+
+#. Installed with :download:`install.sh </sharc/software/install_scripts/libs/CUDA/install.sh>` with ``11.3.0_465.19.01`` as the sole argument. 
+#. :download:`Modulefile </sharc/software/modulefiles/libs/CUDA/11.3.0/binary>` was installed as ``/usr/local/modulefiles/libs/CUDA/11.3.0/binary``
+
+
+CUDA 11.2.0
+^^^^^^^^^^^
+
+#. Installed with :download:`install.sh </sharc/software/install_scripts/libs/CUDA/install.sh>` with ``11.2.0_460.27.04`` as the sole argument. 
+#. :download:`Modulefile </sharc/software/modulefiles/libs/CUDA/11.2.0/binary>` was installed as ``/usr/local/modulefiles/libs/CUDA/11.2.0/binary``
+
+CUDA 11.1.1
 ^^^^^^^^^^^
 
 #. Installed with :download:`install.sh </sharc/software/install_scripts/libs/CUDA/install.sh>` with ``11.1.1_455.32.00`` as the sole argument. 

--- a/sharc/software/libs/cudnn.rst
+++ b/sharc/software/libs/cudnn.rst
@@ -25,6 +25,9 @@ Load the appropriate cuDNN version (**and implicitly load a specific CUDA versio
 
 .. code-block:: bash
 
+   module load libs/cudnn/8.2.1.32/binary-cuda-11.3.0
+   module load libs/cudnn/8.2.1.32/binary-cuda-11.2.0
+   module load libs/cudnn/8.1.1.33/binary-cuda-11.2.0
    module load libs/cudnn/8.0.5.39/binary-cuda-11.1.1
    module load libs/cudnn/7.6.5.32/binary-cuda-10.2.89
    module load libs/cudnn/7.6.5.32/binary-cuda-10.1.243
@@ -47,6 +50,9 @@ Examples
 
 Examples are provided for the following versions 
 
+ * ``libs/cudnn/8.2.1.32/binary-cuda-11.3.0``
+ * ``libs/cudnn/8.2.1.32/binary-cuda-11.2.0``
+ * ``libs/cudnn/8.1.1.33/binary-cuda-11.2.0``
  * ``libs/cudnn/8.0.5.39/binary-cuda-11.1.1``
  * ``libs/cudnn/7.6.5.32/binary-cuda-10.2.89``
  * ``libs/cudnn/7.6.5.32/binary-cuda-10.1.243``
@@ -79,6 +85,26 @@ This section is primarily for administrators of the system.
 
 The cuDNN library is only available to download through the `developer portal <https://developer.nvidia.com/cudnn>`_.  
 Installation ``.tgz`` files and ``.deb`` files containing samples are located in ``/usr/local/media/protected/cudnn``.
+
+
+Version 8.2.1.32
+^^^^^^^^^^^^^^^^
+- Install script: :download:`install.sh </sharc/software/install_scripts/libs/cudnn/install.sh>`
+- :download:`Module file for CUDA 11.3 </sharc/software/modulefiles/libs/cudnn/8.2.1.32/binary-cuda-11.3.0>`
+- :download:`Module file for CUDA 11.2 </sharc/software/modulefiles/libs/cudnn/8.2.1.32/binary-cuda-11.2.0>`
+- Testing: ran the ``mnistCUDNN`` example (see *Examples* above) with CUDA 11.2 & 11.3 on a K80 GPU. 
+
+Note that FreeImage is no longer distributed with CUDA version 11.2 or higher thus the 
+``libs/FreeImage/3.18.0/gcc-8.2`` module must be loaded during testing with the ``mnistCUDNN`` example.
+
+Version 8.1.1.33
+^^^^^^^^^^^^^^^^
+- Install script: :download:`install.sh </sharc/software/install_scripts/libs/cudnn/install.sh>`
+- :download:`Module file for CUDA 11.2 </sharc/software/modulefiles/libs/cudnn/8.1.1.33/binary-cuda-11.2.0>`
+- Testing: ran the ``mnistCUDNN`` example (see *Examples* above) with CUDA 11.2 on a K80 GPU. Note that
+
+Note that FreeImage is no longer distributed with CUDA version 11.2 or higher thus the 
+``libs/FreeImage/3.18.0/gcc-8.2`` module must be loaded during testing with the ``mnistCUDNN`` example.
 
 Version 8.0.5.39
 ^^^^^^^^^^^^^^^^

--- a/sharc/software/modulefiles/libs/CUDA/11.2.0/binary
+++ b/sharc/software/modulefiles/libs/CUDA/11.2.0/binary
@@ -1,0 +1,32 @@
+#%Module1.0#####################################################################
+##
+## cuda 11.2.0 module file
+##
+################################################################################
+
+## Module file logging
+source /usr/local/etc/module_logging.tcl
+
+proc ModulesHelp { } {
+        global vers
+        puts stderr "	Adds `Nvidia Cuda-$vers' to your PATH environment variable and necessary libraries"
+}
+
+set vers      11.2.0
+set shortvers 11.2
+
+
+module-whatis   "Loads the necessary `cuda-$vers' library paths"
+
+set prefix /usr/local/packages/libs/CUDA/$vers/binary
+
+setenv       CUDA_DIR        $prefix
+setenv       CUDA_HOME       $prefix
+setenv       CUDA_ROOT       $prefix
+setenv       CUDA_PATH       $prefix
+setenv	     CUDA_SDK	     [format "%s/NVIDIA_CUDA-%s_Samples" $prefix $shortvers]
+
+prepend-path PATH            $prefix/bin
+prepend-path CPATH           $prefix/include
+prepend-path LD_LIBRARY_PATH $prefix/lib64
+prepend-path MANPATH         $prefix/doc/man

--- a/sharc/software/modulefiles/libs/CUDA/11.3.0/binary
+++ b/sharc/software/modulefiles/libs/CUDA/11.3.0/binary
@@ -1,0 +1,32 @@
+#%Module1.0#####################################################################
+##
+## cuda 11.3.0 module file
+##
+################################################################################
+
+## Module file logging
+source /usr/local/etc/module_logging.tcl
+
+proc ModulesHelp { } {
+        global vers
+        puts stderr "	Adds `Nvidia Cuda-$vers' to your PATH environment variable and necessary libraries"
+}
+
+set vers      11.3.0
+set shortvers 11.3
+
+
+module-whatis   "Loads the necessary `cuda-$vers' library paths"
+
+set prefix /usr/local/packages/libs/CUDA/$vers/binary
+
+setenv       CUDA_DIR        $prefix
+setenv       CUDA_HOME       $prefix
+setenv       CUDA_ROOT       $prefix
+setenv       CUDA_PATH       $prefix
+setenv	     CUDA_SDK	     [format "%s/NVIDIA_CUDA-%s_Samples" $prefix $shortvers]
+
+prepend-path PATH            $prefix/bin
+prepend-path CPATH           $prefix/include
+prepend-path LD_LIBRARY_PATH $prefix/lib64
+prepend-path MANPATH         $prefix/doc/man

--- a/sharc/software/modulefiles/libs/cudnn/8.1.1.33/binary-cuda-11.2.0
+++ b/sharc/software/modulefiles/libs/cudnn/8.1.1.33/binary-cuda-11.2.0
@@ -1,0 +1,33 @@
+#%Module1.0#####################################################################
+##
+## cuDNN 8.1.1.33 module file for CUDA 11.2
+##
+################################################################################
+
+## Module file logging
+source /usr/local/etc/module_logging.tcl
+##
+
+proc ModulesHelp { } {
+        global cudnnvers
+        global cudavers
+
+        puts stderr "	Adds `Nvidia cuDNN-$cudnnvers and CUDA $cudavers' to your PATH environment variable 
+}
+
+set cudnnvers 8.1.1.33
+set cudavers  11.2.0
+set cudashortvers  11.2
+
+module-whatis   "loads the necessary `cuDNN-$cudnnvers and CUDA $cudavers' library paths"
+
+module load libs/CUDA/$cudavers/binary
+
+set CUDNN_HOME /usr/local/packages/libs/cudnn/$cudnnvers/binary-cuda-$cudashortvers/cuda
+setenv CUDNN_HOME $CUDNN_HOME
+
+prepend-path C_INCLUDE_PATH $CUDNN_HOME/include/
+prepend-path CPLUS_INCLUDE_PATH $CUDNN_HOME/include/
+prepend-path LD_LIBRARY_PATH $CUDNN_HOME/lib64/
+prepend-path CPATH $CUDNN_HOME/include/
+prepend-path LIBRARY_PATH $CUDNN_HOME/lib64/

--- a/sharc/software/modulefiles/libs/cudnn/8.2.1.32/binary-cuda-11.2.0
+++ b/sharc/software/modulefiles/libs/cudnn/8.2.1.32/binary-cuda-11.2.0
@@ -1,0 +1,33 @@
+#%Module1.0#####################################################################
+##
+## cuDNN 8.2.1.32 module file for CUDA 11.2
+##
+################################################################################
+
+## Module file logging
+source /usr/local/etc/module_logging.tcl
+##
+
+proc ModulesHelp { } {
+        global cudnnvers
+        global cudavers
+
+        puts stderr "	Adds `Nvidia cuDNN-$cudnnvers and CUDA $cudavers' to your PATH environment variable 
+}
+
+set cudnnvers 8.2.1.32
+set cudavers  11.2.0
+set cudashortvers  11.2
+
+module-whatis   "loads the necessary `cuDNN-$cudnnvers and CUDA $cudavers' library paths"
+
+module load libs/CUDA/$cudavers/binary
+
+set CUDNN_HOME /usr/local/packages/libs/cudnn/$cudnnvers/binary-cuda-$cudashortvers/cuda
+setenv CUDNN_HOME $CUDNN_HOME
+
+prepend-path C_INCLUDE_PATH $CUDNN_HOME/include/
+prepend-path CPLUS_INCLUDE_PATH $CUDNN_HOME/include/
+prepend-path LD_LIBRARY_PATH $CUDNN_HOME/lib64/
+prepend-path CPATH $CUDNN_HOME/include/
+prepend-path LIBRARY_PATH $CUDNN_HOME/lib64/

--- a/sharc/software/modulefiles/libs/cudnn/8.2.1.32/binary-cuda-11.3.0
+++ b/sharc/software/modulefiles/libs/cudnn/8.2.1.32/binary-cuda-11.3.0
@@ -1,0 +1,33 @@
+#%Module1.0#####################################################################
+##
+## cuDNN 8.2.1.32 module file for CUDA 11.3
+##
+################################################################################
+
+## Module file logging
+source /usr/local/etc/module_logging.tcl
+##
+
+proc ModulesHelp { } {
+        global cudnnvers
+        global cudavers
+
+        puts stderr "	Adds `Nvidia cuDNN-$cudnnvers and CUDA $cudavers' to your PATH environment variable 
+}
+
+set cudnnvers 8.2.1.32
+set cudavers  11.3.0
+set cudashortvers  11.3
+
+module-whatis   "loads the necessary `cuDNN-$cudnnvers and CUDA $cudavers' library paths"
+
+module load libs/CUDA/$cudavers/binary
+
+set CUDNN_HOME /usr/local/packages/libs/cudnn/$cudnnvers/binary-cuda-$cudashortvers/cuda
+setenv CUDNN_HOME $CUDNN_HOME
+
+prepend-path C_INCLUDE_PATH $CUDNN_HOME/include/
+prepend-path CPLUS_INCLUDE_PATH $CUDNN_HOME/include/
+prepend-path LD_LIBRARY_PATH $CUDNN_HOME/lib64/
+prepend-path CPATH $CUDNN_HOME/include/
+prepend-path LIBRARY_PATH $CUDNN_HOME/lib64/


### PR DESCRIPTION
Adding the newer versions of both required for Tensorflow 2.5.0 and Alphafold 2 to the docs.