### PR TITLE
Add warning block for Conda modules

### DIFF
--- a/bessemer/software/apps/python.rst
+++ b/bessemer/software/apps/python.rst
@@ -34,6 +34,11 @@ The ``root`` conda environment (the default) provides Python 3 and no extra
 modules, it is automatically updated, and not recommended for general use, just
 as a base for your own environments.
 
+.. warning::
+
+    Due to Anaconda being installed in a module you must use the ``source`` command instead of ``conda`` 
+    when activating or deactivating environments!
+
 .. _python_conda_bessemer_create_env:
 
 Creating an Environment

--- a/sharc/software/apps/python.rst
+++ b/sharc/software/apps/python.rst
@@ -33,6 +33,11 @@ modules, it is automatically updated, and not recommended for general use, just
 as a base for your own environments. There is also a ``python2`` environment,
 which is the same but with a Python 2 installation.
 
+.. warning::
+
+    Due to Anaconda being installed in a module you must use the ``source`` command instead of ``conda`` 
+    when activating or deactivating environments!
+
 Quickly Loading Anaconda Environments
 -------------------------------------
 


### PR DESCRIPTION
Adds warning:

    Due to Anaconda being installed in a module you must use the ``source`` command instead of ``conda`` 
    when activating or deactivating environments!