### PR TITLE
standardise on preempt without a hyphen

### DIFF
--- a/bessemer/groupnodes/dcs-acad-gpu-nodes.rst
+++ b/bessemer/groupnodes/dcs-acad-gpu-nodes.rst
@@ -67,7 +67,7 @@ Only certain users have access to a given Account.
 
 .. _dcs_acad_gpu_nodes_non_prempt_access:
 
-1. Non-pre-emptable access to half a node
+1. Non-preemptable access to half a node
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Each of the four academics (plus their collaborators) have ring-fenced, on-demand access to the resources of half a node.
@@ -89,7 +89,7 @@ Resource limits per job:
 .. todo::
    If using cluster-wide values for default and max run time then link to central info re that rather than duplicating here.
 
-2. Pre-emptable access to both nodes
+2. Preemptable access to both nodes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If any of the academics (or their collaborators) want to run a larger job that requires
@@ -100,11 +100,11 @@ then they can :ref:`specify a different Partition <slurm_access_priv_nodes>` whe
 * Account: ``dcs-acadX`` where ``X`` is 1, 2, 3 or 4 and :ref:`varies between the academics <dcs_acad_gpu_node_accounts>`).
 * QoS: do not specify one i.e. do not use the ``--qos`` parameter.
 
-*However*, to facilitate fair sharing of these GPU nodes jobs submitted via this route are *pre-emptable*:
+*However*, to facilitate fair sharing of these GPU nodes jobs submitted via this route are *preemptable*:
 they will be stopped mid-execution if a job is submitted to the ``dcs-acad`` partition (:ref:`see above <dcs_acad_gpu_nodes_non_prempt_access>`)
 that requires those resources.
 
-When a job submitted by this route is pre-empted by another job the pre-empted job is terminated and re-queued.
+When a job submitted by this route is preempted by another job the preempted job is terminated and re-queued.
 
 Resource limits per job:
 
@@ -116,14 +116,14 @@ Resource limits per job:
 
    Re-add the following after setting it up:
 
-   3. General pre-emptable access to both nodes
+   3. General preemptable access to both nodes
 
    Users other than the academics and their collaborators can make use of idle time on these nodes and other nodes by
    submitting batch jobs and starting interactive sessions using a :ref:`particular partition <slurm_access_priv_nodes>`:
 
    * Partition: ``preempt``
 
-   These jobs can be pre-empted by jobs submitted to the ``dcs-acad-pre`` and ``dcs-acad`` partitions.
+   These jobs can be preempted by jobs submitted to the ``dcs-acad-pre`` and ``dcs-acad`` partitions.
 
 
 .. _Carolina Scarton: https://www.sheffield.ac.uk/dcs/people/academic/carolina-scarton

--- a/bessemer/groupnodes/dcs-gpu-nodes.rst
+++ b/bessemer/groupnodes/dcs-gpu-nodes.rst
@@ -99,7 +99,7 @@ Resource limits per job:
 
    Leave commented until implemented and tested
 
-   3. General pre-emptable access
+   3. General preemptable access
 
    Users other than Computer Science researchers and their collaborators can
    make use of idle time on these nodes and other nodes
@@ -108,6 +108,6 @@ Resource limits per job:
 
    * Partition: ``preempt``
 
-   These jobs can be pre-empted by jobs submitted to the ``dcs-gpu`` and ``dcs-gpu-test`` partitions;
+   These jobs can be preempted by jobs submitted to the ``dcs-gpu`` and ``dcs-gpu-test`` partitions;
    if this happens
-   the pre-empted jobs will be stopped mid-execution and re-queued.
+   the preempted jobs will be stopped mid-execution and re-queued.

--- a/hpc/scheduler/index.rst
+++ b/hpc/scheduler/index.rst
@@ -484,41 +484,41 @@ Here is a more complex example that requests more resources:
 
 .. _preemptable_jobs_bessemer:
 
-Pre-emptable Jobs
+Preemptable Jobs
 ^^^^^^^^^^^^^^^^^
 
 Under certain conditions,
 Slurm on Bessemer allows jobs running in higher-priority Partitions (sets of nodes) to
-*pre-empt* jobs in lower-priority Partitions.
-When a higher priority job *pre-empts* a lower priority job,
+*preempt* jobs in lower-priority Partitions.
+When a higher priority job *preempts* a lower priority job,
 the lower priority job is stopped (and by default cancelled) and
 the higher priority job takes its place.
 
 Specifically, Slurm allows users to run interactive sessions and batch jobs using idle resources
 in :ref:`private (research group-owned or dept-owned) nodes <groupnodes_bessemer>`,
-but these resources will be reclaimed (and the associated jobs pre-empted) if
+but these resources will be reclaimed (and the associated jobs preempted) if
 members of those groups/departments submit jobs that can only start if those resources are repurposed.
 
 .. note::
-    Support for pre-emptable jobs has been enabled on a trial basis
+    Support for preemptable jobs has been enabled on a trial basis
     and will be disabled if it impacts on
     priority access by groups / departments to
     private nodes they have purchased.
 
-An example of the use of pre-emptable jobs:
+An example of the use of preemptable jobs:
 
 1. Researcher A wants to run a job using 2 GPUs.  All 'public' GPUs are being used by jobs, but some GPUs in a private node belonging to research group X are idle.
-2. Researcher A decides that they want to use those idle GPUs but they aren't a member of research group X; however, they are happy to take the risk of their job being pre-empted by a member of research group X.
-3. Researcher A submits a job and makes it pre-emptable (by adding submitting it to the ``preempt`` Partition using ``--partition=preempt``).
+2. Researcher A decides that they want to use those idle GPUs but they aren't a member of research group X; however, they are happy to take the risk of their job being preempted by a member of research group X.
+3. Researcher A submits a job and makes it preemptable (by adding submitting it to the ``preempt`` Partition using ``--partition=preempt``).
 4. The job starts running on a node which is a member of the ``preempt`` and ``research-group-X`` Partitions.
 5. Researcher B is a member of research group X and submits a job to the ``research-group-X`` Partition.  
 6. This job can only start if the resources being used by the first job are reclaimed.
-7. As a result, Slurm pre-empts the first job with this second job, as a result of which the first job is cancelled.
+7. As a result, Slurm preempts the first job with this second job, as a result of which the first job is cancelled.
 8. The second job runs to completion.
 
-Tips for using pre-emptable jobs:
+Tips for using preemptable jobs:
 
-* Ensure that you're able to reliably re-submit your pre-emptable job if it is pre-empted before completion.  A common way of doing this is to write out state/progress information periodically whilst the job is running.
+* Ensure that you're able to reliably re-submit your preemptable job if it is preempted before completion.  A common way of doing this is to write out state/progress information periodically whilst the job is running.
 * Select a sensible frequency for writing out state/progress information or you may cause poor performance due to storage write speed limits.
 
 Monitoring running Jobs


### PR DESCRIPTION
- Notes on pre-emptable jobs
- Pre-emptable jobs: changes to wording following review
- Pre-emptable jobs: note that is a trial (and remove trailing whitespace)
- Standardise on preempt without a hyphen
