### PR TITLE
Correct the number of cores per CPU in Bessemer DCS GPU nodes

### DIFF
--- a/bessemer/groupnodes/dcs-acad-gpu-nodes.rst
+++ b/bessemer/groupnodes/dcs-acad-gpu-nodes.rst
@@ -33,7 +33,7 @@ Hardware specifications
    :header-rows: 0
 
    * - Processors
-     - 2x Intel Xeon Gold 6138 (2.00GHz; 40 cores per CPU)
+     - 2x Intel Xeon Gold 6138 (2.00GHz; 20 cores per CPU)
    * - RAM
      - 192GB (DDR4 @ 2666 MHz)
    * - NUMA nodes

--- a/bessemer/groupnodes/dcs-gpu-nodes.rst
+++ b/bessemer/groupnodes/dcs-gpu-nodes.rst
@@ -17,7 +17,7 @@ Eight nodes (``bessemer-node030`` to ``bessemer-node037``) each have:
    :header-rows: 0
 
    * - Processors
-     - 2x Intel Xeon Gold 6138 (2.00GHz; 40 cores per CPU)
+     - 2x Intel Xeon Gold 6138 (2.00GHz; 20 cores per CPU)
    * - RAM
      - 192GB (DDR4 @ 2666 MHz)
    * - NUMA nodes


### PR DESCRIPTION
The DCS V100 nodes have 40 CPU cores in total according to slurm, not 40 per CPU.


```
sinfo -p dcs-gpu -N -O NodeList,Gres,CPUs,Memory
NODELIST            GRES                CPUS                MEMORY              
bessemer-node030    gpu:v100:4(S:0)     40                  196608              
bessemer-node031    gpu:v100:4(S:0)     40                  196608              
bessemer-node032    gpu:v100:4(S:0)     40                  196608              
bessemer-node033    gpu:v100:4(S:0)     40                  196608              
bessemer-node034    gpu:v100:4(S:0)     40                  196608              
bessemer-node035    gpu:v100:4(S:0)     40                  196608              
bessemer-node036    gpu:v100:4(S:0)     40                  196608              
bessemer-node037    gpu:v100:4(S:0)     40                  196608
```

```
sinfo -p dcs-acad -N -O NodeList,Gres,CPUs,Memory
NODELIST            GRES                CPUS                MEMORY              
bessemer-node041    gpu:v100:4(S:0)     40                  196608              
bessemer-node042    gpu:v100:4(S:0)     40                  196608     
```