### PR TITLE
Correcting nested use of srun on Bess Openfoam

### DIFF
--- a/bessemer/software/apps/openfoam.rst
+++ b/bessemer/software/apps/openfoam.rst
@@ -45,9 +45,9 @@ After connecting to Bessemer (see :ref:`ssh`), you can start an `interactive gra
     cd /fastdata/$USER/tests/openfoam/run
     cp -r $FOAM_TUTORIALS/incompressible/simpleFoam/pitzDaily .
     chmod 700 -R pitzDaily && cd pitzDaily
-    srun --export=ALL blockMesh
-    srun --export=ALL simpleFoam
-    srun --export=ALL paraFoam #To view the output.
+    mpirun blockMesh
+    mpirun simpleFoam
+    mpirun paraFoam #To view the output.
 
 ------------
 


### PR DESCRIPTION
```srun``` will silently fail to allocate resources when calling srun inside srun. Users can either use ```mpirun``` as here with mpi enabled applications or use ```salloc srun mycommand```