### PR TITLE
Gaussian stub page update.

### DIFF
--- a/sharc/software/apps/gaussian.rst
+++ b/sharc/software/apps/gaussian.rst
@@ -1,6 +1,8 @@
 Gaussian
 ========
 
+.. _gaussian_sharc:
+
 .. sidebar:: Gaussian 
 
    :Version: 09 E.01, 16 C.01

--- a/sharc/software/apps/gaussian_09.rst
+++ b/sharc/software/apps/gaussian_09.rst
@@ -3,4 +3,6 @@ Gaussian_09
 
 .. raw:: html
 
-    <meta http-equiv="refresh" content="time; URL=./gaussian.html" />
+    <meta http-equiv="refresh" content="0; URL=./gaussian.html" />
+
+This page is now a stub, the details for Gaussian on ShARC can now be found here: :ref:`Gaussian on ShARC.<gaussian_sharc>`


### PR DESCRIPTION
This should fix the redirect (does in Chromium for me.)
Also adds a link if the redirect does not work.