### PR TITLE
MPI-version-fix-and-rewording

### DIFF
--- a/sharc/software/apps/ansys/mechanical.rst
+++ b/sharc/software/apps/ansys/mechanical.rst
@@ -12,7 +12,7 @@ Mechanical / Map-DL
 
 Ansys Mechanical is a finite element analysis (FEA) tool that enables you to analyze complex product architectures and solve difficult mechanical problems.
 You can use Ansys Mechanical to simulate real world behavior of components and sub-systems, and customize it to test design variations quickly and accurately.
-ANSYS Mechanical has interfaces to other pre and post processing packages supplied by ANSYS and can make use of  built in :ref:`MPI <parallel_MPI>` to utilize multiple cross node CPU and can scale to hundreds of cores.
+ANSYS Mechanical has interfaces to other pre and post processing packages supplied by ANSYS and can make use of  built in :ref:`MPI <parallel_MPI>` to utilize multiple cross node CPUs and can scale to hundreds of cores.
 
 ----------------
 
@@ -35,12 +35,15 @@ Batch jobs
 ----------
 
 MAPDL is capable of running in both :ref:`MPI <parallel_MPI>` and :ref:`SMP <parallel_SMP>` parallel environments but will use its in-build MPI communications for both.
-On ShARC, cross process communication must use the RSH protocol instead of SSH.
-This necessitates the use of either the ``smp`` (up to 16 cores on a single node only) or ``mpi-rsh`` (as many cores as desired across many nodes) parallel processing environments.
+This necessitates the use of either the ``smp`` (up to 16 cores on a single node only) or ``mpi`` (as many cores as desired across many nodes) parallel processing environments.
 
 
 Sample MPI MAPDL Scheduler Job Script
 """"""""""""""""""""""""""""""""""""""""""
+
+.. error::
+    * Please use ANSYS versions 19.4 and above to avoid errors which result in MAPDL falling back to 
+      using SMP rather than MPI mode. 
 
 The following is an example batch submission script, ``mech_job.sh``, to run the mechanical executable ``mapdl`` with input file ``CrankSlot_Flexible.inp``, and carry out a mechanical simulation.
 The script requests 4 cores using the MPI parallel environment with a runtime of 10 mins and 2 GB of real memory per core:
@@ -48,12 +51,11 @@ The script requests 4 cores using the MPI parallel environment with a runtime of
 .. hint::
 
     * Use of the ``#$ -V`` SGE option will instruct SGE to import your current terminal environment variables to be imported - **CAUTION** - this may not be desirable.
-    * Use of the ``mpi-rsh`` parallel environment to run MPI parallel jobs for Ansys is required if using more than 16 cores on ShARC.
+    * Use of the ``mpi`` parallel environment to run MPI parallel jobs for Ansys is required if using more than 16 cores on ShARC.
     * The argument ``$NSLOTS`` is a Sun of Grid Engine variable which will return the requested number of cores.
-    * The argument ``-mpi=INTELMPI`` instructs MAPDL to use the in-built Intel MPI communications - important for using the high performance :ref:`Omnipath networking <sharc-network-specs>` between nodes.
-    * The argument ``-rsh`` tells MAPDL to use RSH instead of SSH.
-    * The argument ``-sge`` forces MAPDL to recognise job submission via SGE.
-    * The argument ``-sgepe`` selects the *mpi-rsh* SGE parallel environment.
+    * The argument ``-mpi=INTELMPI`` instructs MAPDL to use the in-built Intel MPI communications - 
+      important for using the high performance :ref:`Omnipath networking <sharc-network-specs>` between nodes.
+
 
 .. code-block:: bash
 
@@ -65,9 +67,9 @@ The script requests 4 cores using the MPI parallel environment with a runtime of
     #$ -m abe
     #$ -l h_rt=00:10:00
     #$ -l rmem=2G
-    #$ -pe mpi-rsh 4
+    #$ -pe mpi 4
     module load apps/ansys/20.2/binary
-    mapdl -i CrankSlot_Flexible.inp -b -np $NSLOTS -sge -mpi=INTELMPI -rsh -sgepe mpi-rsh
+    mapdl -i CrankSlot_Flexible.inp -b -np $NSLOTS -mpi=INTELMPI
 
 -----------------------
 

--- a/sharc/software/apps/ansys/module-load-list.rst
+++ b/sharc/software/apps/ansys/module-load-list.rst
@@ -3,7 +3,7 @@ Module loading
 -----------------
 
 After connecting to ShARC (see :ref:`ssh`),  you can start an :ref:`interactive graphical session <submit-interactive>`
-or :ref:`submit a batch job <submit-batch>` using ANSYS programs activating them and making them available with one of the module load commands below: ::
+or :ref:`submit a batch job <submit-batch>` using ANSYS programs by activating them and making them available with one of the module load commands below: ::
 
 
   module load apps/ansys/15.0


### PR DESCRIPTION
Updates with respect to the investigation undertaken to assess the correct running of MAPDL under the SGE scheduler.

Issues identified with versions 19.3 and below with no fix at present. More recent versions work more reliably with the updated command.

Data summary at: https://drive.google.com/drive/folders/1WKmFGPXAXJgWIB1pBR55cKUOqH8zWa82?usp=sharing

Only accessible for TUoS users.

