### PR TITLE
NetLogo JVM Max Heap size RAM amendment.

### DIFF
--- a/bessemer/software/apps/NetLogo.rst
+++ b/bessemer/software/apps/NetLogo.rst
@@ -150,6 +150,10 @@ Installation method
 |softwarename| version 6.2.0 was installed using Easybuild 4.4.0, build details can be found 
 in ``/usr/local/packages/live/eb/NetLogo/6.2.0-64/easybuild/``
 
+The NetLogo configuration file, ``/usr/local/packages/live/eb/NetLogo/6.2.0-64/app/NetLogo.cfg`` has been amended 
+to permit a larger default JVM "maximum Java heapsize" of 64GB RAM. For further details see: 
+https://ccl.northwestern.edu/netlogo/docs/faq.html#how-big-can-my-model-be-how-many-turtles-patches-procedures-buttons-and-so-on-can-my-model-contain
+
 
 --------
 


### PR DESCRIPTION
Amendment of config file on system and update to docs to reflect the new 64GB JVM -Xmx max heap size.