### PR TITLE
Amendments to ShARC conda page and the reference section for installations of software.

### DIFF
--- a/referenceinfo/linux-shell/making-software-available-with-bashrc.rst
+++ b/referenceinfo/linux-shell/making-software-available-with-bashrc.rst
@@ -5,11 +5,16 @@
 
 Making software available via the .bashrc file
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 Software can be made available using your ``.bashrc`` file and adding/editing any 
 relevant environment variables. 
 
 .. warning::
+
+    Using your ``.bashrc`` file to make software available on ShARC will not work correctly in 
+    ``qsub`` batch jobs unless you amend the bash shebang from ``#!/bin/bash`` to ``#!/bin/bash -i`` 
+    due to non-interactive sessions **not** sourcing the ``.bashrc`` file. 
+
+.. caution::
 
     We do not recommend editing your ``.bashrc`` file as this could result in corrupting your 
     shell environment. If possible make use of the :ref:`modules system <software_installs_modules>`.

--- a/referenceinfo/linux-shell/making-software-available-with-bashrc.rst
+++ b/referenceinfo/linux-shell/making-software-available-with-bashrc.rst
@@ -11,8 +11,8 @@ relevant environment variables.
 .. warning::
 
     Using your ``.bashrc`` file to make software available on ShARC will not work correctly in 
-    ``qsub`` batch jobs unless you amend the bash shebang from ``#!/bin/bash`` to ``#!/bin/bash -i`` 
-    due to non-interactive sessions **not** sourcing the ``.bashrc`` file. 
+    ``qsub`` batch jobs unless you supply the ``#$ -V`` SGE  argument in your submission script as 
+    non-interactive sessions **do not** source the ``.bashrc`` file.
 
 .. caution::
 

--- a/sharc/software/apps/python.rst
+++ b/sharc/software/apps/python.rst
@@ -125,13 +125,8 @@ If you want to create one or more large Conda environments
 (e.g. containing bulky Deep Learning packages such as TensorFlow or PyTorch)
 then there's a risk you'll quickly use up your home directory's :ref:`10GB storage quota <filestore>`.
 
-First, tell conda where to look for a config file: ::
-
-   echo "export CONDARC=$HOME/.condarc-sharc.yml" >> ~/.bashrc
-
-Next, create a ``.condarc-sharc.yml`` file in your home directory, 
-copy in the contents of your ``.condarc`` file if you have one,
-then add an ``envs_dirs:`` and ``pkgs_dirs:`` entries below as:
+Create a ``.condarc`` file in your home directory if it does not already exist. 
+Add an ``envs_dirs:`` and ``pkgs_dirs:`` section as shown below:
 
 ::
 
@@ -146,6 +141,9 @@ Make sure to replace ``username`` with your own username and
 then create these folders by running the following command: ::
 
     mkdir -p /data/$USER/anaconda/.pkg-cache/  /data/$USER/anaconda/.envs
+
+Installations of environments and package caching should now occur in your ``/data`` 
+area.
 
 
 Installing Packages Inside an Environment


### PR DESCRIPTION
Adds the corrections to ensure condarc loads in qsub sessions as well as highlighting the need for interactive bash shebangs for qsub jobs that need to load the .bashrc environment.