### PR TITLE
Refactor emails

### DIFF
--- a/bessemer/software/apps/R.rst
+++ b/bessemer/software/apps/R.rst
@@ -133,7 +133,7 @@ To load external libraries you should  :ref:`search for a module <search_env_mod
 build chain of the R version you are using to avoid load conflicts e.g. for R 4.0.0, foss-2020a.
 
 To request the installation of dependencies for R packages that depend on non-R libraries
-please contact ``it-servicedesk@sheffield.ac.uk``.
+please contact ``research-it@sheffield.ac.uk``.
 
 Using the Rmath library in C Programs
 -------------------------------------

--- a/hpc/accounts.rst
+++ b/hpc/accounts.rst
@@ -11,8 +11,14 @@ of all of our clusters (:ref:`Bessemer <bessemer>` and :ref:`ShARC <sharc>`).
 For Staff
 ^^^^^^^^^
 
-HPC access is made available for staff by emailing their request to 
-`it-servicedesk@sheffield.ac.uk <it-servicedesk@sheffield.ac.uk>`_.
+HPC access is made available for staff by request via the HPC access 
+request form which can be found at the 
+`IT Service Desk Self Service Portal <https://shef.topdesk.net/tas/public/ssp/>`_ under the option 
+Service Request Forms.
+
+We recommend that staff also complete the 
+`HPC Driving License test <https://infosecurity.shef.ac.uk/>`_. **(The VPN must be connected for 
+access.)**
 
 For Students
 ^^^^^^^^^^^^
@@ -25,7 +31,7 @@ the permission of their supervisors:
 * Undergraduates 3rd & 4th year  - for project work
 
 To be granted HPC access, all students must first pass the 
-`HPC Driving License test <https://infosecurity.shef.ac.uk/>`_. **(The VPN must be connected in order to 
+`HPC Driving License test <https://infosecurity.shef.ac.uk/>`_. **(The VPN must be connected for 
 access.)**
 
 Following this, they should request that their academic supervisor fill in the HPC access 
@@ -67,7 +73,7 @@ controls that the HPC may not have in place.
 
 Extra care should always be taken when dealing with sensitive information; if you are in any doubt about 
 the sensitivity of information, or how it should be handled, then please contact IT Services 
-`it-servicedesk@sheffield.ac.uk <it-servicedesk@sheffield.ac.uk>`_ for advice.
+`research-it@sheffield.ac.uk <research-it@sheffield.ac.uk>`_ for advice.
 
 
 

--- a/hpc/connecting.rst
+++ b/hpc/connecting.rst
@@ -232,7 +232,7 @@ if you are unable to use VPN we also provide an SSH gateway service to allow off
 
 .. note::
   * Access to the HPC SSH gateway service requires that you have an existing :ref:`HPC account <accounts>`.
-  * You must additionally request access to the HPC SSH gateway by emailing `it-servicedesk@sheffield.ac.uk <it-servicedesk@sheffield.ac.uk>`_ including a justification for your request.
+  * You must additionally request access to the HPC SSH gateway by emailing `research-it@sheffield.ac.uk <research-it@sheffield.ac.uk>`_ including a justification for your request.
   * If the cluster access can be handled via the usage of the SSL VPN without undue effort, your request will not be granted.
 
 For more information see :ref:`HPC Gateway Service Details <hpcgateway>`.

--- a/hpc/filestore.rst
+++ b/hpc/filestore.rst
@@ -211,7 +211,7 @@ will be accessible if you ``cd`` (change directory) into a subdirectory e.g. ``c
 Specifics for Bessemer
 ^^^^^^^^^^^^^^^^^^^^^^
 
-If you need to access a ``/shared`` area on Bessemer please contact `it-servicedesk@sheffield.ac.uk <it-servicedesk@sheffield.ac.uk>`__ to arrange this.
+If you need to access a ``/shared`` area on Bessemer please contact `research-it@sheffield.ac.uk <research-it@sheffield.ac.uk>`__ to arrange this.
 
 
 .. warning::

--- a/hpc/hpcgateway.rst
+++ b/hpc/hpcgateway.rst
@@ -14,7 +14,7 @@ if you are unable to use VPN we also provide an SSH gateway service to allow off
 
 .. note::
   * Access to the HPC SSH gateway service requires that you have an existing :ref:`HPC account <accounts>`.
-  * You must additionally request access to the HPC SSH gateway by emailing `it-servicedesk@sheffield.ac.uk <it-servicedesk@sheffield.ac.uk>`_ including a justification for your request.
+  * You must additionally request access to the HPC SSH gateway by emailing `research-it@sheffield.ac.uk <research-it@sheffield.ac.uk>`_ including a justification for your request.
   * If the cluster access can be handled via the usage of the SSL VPN without undue effort, your request will not be granted.
 
 The SSH gateway server, ``hpcgw.shef.ac.uk``, is configured to be a SSH 'jump host' only:

--- a/hpc/jupyterhub.rst
+++ b/hpc/jupyterhub.rst
@@ -76,7 +76,7 @@ Status of and maintenance of ShARC's JupyterHub service
 
 This service is currenty **experimental**.
 If you use this service and encounter a problem,
-please contact `it-servicedesk@sheffield.ac.uk <it-servicedesk@sheffield.ac.uk>`_.
+please contact `research-it@sheffield.ac.uk <research-it@sheffield.ac.uk>`_.
 
 The server that provider the JupyterHub service is 
 typically **rebooted at 03:26 on the 2nd Tuesday of the month**


### PR DESCRIPTION
Correction from no longer functional it-servicedesk@sheffield.ac.uk to research-it@sheffield.ac.uk