### PR TITLE
Conda package version amendments

### DIFF
--- a/bessemer/software/apps/python.rst
+++ b/bessemer/software/apps/python.rst
@@ -58,7 +58,7 @@ environment named ``mynumpy``.
 
 Any version of Python or list of packages can be provided::
 
-    conda create -n myscience python=3.5 numpy=1.8.1 scipy
+    conda create -n myscience python=3.5 numpy=1.15.2 scipy
 
 If you wish to modify an existing environment, such as one of the anaconda
 installations, you can ``clone`` that environment::

--- a/sharc/software/apps/python.rst
+++ b/sharc/software/apps/python.rst
@@ -105,7 +105,7 @@ environment named ``mynumpy``.
 
 Any version of Python or list of packages can be provided::
 
-    conda create -n myscience python=3.5 numpy=1.8.1 scipy
+    conda create -n myscience python=3.5 numpy=1.15.2 scipy
 
 If you wish to modify an existing environment, such as one of the anaconda
 installations, you can ``clone`` that environment::


### PR DESCRIPTION
Update to correct numpy to a version capable of installing for the given Python version.

A change upstream I assume has been made breaking the existing docs example.