### PR TITLE
GDAL additional driver support + docs

### DIFF
--- a/sharc/software/install_scripts/libs/gdal/install_gdal.sh
+++ b/sharc/software/install_scripts/libs/gdal/install_gdal.sh
@@ -4,7 +4,7 @@
 #$ -m abe
 #$ -l h_rt=02:00:00
 #$ -l rmem=2G
-#$ -pe smp 4
+#$ -pe smp 8
 #$ -N gdal-install
 ##$ -q cstest.q
 ##$ -P cstest
@@ -22,7 +22,7 @@
 
 #Define Names and versions
 PACKAGENAME=gdal
-PACKAGEVER=3.0.1
+PACKAGEVER=3.3.1
 GCCVER=8.2
 CMAKEVER=3.17.1
 
@@ -60,6 +60,7 @@ module load dev/gcc/$GCCVER
 module load dev/cmake/$CMAKEVER/gcc-$GCCVER
 module load apps/doxygen/1.9.1/gcc-$GCCVER-cmake-$CMAKEVER
 module load libs/proj/7.1.0/gcc-8.2.0
+module load libs/sqlite/3.32.3/gcc-8.2.0
 
 echo "Loaded Modules: " $LOADEDMODULES
 
@@ -99,7 +100,7 @@ cd $PACKAGENAME-$PACKAGEVER
 
 #Configure
 
-./configure --prefix=$INSTALLDIR
+./configure --prefix=$INSTALLDIR --with-sqlite3=/usr/local/packages/libs/sqlite/3.32.3/gcc-8.2.0
 
 #Clean
 echo "Make precleaning:"

--- a/sharc/software/libs/gdal.rst
+++ b/sharc/software/libs/gdal.rst
@@ -99,7 +99,10 @@ script. This script will automatically install GDAL, generate the module file an
 permissions as needed. Build logs are also automatically generated and copied to the base install 
 directory or src directory.
 
-The **file formats** supported by this build are listed in the compilation log files which can be found 
+The additional **GPKG** and **SQlite** drivers are added via the loading of the SQLite module and manual specification 
+of the SQLite root directory for the ``./configure`` step.
+
+The **file formats** and **drivers** supported by this build are listed in the compilation log files which can be found 
 in the module top level directory. e.g. ``gdal-install.o1234567``
 
 **Version 3.0.1**
@@ -110,7 +113,10 @@ script. This script will automatically install GDAL, generate the module file an
 permissions as needed. Build logs are also automatically generated and copied to the base install 
 directory or src directory.
 
-The **file formats** supported by this build are listed in the compilation log files which can be found 
+The additional **GPKG** and **SQlite** drivers are added via the loading of the SQLite module and manual specification 
+of the SQLite root directory for the ``./configure`` step.
+
+The **file formats** and **drivers** supported by this build are listed in the compilation log files which can be found 
 in the module top level directory. e.g. ``gdal-install.o1234567``
 
 **Version 2.2.0**


### PR DESCRIPTION
GPKG and SQLite driver support added for the 3.x.x versions of GDAL via the inclusion of the SQLite module and specification of the SQLite module root directory via the ``./configure`` step.