### PR TITLE
ANSYS 21.2 Added - docs update

### DIFF
--- a/bessemer/software/apps/ansys/bessemer-sidebar.rst
+++ b/bessemer/software/apps/ansys/bessemer-sidebar.rst
@@ -4,6 +4,6 @@
 
 .. sidebar:: ANSYS
 
-   :Versions: 19.4, 20.1, 20.2  and 21.1
-   :Dependencies: UDFs / User subroutines need the GCC/7.3.0-2.30 compiler or above.
+   :Versions: 19.4, 20.1, 20.2,  21.1  and 21.2
+   :Dependencies: UDFs / User subroutines will also need either the GCC or Intel C compiler with correct versions.
    :URL: http://www.ansys.com

--- a/bessemer/software/apps/ansys/index.rst
+++ b/bessemer/software/apps/ansys/index.rst
@@ -44,6 +44,7 @@ ANSYS example models
 ANSYS contains a large number of example models which can be used to become familiar with the software.
 The models can be found in::
 
+   /usr/local/packages/live/noeb/ANSYS/21.2/binary/v212/ansys/data/
    /usr/local/packages/live/noeb/ANSYS/21.1/binary/v211/ansys/data/
    /usr/local/packages/live/noeb/ANSYS/20.2/binary/v202/ansys/data/
    /usr/local/packages/live/noeb/ANSYS/20.1/binary/v201/ansys/data/
@@ -68,15 +69,16 @@ The following instruction should be inserted at line 2433 in ``anssh.ini``::
 
 ------------
 
-Please note ANSYS 20.1, 20.2 and 21.1 have been installed manually with the GUI in the following directories and permissions corrected as follows::
+Please note ANSYS 20.1 and higher versions have been installed manually with the GUI in the following directories and permissions corrected as follows::
 
     chmod 775 -R /usr/local/packages/live/noeb/ANSYS/20.1/binary/
     chmod 775 -R /usr/local/packages/live/noeb/ANSYS/20.2/binary/
     chmod 775 -R /usr/local/packages/live/noeb/ANSYS/21.1/binary/
+    chmod 775 -R /usr/local/packages/live/noeb/ANSYS/21.2/binary/
 
 Please follow the same install directory structure.
 
-In addition the following software packages are not included with the installations::
+In addition the following software packages are not included with the installations for ANSYS 19.4::
 
 
     "ANSYS Chemkin"
@@ -89,3 +91,5 @@ Module files are available below:
 - :download:`/usr/local/modulefiles/live/eb/all/ANSYS/19.4 </bessemer/software/modulefiles/ansys/19.4/19.4>`
 - :download:`/usr/local/modulefiles/live/noeb/ANSYS/20.1/binary </bessemer/software/modulefiles/ansys/20.1/binary>`
 - :download:`/usr/local/modulefiles/live/noeb/ANSYS/20.2/binary  </bessemer/software/modulefiles/ansys/20.2/binary>`
+- :download:`/usr/local/modulefiles/live/noeb/ANSYS/21.1/binary  </bessemer/software/modulefiles/ansys/21.1/binary>`
+- :download:`/usr/local/modulefiles/live/noeb/ANSYS/21.2/binary  </bessemer/software/modulefiles/ansys/21.2/binary>`

--- a/bessemer/software/apps/ansys/module-load-list.rst
+++ b/bessemer/software/apps/ansys/module-load-list.rst
@@ -8,3 +8,4 @@ After connecting to Bessemer (see :ref:`ssh`),  you can start an `interactive gr
    module load ANSYS/20.1/binary
    module load ANSYS/20.2/binary
    module load ANSYS/21.1/binary
+   module load ANSYS/21.2/binary

--- a/bessemer/software/modulefiles/ansys/21.1/binary
+++ b/bessemer/software/modulefiles/ansys/21.1/binary
@@ -1,0 +1,52 @@
+#%Module
+source /usr/local/etc/module_logging.tcl
+
+proc ModulesHelp { } {
+    puts stderr {
+
+Description
+===========
+ANSYS simulation software enables organizations to confidently predict
+    how their products will operate in the real world. We believe that every product is
+    a promise of something greater.
+
+
+More information
+================
+ - Homepage: http://www.ansys.com
+    }
+}
+
+module-whatis {Description: ANSYS simulation software enables organizations to confidently predict
+    how their products will operate in the real world. We believe that every product is
+    a promise of something greater. }
+module-whatis {Homepage: http://www.ansys.com}
+module-whatis {URL: http://www.ansys.com}
+
+set root /usr/local/packages/live/noeb/ANSYS/21.1/binary/
+
+conflict ANSYS
+
+prepend-path	PATH		$root/v211/Framework/bin/Linux64
+prepend-path	PATH		$root/v211/aisol/bin/linx64
+prepend-path	PATH		$root/v211/RSM/bin
+prepend-path	PATH		$root/v211/ansys/bin
+prepend-path	PATH		$root/v211/autodyn/bin
+prepend-path	PATH		$root/v211/CFD-Post/bin
+prepend-path	PATH		$root/v211/CFX/bin
+prepend-path	PATH		$root/v211/fluent/bin
+prepend-path	PATH		$root/v211/TurboGrid/bin
+prepend-path	PATH		$root/v211/polyflow/bin
+prepend-path	PATH		$root/v211/Icepak/bin
+prepend-path	PATH		$root/v211/icemcfd/linux64_amd/bin
+prepend-path	PATH		$root/v211/CEI/bin
+setenv	EBROOTANSYS		"$root"
+setenv	EBVERSIONANSYS		"21.1"
+setenv	EBDEVELANSYS		"$root/easybuild/ANSYS-21.1-easybuild-devel"
+
+prepend-path	PATH		$root
+setenv	ICEM_ACN		"/usr/local/packages/live/noeb/ANSYS/21.1/binary/v211/icemcfd/linux64_amd"
+# NOT Built with EasyBuild version 4.0.0
+
+# Fix applied for issue with core allocation problem - JM 25-09-2020 - see https://github.com/rcgsheffield/sheffield_hpc/issues/1082
+setenv FLUENT_AFFINITY "0" 

--- a/bessemer/software/modulefiles/ansys/21.2/binary
+++ b/bessemer/software/modulefiles/ansys/21.2/binary
@@ -1,0 +1,52 @@
+#%Module
+source /usr/local/etc/module_logging.tcl
+
+proc ModulesHelp { } {
+    puts stderr {
+
+Description
+===========
+ANSYS simulation software enables organizations to confidently predict
+    how their products will operate in the real world. We believe that every product is
+    a promise of something greater.
+
+
+More information
+================
+ - Homepage: http://www.ansys.com
+    }
+}
+
+module-whatis {Description: ANSYS simulation software enables organizations to confidently predict
+    how their products will operate in the real world. We believe that every product is
+    a promise of something greater. }
+module-whatis {Homepage: http://www.ansys.com}
+module-whatis {URL: http://www.ansys.com}
+
+set root /usr/local/packages/live/noeb/ANSYS/21.2/binary/
+
+conflict ANSYS
+
+prepend-path	PATH		$root/v212/Framework/bin/Linux64
+prepend-path	PATH		$root/v212/aisol/bin/linx64
+prepend-path	PATH		$root/v212/RSM/bin
+prepend-path	PATH		$root/v212/ansys/bin
+prepend-path	PATH		$root/v212/autodyn/bin
+prepend-path	PATH		$root/v212/CFD-Post/bin
+prepend-path	PATH		$root/v212/CFX/bin
+prepend-path	PATH		$root/v212/fluent/bin
+prepend-path	PATH		$root/v212/TurboGrid/bin
+prepend-path	PATH		$root/v212/polyflow/bin
+prepend-path	PATH		$root/v212/Icepak/bin
+prepend-path	PATH		$root/v212/icemcfd/linux64_amd/bin
+prepend-path	PATH		$root/v212/CEI/bin
+setenv	EBROOTANSYS		"$root"
+setenv	EBVERSIONANSYS		"21.2"
+setenv	EBDEVELANSYS		"$root/easybuild/ANSYS-21.2-easybuild-devel"
+
+prepend-path	PATH		$root
+setenv	ICEM_ACN		"/usr/local/packages/live/noeb/ANSYS/21.2/binary/v212/icemcfd/linux64_amd"
+# NOT Built with EasyBuild version 4.0.0
+
+# Fix applied for issue with core allocation problem - JM 25-09-2020 - see https://github.com/rcgsheffield/sheffield_hpc/issues/1082
+setenv FLUENT_AFFINITY "0" 

--- a/sharc/software/apps/ansys/index.rst
+++ b/sharc/software/apps/ansys/index.rst
@@ -42,6 +42,7 @@ ANSYS example models
 ANSYS contains a large number of example models which can be used to become familiar with the software.
 The models can be found in::
 
+  /usr/local/packages/apps/ansys/21.2/binary/v212/ansys/data
   /usr/local/packages/apps/ansys/21.1/binary/v211/ansys/data
   /usr/local/packages/apps/ansys/20.2/binary/v202/ansys/data
   /usr/local/packages/apps/ansys/20.1/binary/v201/ansys/data
@@ -63,6 +64,9 @@ The models can be found in::
 
 Installation notes
 ------------------
+
+The ``mpi-rsh`` tight-integration parallel environment is required to run ANSYS/Fluent using MPI due to
+SSH access to worker nodes being prohibited for most users.
 
 ANSYS 15.0 was installed using the
 :download:`install_ansys.sh </sharc/software/install_scripts/apps/ansys/15.0/install_ansys.sh>` script; the module
@@ -114,18 +118,35 @@ ANSYS 19.4 was installed using the
 file is
 :download:`/usr/local/modulefiles/apps/ansys/19.4/binary </sharc/software/modulefiles/apps/ansys/19.4/binary>`.
 
+ANSYS 20.1 was installed using the GUI installer with all features and the module
+file is
+:download:`/usr/local/modulefiles/apps/ansys/20.1/binary </sharc/software/modulefiles/apps/ansys/20.1/binary>`.
+
+ANSYS 20.2 was installed using the GUI installer with all features and the module
+file is
+:download:`/usr/local/modulefiles/apps/ansys/20.2/binary </sharc/software/modulefiles/apps/ansys/20.2/binary>`.
+
+ANSYS 21.1 was installed using the GUI installer with all features and the module
+file is
+:download:`/usr/local/modulefiles/apps/ansys/21.1/binary </sharc/software/modulefiles/apps/ansys/21.1/binary>`.
+
+ANSYS 21.2 was installed using the GUI installer with all features and the module
+file is
+:download:`/usr/local/modulefiles/apps/ansys/21.2/binary </sharc/software/modulefiles/apps/ansys/21.2/binary>`.
+
+
 ----------
 
-ANSYS 20.1, 20.2 and 21.1 were installed using the GUI installer and then permissions were corrected as follows::
+ANSYS 20.1, and higher were installed using the GUI installer and then permissions were corrected as follows::
 
     chmod 775 -R /usr/local/packages/apps/ansys/20.1/binary
     chmod 775 -R /usr/local/packages/apps/ansys/20.2/binary
     chmod 775 -R /usr/local/packages/apps/ansys/21.1/binary
+    chmod 775 -R /usr/local/packages/apps/ansys/21.2/binary
 
 Please follow the same install directory structure.
 
-The ``mpi-rsh`` tight-integration parallel environment is required to run ANSYS/Fluent using MPI due to
-SSH access to worker nodes being prohibited for most users.
+
 
 For versions 19.3 & 19.4 and onward mapdl will not run without modifying the file::
 

--- a/sharc/software/apps/ansys/module-load-list.rst
+++ b/sharc/software/apps/ansys/module-load-list.rst
@@ -19,3 +19,4 @@ or :ref:`submit a batch job <submit-batch>` using ANSYS programs activating them
   module load apps/ansys/20.1/binary
   module load apps/ansys/20.2/binary
   module load apps/ansys/21.1/binary
+  module load apps/ansys/21.2/binary

--- a/sharc/software/apps/ansys/sharc-sidebar.rst
+++ b/sharc/software/apps/ansys/sharc-sidebar.rst
@@ -4,6 +4,6 @@
 
 .. sidebar:: ANSYS
 
-   :Versions: 15.0, 16.1, 17.2, 18.0, 18.2, 19.0, 19.1, 19.2, 19.3, 19.4, 20.1, 20.2 & 21.1
-   :Dependencies: No prerequisite modules loaded. However, if using the User Defined Functions (UDF) will also need the following: For ANSYS Mechanical, Workbench, CFX and AutoDYN: Intel 14.0 or above; Compiler For Fluent: GCC 4.6.1 or above
+   :Versions: 15.0, 16.1, 17.2, 18.0, 18.2, 19.0, 19.1, 19.2, 19.3, 19.4, 20.1, 20.2, 21.1 & 21.2
+   :Dependencies: UDFs / User subroutines will also need either the GCC or Intel C compiler with correct versions.
    :URL: http://www.ansys.com

--- a/sharc/software/modulefiles/apps/ansys/21.1/binary
+++ b/sharc/software/modulefiles/apps/ansys/21.1/binary
@@ -1,0 +1,48 @@
+#%Module10.2#####################################################################
+##
+## ANSYS 21.1 module file
+##
+#  Updated by James Moore 18/01/2021
+#
+#  
+################################################################################
+
+## Module file logging
+source /usr/local/etc/module_logging.tcl
+##
+
+proc ModulesHelp { } {
+        global version
+
+        puts stderr "   Makes ANSYS Version 21.1 available for use"
+}
+
+module-whatis   "Makes ANSYS V21.1 available"
+
+# module variables
+#
+set ANSYS_DIR     /usr/local/packages/apps/ansys/21.1/binary/v211
+
+setenv  ANSYSROOT $ANSYS_DIR
+setenv  ANSYSVER 211
+setenv  ANSWBCOMMAND $ANSYS_DIR/Framework/bin/Linux64/runwb2
+setenv  FLUENT_INC $ANSYS_DIR/fluent
+setenv  ICEM_ACN $ANSYS_DIR/icemcfd/linux64_amd
+setenv  REACTION_DIR $ANSYS_DIR/reaction
+
+prepend-path PATH $ANSYS_DIR/Framework/bin/Linux64/
+prepend-path PATH $ANSYS_DIR/aisol/bin/linx64
+prepend-path PATH $ANSYS_DIR/RSM/bin
+prepend-path PATH $ANSYS_DIR/ansys/bin
+prepend-path PATH $ANSYS_DIR/autodyn/bin
+prepend-path PATH $ANSYS_DIR/CFD-Post/bin
+prepend-path PATH $ANSYS_DIR/CFX/bin
+prepend-path PATH $ANSYS_DIR/fluent/bin
+prepend-path PATH $ANSYS_DIR/TurboGrid/bin
+prepend-path PATH $ANSYS_DIR/polyflow/bin
+prepend-path PATH $ANSYS_DIR/Icepak/bin
+prepend-path PATH $ANSYS_DIR/icemcfd/linux64_amd/bin
+prepend-path PATH $ANSYS_DIR/CEI/bin
+
+set-alias  ansyswb {\$ANSYSROOT/Framework/bin/Linux64/runwb2}
+set-alias  ansys-mechanical {\$ANSYSROOT/ansys/bin/mapdl}

--- a/sharc/software/modulefiles/apps/ansys/21.2/binary
+++ b/sharc/software/modulefiles/apps/ansys/21.2/binary
@@ -1,0 +1,48 @@
+#%Module10.2#####################################################################
+##
+## ANSYS 21.2 module file
+##
+#  Updated by James Moore 01/09/2021
+#
+#  
+################################################################################
+
+## Module file logging
+source /usr/local/etc/module_logging.tcl
+##
+
+proc ModulesHelp { } {
+        global version
+
+        puts stderr "   Makes ANSYS Version 21.2 available for use"
+}
+
+module-whatis   "Makes ANSYS V21.2 available"
+
+# module variables
+#
+set ANSYS_DIR     /usr/local/packages/apps/ansys/21.2/binary/v212
+
+setenv  ANSYSROOT $ANSYS_DIR
+setenv  ANSYSVER 212
+setenv  ANSWBCOMMAND $ANSYS_DIR/Framework/bin/Linux64/runwb2
+setenv  FLUENT_INC $ANSYS_DIR/fluent
+setenv  ICEM_ACN $ANSYS_DIR/icemcfd/linux64_amd
+setenv  REACTION_DIR $ANSYS_DIR/reaction
+
+prepend-path PATH $ANSYS_DIR/Framework/bin/Linux64/
+prepend-path PATH $ANSYS_DIR/aisol/bin/linx64
+prepend-path PATH $ANSYS_DIR/RSM/bin
+prepend-path PATH $ANSYS_DIR/ansys/bin
+prepend-path PATH $ANSYS_DIR/autodyn/bin
+prepend-path PATH $ANSYS_DIR/CFD-Post/bin
+prepend-path PATH $ANSYS_DIR/CFX/bin
+prepend-path PATH $ANSYS_DIR/fluent/bin
+prepend-path PATH $ANSYS_DIR/TurboGrid/bin
+prepend-path PATH $ANSYS_DIR/polyflow/bin
+prepend-path PATH $ANSYS_DIR/Icepak/bin
+prepend-path PATH $ANSYS_DIR/icemcfd/linux64_amd/bin
+prepend-path PATH $ANSYS_DIR/CEI/bin
+
+set-alias  ansyswb {\$ANSYSROOT/Framework/bin/Linux64/runwb2}
+set-alias  ansys-mechanical {\$ANSYSROOT/ansys/bin/mapdl}


### PR DESCRIPTION
Added the new numbers and adjusted the docs to reflect the all features installation status of versions 20.X and above to fix missing Chemkin setup script files. (Thanks Ansys!)

Both clusters.