### PR TITLE
Correct bash shebang line on Netlogo batch script.

### DIFF
--- a/bessemer/software/apps/NetLogo.rst
+++ b/bessemer/software/apps/NetLogo.rst
@@ -113,7 +113,7 @@ multicore NetLogo jobs.
 
 .. code-block:: shell
 
-    !/bin/bash
+    #!/bin/bash
     #SBATCH --nodes=1
     #SBATCH --ntasks-per-node=4
     #SBATCH --mem=8000


### PR DESCRIPTION
As above, corrects missing "#" .