### PR TITLE
Revert "Fix-setuptools-version-to-fix-RTD-build"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,6 @@ pyparsing==2.4.7
 pytz==2020.1
 PyYAML==5.4
 requests==2.25.0
-setuptools==57.5.0
 six==1.15.0
 snowballstemmer==2.0.0
 Sphinx==3.4.3


### PR DESCRIPTION
Reverts rcgsheffield/sheffield_hpc#1262

Looks like the downstream theme package is still checking for use_2to3=True (in setup.py ) and using this as an error condition even if setuptools version is locked with support.

Going to edit setup.py instead and see if it still goes boom.