### PR TITLE
Update R&I team name

### DIFF
--- a/bessemer/software/apps/ansys/ls-dyna.rst
+++ b/bessemer/software/apps/ansys/ls-dyna.rst
@@ -145,8 +145,8 @@ Due to the limited number of licenses available if issues are encountered with r
 jobs please check the logs to see if the program is indicating an insufficient number 
 of available licenses. If this is the case, please resubmit your job until it runs.
 
-For other issues or if you wish to purchase some reserved licenses please contact
-Research IT.
+For other issues or if you wish to purchase some reserved licenses please
+:ref:`contact IT Services<need_help>`.
 
 If desired to perform post modelling analysis etc... the ANSYS Workbench GUI 
 executable can be launched with the  ``runwb2`` command. 

--- a/conf.py
+++ b/conf.py
@@ -94,8 +94,8 @@ html_theme_options = {
 #                       'navbar_title': ' ',
 #                       'navbar_links': [
 #                           ("Home", "index"),
-#                           ("Research Computing @ IT Services", "https://www.shef.ac.uk/it-services/research", True),
-#                           ("Research Software Engineering @ TUOS", "https://rse.shef.ac.uk", True)
+#                           ("Research and Innovation team, IT Services", "https://students.sheffield.ac.uk/it-services/research", True),
+#                           ("Research Software Engineering", "https://rse.shef.ac.uk", True)
 #                       ],
 #                       'globaltoc_depth': 1}
 

--- a/help.rst
+++ b/help.rst
@@ -4,7 +4,7 @@
 Need help?
 ==========
 
-If you need some help Research and Innovation IT have a lot of resources available to help you, please 
+If you need some help the Research and Innovation team in IT Services have a lot of resources available to help you, please 
 read through these resources below to find the most appropriate resources for your issues.
 
 ------
@@ -32,16 +32,16 @@ please have a look through the sections for :ref:`job debugging on ShARC <job_de
     Please make sure you check through our resources prior to contacting us as we are a small team with limited resources.
 
 If you are still having issues or need specific advice e.g. how to best parallelise your workflow, please contact 
-`Research IT <mailto:research-it@sheffield.ac.uk>`_ or if you have more specific queries about programming / coding for HPC clusters e.g. CUDA programming please contact
-the `Research Software Engineering Group <https://rse.shef.ac.uk/contact/>`_.
+`IT Services' Research and Innovation team <mailto:research-it@sheffield.ac.uk>`_ or if you have more specific queries about programming / coding for HPC clusters e.g. CUDA programming please contact
+the `Research Software Engineering team <https://rse.shef.ac.uk/contact/>`_.
 
 ------
 
 HPC training?
 -------------
 
-Research IT Training courses
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+IT Services' Research and Innovation courses
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If you are new to the cluster, have never used Linux or HPC before you should attend the RIT 101 (Introduction to Linux), 
 102 (Linux Shell Scripting Tutorial) and 103 (Introduction to Running Software on the HPC) courses.
@@ -49,19 +49,12 @@ If you are new to the cluster, have never used Linux or HPC before you should at
 These courses are very popular and run through both semesters. You can register for these courses at the course registration 
 website: https://crs.shef.ac.uk (Only accessible with the VPN turned on.)
 
-Research IT Training index
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+IT Services' Research and Innovation training index
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The Research IT training index is a website which will allow you to search for internal (to TUoS) and external training resources 
+The `Research and Innovation team's training index <https://rcgsheffield.github.io/TUoS-RIT-training-resources/training.html>`__ 
+allows you to search for internal (to TUoS) and external training resources 
 covering categories including HPC, Data Analysis / Visualisation, containerisation as well as domain specific resources such as 
 FEA, CFD, Chemistry and more.
 
 This site is currently in beta and more links are resources are being added.
-
-The site can be found at: https://rcgsheffield.github.io/TUoS-RIT-training-resources/training.html
-
-
-
-
-
-

--- a/hpc/accounts.rst
+++ b/hpc/accounts.rst
@@ -68,8 +68,8 @@ controls that the HPC may not have in place.
 
    The High Performance Computing service should not be used to store or process sensitive information.
    For example: medical records, personal information, financial data, commercially sensitive or 
-   any other form of restricted data without first discussing your requirements with the Research IT Team - 
-   research-it@sheffield.ac.uk 
+   any other form of restricted data without first
+   :ref:`discussing your requirements with IT Services <need_help>`.
 
 Extra care should always be taken when dealing with sensitive information; if you are in any doubt about 
 the sensitivity of information, or how it should be handled, then please contact IT Services 

--- a/hpc/what-is-hpc.rst
+++ b/hpc/what-is-hpc.rst
@@ -201,7 +201,7 @@ HPC clusters, but they cannot teach you how to use your program in great detail
 nor train you on the basic usage of a program.
 
 At The University of Sheffield, research training needs should be addressed via 
-`training courses provided by Research IT <https://crs.shef.ac.uk>`_ 
+`training courses provided by IT Services' Research and Innovation team <https://crs.shef.ac.uk>`_ 
 (VPN must be turned on), 
 `Research Software Engineering <https://rse.shef.ac.uk/>`_  
 or Departmental / research group resources. PhD students can also make use of their 
@@ -231,5 +231,5 @@ How do I get started?
 ---------------------
 
 Potential users should first register and attend training courses RIT 101 to 103 on 
-the `Research IT course registration website <https://crs.shef.ac.uk>`_ 
+`IT Services' Research and Innovation course registration website <https://crs.shef.ac.uk>`_ 
 (VPN must be turned on) and should then :ref:`request an account <accounts>`.

--- a/index.rst
+++ b/index.rst
@@ -8,18 +8,18 @@ This is the documentation for The University of Sheffield's High Performance Com
 * :ref:`bessemer` 
 * :ref:`sharc` 
 
-Run by IT Services' Research Computing Group
+Run by IT Services' Research and Innovation team
 with additional support from the Research Software Engineering team in Computer Science,
 they support the computational needs of hundreds of researchers across all departments.
 
-Research Computing Team
------------------------
+Research and Innovation team
+----------------------------
 
-The research computing team are the team responsible for the HPC services, as well as all other aspects of research computing.
-If you require support with HPC, training or software for your workstations, the research computing team would be happy to help.
-Take a look at the `Research Computing <https://www.shef.ac.uk/it-services/research>`_ website or email `research-it@sheffield.ac.uk <research-it@sheffield.ac.uk>`_.
+The Research and Innovation team in IT Services are the team responsible for the HPC services, as well as all other aspects of research computing.
+If you require support with HPC, training or software for your workstations, the Research and Innovation team would be happy to help.
+Take a look at the `Research and Innovation <https://students.sheffield.ac.uk/it-services/research>`_ website or email `research-it@sheffield.ac.uk <research-it@sheffield.ac.uk>`_.
 
-Research Software Engineering Team
+Research Software Engineering team
 ----------------------------------
 
 The Research Software Engineering team is an academically-led group in the `Department of Computer Science <https://www.sheffield.ac.uk/dcs>`_

--- a/mfa-update-21-10-2021.rst
+++ b/mfa-update-21-10-2021.rst
@@ -23,10 +23,3 @@ The purpose of this layer to the HPC login procedure is to protect your research
 If you are having issues with Filezilla transfers please see our `new instructions <https://notesrcg.blogspot.com/2021/10/mfa-on-hpc-login-nodes-how-to-use.html>`_.
 
 If you are having issues with MobaXterm file transfer windows not loading, please recreate your profiles as instructed on our :ref:`connection instructions <mobaxterm_connecting_profile_setup>` page.
-
-
-*Best wishes,*
-
-*Research-IT*
-
-

--- a/parallel/index.rst
+++ b/parallel/index.rst
@@ -66,4 +66,5 @@ Consult the `software documentation </sharc/software/>`_.
 Getting help
 ------------
 
-If you need advice on how to parallelise your workflow, please contact `Research IT <https://www.sheffield.ac.uk/it-services/research/research-support>`_ or the `Research Software Engineering Group <https://rse.shef.ac.uk/contact/>`_
+If you need advice on how to parallelise your workflow,
+please :ref:`contact IT Services or the Research Software Engineering team <need_help>`.

--- a/sharc/software/apps/ansys/ls-dyna.rst
+++ b/sharc/software/apps/ansys/ls-dyna.rst
@@ -203,7 +203,7 @@ jobs please check the logs to see if the program is indicating an insufficient n
 of available licenses. If this is the case, please resubmit your job until it runs.
 
 For other issues or if you wish to purchase some reserved licenses please contact
-Research IT.
+:ref:`IT Services <need_help>`.
 
 If desired to perform post modelling analysis etc... the ANSYS Workbench GUI 
 executable can be launched with the  ``runwb2`` command. 


### PR DESCRIPTION
We're now Research and Innovation team, not Research Computing Group.  Also updated link to more info on team.
