### PR TITLE
Fix-setuptools-version-to-fix-RTD-build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ pyparsing==2.4.7
 pytz==2020.1
 PyYAML==5.4
 requests==2.25.0
+setuptools==57.5.0
 six==1.15.0
 snowballstemmer==2.0.0
 Sphinx==3.4.3


### PR DESCRIPTION
Fixing the setup-tools version to 57.5.0 for now to resolve the build errors here: https://readthedocs.org/projects/iceberg/builds/14662587/

See: https://setuptools.readthedocs.io/en/latest/history.html

```
v58.0.0¶

04 Sep 2021
Breaking Changes

    #2086: Removed support for 2to3 during builds. Projects should port to a unified codebase or pin to an older version of Setuptools using PEP 518 build-requires.
```
Cross fingers RTD is happier now.