### PR TITLE
Fix-various-intro-wording-and-titles-in-reference-info-section

### DIFF
--- a/referenceinfo/ANSYS/fluent/index.rst
+++ b/referenceinfo/ANSYS/fluent/index.rst
@@ -4,7 +4,8 @@
 ANSYS Fluent Reference Info
 **********************************
 
-This sub-tree contains ANSYS Fluent reference information that is pulled into other pages.
+This page provides links to reference information on the ANSYS Fluent software package which is 
+included into other pages.
 
 
 .. toctree::

--- a/referenceinfo/ANSYS/index.rst
+++ b/referenceinfo/ANSYS/index.rst
@@ -4,7 +4,8 @@
 ANSYS Packages Reference Info
 **********************************
 
-This sub-tree contains ANSYS packages reference information that is pulled into other pages.
+This page provides links to reference information on ANSYS software packages and configuration on 
+the HPC clusters.
 
 
 .. toctree::

--- a/referenceinfo/index.rst
+++ b/referenceinfo/index.rst
@@ -1,7 +1,7 @@
 .. _referenceinfo:
 
 =========================================================
-Reference Infomation Index
+Reference Information Index
 =========================================================
 
 This page provides an index for various pieces of reference information which is included in several locations within other pages of the documentation.

--- a/referenceinfo/index.rst
+++ b/referenceinfo/index.rst
@@ -1,11 +1,12 @@
 .. _referenceinfo:
 
 =========================================================
-Reference Info
+Reference Infomation Index
 =========================================================
 
-This sub-tree contains reference information that is pulled into other pages.
+This page provides an index for various pieces of reference information which is included in several locations within other pages of the documentation.
 
+This section should be used to look for a quick references to very specific information such as scheduler commands, resource limits and software details.
 
 .. toctree::
   :maxdepth: 1

--- a/referenceinfo/scheduler/SGE/Common-commands/index.rst
+++ b/referenceinfo/scheduler/SGE/Common-commands/index.rst
@@ -3,8 +3,8 @@
 SGE Common Commands
 ===================
 
-This sub-tree contains reference information about common SGE commands that are pulled into other pages.
-
+This page provides links to reference information about common SGE commands that are included 
+in other pages.
 
 .. toctree::
   :maxdepth: 1

--- a/referenceinfo/scheduler/SGE/index.rst
+++ b/referenceinfo/scheduler/SGE/index.rst
@@ -1,9 +1,10 @@
 .. _sge_referenceinfo:
 
-SGE Reference Info
-==================
+SGE Scheduler (ShARC) Reference Info
+====================================
 
-This sub-tree contains reference information that is pulled into other pages.
+This page provides links to reference information about the SGE scheduler used on ShARC which 
+is included in other pages.
 
 
 .. toctree::

--- a/referenceinfo/scheduler/SLURM/Common-commands/index.rst
+++ b/referenceinfo/scheduler/SLURM/Common-commands/index.rst
@@ -3,7 +3,8 @@
 SLURM Common Commands
 =====================
 
-This sub-tree contains reference information about common SGE commands that are pulled into other pages.
+This page provides links to reference information about common SLURM commands that are included 
+in other pages.
 
 
 .. toctree::

--- a/referenceinfo/scheduler/SLURM/index.rst
+++ b/referenceinfo/scheduler/SLURM/index.rst
@@ -1,9 +1,10 @@
 .. _slurm_referenceinfo:
 
-SLURM Reference Info
-====================
+SLURM Scheduler (Bessemer) Reference Info
+=========================================
 
-This sub-tree contains reference information that is pulled into other pages.
+This page provides links to reference information about the SLURM scheduler used on Bessemer which 
+is included in other pages.
 
 
 .. toctree::

--- a/referenceinfo/scheduler/index.rst
+++ b/referenceinfo/scheduler/index.rst
@@ -4,7 +4,9 @@
 Scheduler Reference Info
 **********************************
 
-This sub-tree contains reference information that is pulled into other pages.
+This page provides links to reference information on the schedulers' commands, parallel environments 
+and environment variables as well as general comparison pages for the resource limits on the 
+ShARC and Bessemer clusters.
 
 
 .. toctree::


### PR DESCRIPTION
Various amendments to the reference info section in order to clarify its purpose as an index for people to quickly look up very specific info (that is included in other pages.)