### PR TITLE
GHA workflows: rename jobs and switch to using std checkout GHA

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -4,17 +4,16 @@ on:
     # * is a special character in YAML so you have to quote this string
     - cron:  '0 0 1,15 * *'
 jobs:
-  docs:
+  link_check:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        run: |
-          git fetch --tags --prune --force
+      - uses: actions/checkout@v2
 
       - name: Set up Python 3.7
         uses: actions/setup-python@v2
         with:
           python-version: 3.7
+
       - name: Upgrade pip and install Tox
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
 jobs:
-  test_docs:
+  test_docs_build:
     runs-on: ubuntu-latest
     strategy:
       # Spawn and run a job for each of two supported Python 3.x versions
@@ -14,14 +14,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Checkout
-        run: |
-          git fetch --tags --prune --force
 
       - name: Set up a version of Python
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
+
       - name: Upgrade pip and install Tox
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
* Given the workflow jobs better names
* Switched to using the standard GitHub Action for git cloning 