### PR TITLE
Corrections for links broken by new CMS pages.

### DIFF
--- a/hpc/filestore.rst
+++ b/hpc/filestore.rst
@@ -231,7 +231,7 @@ Here we try to explain why.
 
 Behind the scenes, the file server that provides this shared storage manages permissions using 
 Windows-style `ACLs <https://en.wikipedia.org/wiki/Access_control_list>`_ 
-(which can be set by area owners via the `Research Storage management web interface <https://sheffield.ac.uk/storage>`__.
+(which can be set by area owners via the `Research Storage management web interface <https://sheffield.ac.uk/storage/>`__.
 However, the filesystem is mounted on a Linux cluster using NFSv4 so the file server therefore requires 
 a means for mapping Windows-style permissions to Linux ones.  
 An effect of this is that the Linux `mode bits <https://en.wikipedia.org/wiki/Modes_(Unix)>`_ for files/directories under ``/shared`` on the HPC systems

--- a/sharc/software/apps/abaqus.rst
+++ b/sharc/software/apps/abaqus.rst
@@ -7,7 +7,7 @@ Abaqus
    :Dependencies: Module loaded for Intel compiler 15.0.7 (and Foxit for Abaqus version 6.14-2). User subroutines need Intel compiler 2011 or above, GCC 4.1.2 or above.
    :URL: http://www.3ds.com/products-services/simulia/products/abaqus/
    :Documentation: https://help.3ds.com/ (note: register for an account to access.)
-   :Local URL: https://www.sheffield.ac.uk/it-services/research/software/abaqus
+   :Local URL: https://students.sheffield.ac.uk/it-services/research/software#a
 
 
 Abaqus is a software suite for Finite Element Analysis (FEA) developed by Dassault Systèmes.


### PR DESCRIPTION
Amends the Abaqus link and added the missing (but not really needed) trailing slash for the storage link.