### PR TITLE
Add tox support and GHA workflow that uses it

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,4 +1,4 @@
-name: "Periodic docs external links check"
+name: periodic_link_check
 on: 
   schedule:
     # * is a special character in YAML so you have to quote this string
@@ -7,8 +7,18 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: rcgsheffield/sphinx-action@master
-      with:
-        docs-folder: "."
-        build-command: "make linkcheck"
+      - name: Checkout
+        run: |
+          git fetch --tags --prune --force
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - name: Upgrade pip and install Tox
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install tox
+
+      - name: Check links
+        run: tox -e py39-linkcheck

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,12 +1,31 @@
-name: "Pull Request Docs Check"
-on: 
-- pull_request
-
+name: test_docs_build
+on:
+  # Trigger on pull requests against the master branch
+  pull_request:
+    branches:
+      - master
 jobs:
-  docs:
+  test_docs:
     runs-on: ubuntu-latest
+    strategy:
+      # Spawn and run a job for each of two supported Python 3.x versions
+      matrix:
+        python: [3.7, 3.9]
+
     steps:
-    - uses: actions/checkout@v2
-    - uses: rcgsheffield/sphinx-action@master
-      with:
-        docs-folder: "."
+      - uses: actions/checkout@v2
+      - name: Checkout
+        run: |
+          git fetch --tags --prune --force
+
+      - name: Set up a version of Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Upgrade pip and install Tox
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install tox
+
+      - name: Run tests using Tox
+        run: tox -e py

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,7 @@ html/
 get_docs.py
 *.*~
 *swp
-.mypy_cache
-.vscode
+.mypy_cache/
+.vscode/
+UNKNOWN.egg-info/
+.tox/

--- a/README.rst
+++ b/README.rst
@@ -16,22 +16,22 @@ Rendered Documentation
 each push to the ``master`` branch causes the `ReadTheDocs <https://readthedocs.org/>`__ service to
 build and serve the documentation.
 
-The ReadTheDocs build configuration is stored in the ``.readthedocs.yaml`` file with the Python version pinned to 3.7 and two PIP 
+The ReadTheDocs build configuration is stored in the ``.readthedocs.yaml`` file with the Python version pinned to 3.7 and two Pip 
 requirements files. The first requirements file is ``setuptoolsrequirements.txt``  and is set in order to first pin setuptools to 
-version 57.5.0 to retain support for the current theme. See the following for details: 
-https://github.com/ryan-roemer/sphinx-bootstrap-theme/issues/216 
+version 57.5.0 to `retain support for the current theme <https://github.com/ryan-roemer/sphinx-bootstrap-theme/issues/216>`__.
 
 The second requirements file ``requirements.txt`` then installs the remaining dependencies.
 
-Please note that the use of the ``.readthedocs.yaml`` file will also override certain webGUI settings set in the ReadTheDocs administrative panel.
+Please note that the use of the ``.readthedocs.yaml`` file will also override certain web UI settings set in the ReadTheDocs administrative panel.
+
 
 How to Contribute
 -----------------
-To contribute to this documentation, first you have to fork it on GitHub and clone it to your machine, see `Fork a Repo <https://help.github.com/articles/fork-a-repo/>`_ for the GitHub documentation on this process.
+To contribute to this documentation, first you have to fork it on GitHub and clone it to your machine,
+see `Fork a Repo <https://help.github.com/articles/fork-a-repo/>`_ for the GitHub documentation on this process.
 
 Once you have the git repository locally on your computer,
-you will need to install specific versions of the ``sphinx`` and ``sphinx_bootstrap_theme`` to be able to build the documentation.
-See the instructions below for how to achieve this.
+you will need to ensure you have Python and the Tox_ build tool installed.
 
 Once you have made your changes and updated your Fork on GitHub you will need to `Open a Pull Request <https://help.github.com/articles/using-pull-requests/>`_.
 All changes to the repository should be made through Pull Requests, including those made by the people with direct push access.
@@ -50,35 +50,28 @@ Building the documentation on a local Windows machine
 
 #. Create a new *conda environment* for building the documentation by running the following from this window: ::
 
-    conda create --name sheffield_hpc python=3
+    conda create --name sheffield_hpc python=3.7
     conda activate sheffield_hpc	# . activate sheffield_hpc on older versions of conda
-    pip install -r requirements.txt
+    pip install tox
 
 #. To build the HTML documentation run: ::
 
-    make html
-	
-   Or if you don't have the ``make`` utility installed on your machine then build with *sphinx* directly: ::
+    tox -e py37
 
-    sphinx-build . ./html
+The output should be written to ``./_build/html``.
 
 Building the documentation on a local Linux machine
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-#. Ensure Python 3 is installed.
-#. Create a `virtual environment <https://docs.python.org/3/tutorial/venv.html>`_ to install sphinx into: ::
+#. Ensure one of Python 3.9 or 3.7 are installed.
+#. Ensure the Tox_ build tool is installed and can be used/seen by your chosen Python interpreter.
 
-    mkdir -m 700 ~/.venvs
-    python3 -m venv ~/.venvs/sheffield_hpc_py3
-    source ~/.venvs/sheffield_hpc_py3/bin/activate
+#. Run Tox to create an isolated Python virtual environment then build documentation: ::
 
-#. Install the Python packages needed to build the HTML documentation: ::
+     tox -e py37  # OR
+     tox -e py39
 
-     pip3 install -r requirements.txt
-
-#. Build the documentation: ::
-
-     make html
+The output should be written to ``./_build/html``.
 
 Building the documentation on a local Mac machine
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -87,40 +80,36 @@ Building the documentation on a local Mac machine
 #. Install the Python packages needed to build the HTML documentation.  If you are using (mini)conda create a new *conda environment* for building the documentation by running: ::
 
     export PATH=${HOME}/miniconda3/bin:$PATH
-    conda create -n sheffield_hpc python=3
-    pip install -r requirements.txt
-
-   If you are *not* using (mini)conda to provide Python 3: ::
-
-    mkdir -m 700 ~/.venvs
-    python3 -m venv ~/.venvs/sheffield_hpc_py3
-    source ~/.venvs/sheffield_hpc_py3/bin/activate
-    pip3 install --requirement requirements.txt
+    conda create -n sheffield_hpc python=3.7
+    conda activate sheffield_hpc	# . activate sheffield_hpc on older versions of conda
+    pip install tox
 
 #. To build the HTML documentation run::
 
-    make html
+    tox -e py37
+
+The output should be written to ``./_build/html``.
 
 Check external links
 ^^^^^^^^^^^^^^^^^^^^
 
 Do this with: ::
 
-   make linkcheck
+   tox -e py37-linkcheck
 
 Continuous build and serve
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Build and serve the site and automatically rebuild when source files change:
+Build and serve the site and automatically rebuild when source files change: ::
 
-    make livehtml
+   tox -e py37-livehtml
 
 Testing the building of the documentation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The validity of the reStructuredText in this repo and the ability to convert that to HTML with Sphinx can be tested in three ways:
 
-* Locally by contributors when they run e.g. ``make html``
+* Locally by contributors when they run e.g. ``tox -e py37-livehtml``
 * By a [GitHub Actions](https://github.com/rcgsheffield/sheffield_hpc/actions/) Workflow each time a contributor creates or updates a Pull Request.
 * By `ReadTheDocs <https://readthedocs.org/projects/iceberg/>`__ on each push to the ``master`` branch.
 
@@ -138,3 +127,4 @@ How to install mermaid-cli and regenerate one of these diagrams: ::
 .. _Sphinx: https://www.sphinx-doc.org/en/master/
 .. _reStructuredText: https://docutils.sourceforge.io/rst.html
 .. _Miniconda installer: https://conda.io/miniconda.html
+.. _Tox: https://tox.readthedocs.io/en/latest/

--- a/conf.py
+++ b/conf.py
@@ -58,7 +58,14 @@ language = None
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build', 'themes', 'README.rst','global.rst']
+exclude_patterns = [
+    '_build',
+    'themes',
+    'README.rst',
+    'global.rst',
+    '.tox',
+    'mypy_cache'
+]
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[build-system]
+# Pin setuptools because of https://github.com/ryan-roemer/sphinx-bootstrap-theme/issues/216
+requires = ["setuptools<58", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,20 @@
+[tox]
+isolated_build = True
+
+[testenv]
+deps =
+    -r requirements.txt
+whitelist_externals =
+    make
+    echo
+commands =
+    make html
+
+[testenv:py{37,39}-linkcheck]
+commands =
+    make html
+    make linkcheck
+
+[testenv:py{37,39}-livehtml]
+commands =
+    make livehtml


### PR DESCRIPTION
Tox creates hidden virtualenvs for e.g. testing purposes.

This PR should
 - Ensure that contributors are able to build docs in a more reproducible build environment by just running `tox -e py39` to test with Python 3.9 (instead of running `make html`)
 - Ensure that PRs are tested using the same Python environment by rewriting our GHA workflow for PRs to call tox to build the docs rather than build the docs directly.

@jkwmoore and @desmfryan Does this work for you? 

EDIT: updated README and link-checking GHA workflow.