### PR TITLE
Sharc nag libs

### DIFF
--- a/sharc/software/libs/nag-libs.rst
+++ b/sharc/software/libs/nag-libs.rst
@@ -18,17 +18,17 @@ including Python, Java, .NET and MATLAB.
 
 Usage
 -----
-Use the following command to make Mark 27 of the serial (1 CPU core) version of the NAG C and Fortran Library for Intel compilers available: ::
+Use the following command to make Mark 27.3 of the serial (1 CPU core) version of the NAG C and Fortran Library for Intel compilers available: ::
 
-   module load libs/NAG/nll6i27dbl
+   module load libs/NAG/nll6i273bl
 
 In addition to loading a module for the library, 
 you will usually need to load a module for the compiler you are using.
 
-``nll6i27dbl`` is compatible with the Intel compilers >= 19.0.3 
+``nll6i273bl`` is compatible with the Intel compilers >= 19.1.3 
 so you should load an appropriate module from the :ref:`list of available Intel compiler modules <sharc-intel-compilers>` e.g.: ::
 
-   module load dev/intel-compilers/19.0.3
+   module load dev/intel-compilers/19.1.3
 
 You can now compile a Fortran program so it is linked against the NAG library: ::
 
@@ -62,46 +62,46 @@ the output you get will vary according to which version of the NAG library you a
 
    nag_example a00aaf
 
-If you have loaded the ``module`` for nll6i27dbl this will give the following output ::
+If you have loaded the ``module`` for nll6i273bl this will give the following output ::
 
-   Use nagvars script to set NAG compile and link environment
-   variables within nag_example script
-   . /usr/local/packages/libs/NAG/nll6i27dbl/scripts/nagvars.sh -quiet int32 static nag
-   
-   Copying a00aafe.f90 to current directory
-   cp /usr/local/packages/libs/NAG/nll6i27dbl/f_examples/source/a00aafe.f90 .
-   
-   Compiling and linking a00aafe.f90 to produce executable a00aafe.exe
-   ifort -I/usr/local/packages/libs/NAG/nll6i27dbl/lp64/include -I/usr/local/packages/libs/NAG/nll6i27dbl/lp64/nag_interface_blocks a00aafe.f90 /usr/local/packages/libs/NAG/nll6i27dbl/lp64/lib/libnag_nag.a -lm -ldl -lpthread -lstdc++ -o a00aafe.exe
-   
-   Running a00aafe.exe
-   ./a00aafe.exe > a00aafe.r
-    A00AAF Example Program Results
-    
-    *** Start of NAG Library implementation details ***
-    
-    Implementation title: Linux, 64-bit, Intel C/C++ or Intel Fortran
-               Precision: double precision
-            Product Code: NLL6I27DBL
-                    Mark: 27.0.0 (self-contained)
-    
-     This is a 64-bit library using 32-bit integers.
-    
-    *** End of NAG Library implementation details ***
+Use nagvars script to set NAG compile and link environment
+variables within nag_example script
+. /usr/local/packages/libs/NAG/nll6i273bl/scripts/nagvars.sh -quiet int32 static nag
+
+Copying a00aafe.f90 to current directory
+cp /usr/local/packages/libs/NAG/nll6i273bl/f_examples/source/a00aafe.f90 .
+
+Compiling and linking a00aafe.f90 to produce executable a00aafe.exe
+ifort -I/usr/local/packages/libs/NAG/nll6i273bl/lp64/nag_interface_blocks a00aafe.f90 /usr/local/packages/libs/NAG/nll6i273bl/lp64/lib/libnag_nag.a -lm -ldl -lstdc++ -o a00aafe.exe
+
+Running a00aafe.exe
+./a00aafe.exe > a00aafe.r
+ A00AAF Example Program Results
+ 
+ *** Start of NAG Library implementation details ***
+ 
+ Implementation title: Linux, 64-bit, Intel Classic C/C++ or Intel Classic Fortran
+            Precision: double precision
+         Product Code: NLL6I273BL
+                 Mark: 27.3.0 (self-contained)
+ 
+  This is a 64-bit library using 32-bit integers.
+ 
+ *** End of NAG Library implementation details ***
 
 Documentation
 -------------
 
 The Numerical and statistical capabilities of the Fortran and C library are described in the 
-`The NAG Library Mark 27 Manual <https://www.nag.co.uk/numeric/nl/nagdoc_27/>`_ (Link to NAG's webbsite).
+`The NAG Library Mark 27.3 Manual <https://www.nag.com/numeric/nl/nagdoc_27.3/>`_ (Link to NAG's webbsite).
 
 Installation notes
 ------------------
-**nll6i27dbl (Mark 27)**
+**nll6i273bl (Mark 27.3)**
 
 These are primarily for system administrators ::
 
-    PRODUCT='nll6i27dbl'
+    PRODUCT='nll6i273bl'
     pushd "${TMPDIR-/tmp}"
     wget "https://www.nag.co.uk/downloads/impl/${PRODUCT}.tgz"
     tar -xvzf "${PRODUCT}.tgz"
@@ -113,7 +113,7 @@ These are primarily for system administrators ::
 
 Module Files
 ------------
-**nll6i27dbl (Mark 27)**
+**nll6i273bl (Mark 27.3)**
 
-* The module file is on the system at ``/usr/local/modulefiles/libs/NAG/nll6i27dbl``
-* The module file is :download:`on github </sharc/software/modulefiles/libs/NAG/nll6i27dbl>`.
+* The module file is on the system at ``/usr/local/modulefiles/libs/NAG/nll6i273bl``
+* The module file is :download:`on github </sharc/software/modulefiles/libs/NAG/nll6i273bl>`.

--- a/sharc/software/libs/nag-libs.rst
+++ b/sharc/software/libs/nag-libs.rst
@@ -64,30 +64,30 @@ the output you get will vary according to which version of the NAG library you a
 
 If you have loaded the ``module`` for nll6i273bl this will give the following output ::
 
-Use nagvars script to set NAG compile and link environment
-variables within nag_example script
-. /usr/local/packages/libs/NAG/nll6i273bl/scripts/nagvars.sh -quiet int32 static nag
+   Use nagvars script to set NAG compile and link environment
+   variables within nag_example script
+   . /usr/local/packages/libs/NAG/nll6i273bl/scripts/nagvars.sh -quiet int32 static nag
 
-Copying a00aafe.f90 to current directory
-cp /usr/local/packages/libs/NAG/nll6i273bl/f_examples/source/a00aafe.f90 .
+   Copying a00aafe.f90 to current directory
+   cp /usr/local/packages/libs/NAG/nll6i273bl/f_examples/source/a00aafe.f90 .
 
-Compiling and linking a00aafe.f90 to produce executable a00aafe.exe
-ifort -I/usr/local/packages/libs/NAG/nll6i273bl/lp64/nag_interface_blocks a00aafe.f90 /usr/local/packages/libs/NAG/nll6i273bl/lp64/lib/libnag_nag.a -lm -ldl -lstdc++ -o a00aafe.exe
+   Compiling and linking a00aafe.f90 to produce executable a00aafe.exe
+   ifort -I/usr/local/packages/libs/NAG/nll6i273bl/lp64/nag_interface_blocks a00aafe.f90 /usr/local/packages/libs/NAG/nll6i273bl/lp64/lib/libnag_nag.a -lm -ldl -lstdc++ -o a00aafe.exe
 
-Running a00aafe.exe
-./a00aafe.exe > a00aafe.r
- A00AAF Example Program Results
+   Running a00aafe.exe
+   ./a00aafe.exe > a00aafe.r
+    A00AAF Example Program Results
  
- *** Start of NAG Library implementation details ***
+    *** Start of NAG Library implementation details ***
  
- Implementation title: Linux, 64-bit, Intel Classic C/C++ or Intel Classic Fortran
-            Precision: double precision
-         Product Code: NLL6I273BL
-                 Mark: 27.3.0 (self-contained)
+    Implementation title: Linux, 64-bit, Intel Classic C/C++ or Intel Classic Fortran
+               Precision: double precision
+            Product Code: NLL6I273BL
+                    Mark: 27.3.0 (self-contained)
  
-  This is a 64-bit library using 32-bit integers.
+     This is a 64-bit library using 32-bit integers.
  
- *** End of NAG Library implementation details ***
+    *** End of NAG Library implementation details ***
 
 Documentation
 -------------

--- a/sharc/software/modulefiles/libs/NAG/nll6i273bl
+++ b/sharc/software/modulefiles/libs/NAG/nll6i273bl
@@ -1,0 +1,29 @@
+#%Module1.0#####################################################################
+## NAG C and Fortran libraries module file for use with the Intel compiler (>=19.0.3)
+
+## Module file logging
+source /usr/local/etc/module_logging.tcl
+
+
+proc ModulesHelp { } {
+    global product
+    global mark
+    global compiler
+    global compilerminvers
+    puts stderr "Makes the $product NAG C and Fortran libraries available (Mark $mark for the $compiler (>= $compilerminvers) compilers) "
+}
+
+set product         nll6i273bl 
+set mark            27.3
+set compiler        intel
+set compilerminvers 19.0.3
+set NAG_DIR         /usr/local/packages/libs/NAG/$product
+
+module-whatis   "Makes the $product NAG C and Fortran libraries available (Mark $mark for the $compiler (>= $compilerminvers) compilers)"
+
+prepend-path LD_LIBRARY_PATH $NAG_DIR/lib
+prepend-path PATH            $NAG_DIR/scripts
+prepend-path CPATH           $NAG_DIR/nag_interface_blocks
+prepend-path LIBRARY_PATH    $NAG_DIR/lib
+setenv       NAG_KUSARI_FILE /usr/local/packages/dev/NAG/license.lic
+


### PR DESCRIPTION
install new NAG Fortran/C libs compatible with intel compiler 19.1.3 (& gcc-4.8.5)