### PR TITLE
Add info on temporary A100 GPU nodes in Bessemer

### DIFF
--- a/bessemer/GPUComputingBessemer.rst
+++ b/bessemer/GPUComputingBessemer.rst
@@ -168,6 +168,11 @@ Specifications per A100 node:
    AMD-compatible modules by 'unusing' the default modules area and 'using' the alternate ``eb-znver3`` area.
    Available modules can then be listed with the ``modules avail`` command."
 
+   Note that if you've compiled any software in your :ref:`home, fastdata or shared areas <filestore>`
+   using other nodes in Bessemer then this may or may not run on these AMD nodes
+   depending on the extent to which the compilation process optimised the code for Intel CPUs.
+   You may need to recompile.
+
    Many users of these nodes will want to use the 
    :ref:`Conda <python_conda_bessemer>` package manager 
    to install software; 

--- a/bessemer/GPUComputingBessemer.rst
+++ b/bessemer/GPUComputingBessemer.rst
@@ -143,7 +143,7 @@ Specifications per A100 node:
 * Chassis: Dell XE8545
 * CPUs: 48 CPU cores from 2x AMD EPYC 7413 CPUs (*AMD Milan* aka *AMD Zen 3* microarchitecture; 2.65 GHz; 128MB L3 cache per CPU)
 * RAM: 512 GB (3200 MT/s)
-* Local storage: 460 GB RAID 1 on SSDs (boot device) plus 2.6 TB RAID 0 on SSDs (:ref:`'/scratch' temporary storage<scratch_dir>`)
+* Local storage: 460 GB boot device (SSD) plus 2.88 TB :ref:`'/scratch' temporary storage<scratch_dir>` (RAID 0 on SSDs)
 * GPUs: 4x `NVIDIA Tesla A100 <https://www.nvidia.com/en-gb/data-center/a100/>`__, each with
 
   * High-bandwidth, low-latency `NVLink <https://www.nvidia.com/en-gb/design-visualization/nvlink-bridges/>`__ GPU interconnects

--- a/bessemer/GPUComputingBessemer.rst
+++ b/bessemer/GPUComputingBessemer.rst
@@ -134,7 +134,7 @@ As of May 2022, 16 addtional GPUs nodes are (temporarily) available to all users
 These feature **NVIDIA A100 GPUs, which may be quite a bit faster than the (older generation) V100 GPUs** available elsewhere in Bessemer.
 
 .. warning::
-   These nodes are being made availble to Bessemer's users on a temporary basis
+   These nodes are being made available to Bessemer's users on a temporary basis
    as they will be migrated to the University's new cluster
    when that comes online in summer 2022.
 

--- a/bessemer/GPUComputingBessemer.rst
+++ b/bessemer/GPUComputingBessemer.rst
@@ -189,29 +189,39 @@ Specifications per A100 node:
       deactivate
       . activate my_non_intel_env2
 
-**Interactive usage/access**: ::
+Interactive usage/access
+^^^^^^^^^^^^^^^^^^^^^^^^
 
- # Start an interactive session on the A100 nodes, this case with just one A100 GPU:
- srun --pty --partition=gpu-a100-tmp --gpus-per-node=1 /bin/bash -i
+Start an interactive session on the A100 nodes (in this case with just one A100 GPU): ::
+
+   srun --pty --partition=gpu-a100-tmp --gpus-per-node=1 /bin/bash -i
  
- # Activate software that has been optimised for the AMD Milan CPUs in these nodes
- module unuse /usr/local/modulefiles/live/eb/all 
- module unuse /usr/local/modulefiles/live/noeb
- module use /usr/local/modulefiles/staging/eb-znver3/all/
+Activate software that has been optimised for the AMD Milan CPUs in these nodes: ::
 
- # List software available for use on these nodes
- module avail
+   module unuse /usr/local/modulefiles/live/eb/all 
+   module unuse /usr/local/modulefiles/live/noeb
+   module use /usr/local/modulefiles/staging/eb-znver3/all/
 
-**Batch job usage/access** - within your job script(s):
+List software available for use on these nodes: ::
+
+   module avail
+
+Batch job usage/access
+^^^^^^^^^^^^^^^^^^^^^^
+
+Within your job script(s):
 
 * Ensure you have ``#SBATCH --partition=gpu-a100-tmp`` near the top of your job script
 * Below that include the three ``module unuse`` / ``module use`` lines shown above before you run any software
 
-**More detailed information on building and running software on AMD EPYC CPUs (e.g. AMD Milan)**:
+More information on using AMD CPUs
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+More detailed information on building and running software on AMD EPYC CPUs (e.g. AMD Milan)**:
 `PRACE's Best Practice Guide - AMD EYPC <https://prace-ri.eu/wp-content/uploads/Best-Practice-Guide_AMD.pdf>`__.
 
 Training materials
-^^^^^^^^^^^^^^^^^^
+------------------
 
-* `Introduction to CUDA by GPUComputing@Sheffield <http://gpucomputing.shef.ac.uk/education/cuda/>`_
+* `Introduction to CUDA by GPUComputing@Sheffield <https://gpucomputing.shef.ac.uk/education/cuda/>`_
 

--- a/bessemer/GPUComputingBessemer.rst
+++ b/bessemer/GPUComputingBessemer.rst
@@ -157,9 +157,6 @@ Specifications per A100 node:
    Attempts to run Intel-optimised software on these nodes
    will often result in *illegal instruction* errors.
 
-
-
-
    A limited number of software packages have been provided 
    for use on these nodes whilst they are temporarily available in Bessemer:
 
@@ -192,7 +189,7 @@ Specifications per A100 node:
       deactivate
       . activate my_non_intel_env2
 
-Interactive usage/access: ::
+**Interactive usage/access**: ::
 
  # Start an interactive session on the A100 nodes, this case with just one A100 GPU:
  srun --pty --partition=gpu-test --gpus-per-node=1 /bin/bash -i
@@ -205,7 +202,7 @@ Interactive usage/access: ::
  # List software available for use on these nodes
  module avail
 
-Batch job usage/access - within your job script(s):
+**Batch job usage/access** - within your job script(s):
 
 * Ensure you have ``#SBATCH --partition=gpu-test`` near the top of your job script
 * Below that include the three ``module unuse`` / ``module use`` lines shown above before you run any software

--- a/bessemer/GPUComputingBessemer.rst
+++ b/bessemer/GPUComputingBessemer.rst
@@ -122,6 +122,60 @@ GPU-enabled Software
   * :ref:`PGI Compilers_bessemer`
   * :ref:`nvidia_compiler_bessemer`
 
+Temporary NVIDIA A100 GPU nodes
+-------------------------------
+
+Prior to May 2022 the Bessemer cluster only featured :ref:`one 'public' GPU node <bessemer-gpu-specs>` containing NVIDIA V100 GPUs
+(although private GPU nodes could be accessed using :ref:`preemptable jobs, for those whose workflows could tolerate preemption<preemptable_jobs_bessemer>`).
+
+As of May 2022, 16 addtional GPUs nodes are (temporarily) available to all users of Bessemer.  
+These feature **NVIDIA A100 GPUs, which may be quite a bit faster than the (older generation) V100 GPUs** available elsewhere in Bessemer.
+
+.. warning::
+   These nodes are being made availble to Bessemer's users on a temporary basis
+   as they will be migrated to the University's new cluster
+   when that comes online in summer 2022.
+
+Specifications per A100 node:
+
+* Chassis: Dell XE8545
+* CPUs: 48 CPU cores from 2x AMD EPYC 7413 CPUs (*AMD Milan* aka *AMD Zen 3* microarchitecture; 2.65 GHz; 128MB L3 cache per CPU)
+* RAM: 512 GB (3200 MT/s)
+* Local storage: 460 GB RAID 1 on SSDs (boot device) plus 2.6 TB RAID 0 on SSDs (temporary storage)
+* GPUs: 4x `NVIDIA Tesla A100 <https://www.nvidia.com/en-gb/data-center/a100/>`__, each with
+
+  * High-bandwidth, low-latency `NVLink <https://www.nvidia.com/en-gb/design-visualization/nvlink-bridges/>`__ GPU interconnects
+  * 80GB memory (HBM2e)
+
+.. warning::
+
+   Much of the :ref:`existing centrally-provided software on Bessemer <bessemer-software>` won't work on
+   the AMD CPUs in these nodes as it has been heavily optimised for Intel CPUs.
+
+   Attempts to run Intel-optimised software on these nodes
+   will often result in *illegal instruction* errors.
+
+   A limited number of software packages have been provided for use on these nodes
+   whilst they are temporarily available in Bessemer.
+
+Interactive usage/access: ::
+
+ # Start an interactive session on the A100 nodes, this case with just one A100 GPU:
+ srun --pty --partition=gpu-test --gpus-per-node=1 /bin/bash -i
+ 
+ # Activate software that has been optimised for the AMD Milan CPUs in these nodes
+ module unuse /usr/local/modulefiles/live/eb/all 
+ module unuse /usr/local/modulefiles/live/noeb
+ module use /usr/local/modulefiles/staging/eb-znver3/all/
+
+ # List software available for use on these nodes
+ module avail
+
+Batch job usage/access - within your job script(s):
+
+* Ensure you have ``#SBATCH --partition=gpu-test`` near the top of your job script
+* Below that include the three ``module unuse`` / ``module use`` lines shown above before you run any software
+
 Training materials
 ^^^^^^^^^^^^^^^^^^
 

--- a/bessemer/GPUComputingBessemer.rst
+++ b/bessemer/GPUComputingBessemer.rst
@@ -207,6 +207,9 @@ Specifications per A100 node:
 * Ensure you have ``#SBATCH --partition=gpu-a100-tmp`` near the top of your job script
 * Below that include the three ``module unuse`` / ``module use`` lines shown above before you run any software
 
+**More detailed information on building and running software on AMD EPYC CPUs (e.g. AMD Milan)**:
+`PRACE's Best Practice Guide - AMD EYPC <https://prace-ri.eu/wp-content/uploads/Best-Practice-Guide_AMD.pdf>`__.
+
 Training materials
 ^^^^^^^^^^^^^^^^^^
 

--- a/bessemer/GPUComputingBessemer.rst
+++ b/bessemer/GPUComputingBessemer.rst
@@ -141,7 +141,7 @@ Specifications per A100 node:
 * Chassis: Dell XE8545
 * CPUs: 48 CPU cores from 2x AMD EPYC 7413 CPUs (*AMD Milan* aka *AMD Zen 3* microarchitecture; 2.65 GHz; 128MB L3 cache per CPU)
 * RAM: 512 GB (3200 MT/s)
-* Local storage: 460 GB RAID 1 on SSDs (boot device) plus 2.6 TB RAID 0 on SSDs (temporary storage)
+* Local storage: 460 GB RAID 1 on SSDs (boot device) plus 2.6 TB RAID 0 on SSDs (:ref:`'/scratch' temporary storage<scratch_dir>`)
 * GPUs: 4x `NVIDIA Tesla A100 <https://www.nvidia.com/en-gb/data-center/a100/>`__, each with
 
   * High-bandwidth, low-latency `NVLink <https://www.nvidia.com/en-gb/design-visualization/nvlink-bridges/>`__ GPU interconnects

--- a/bessemer/GPUComputingBessemer.rst
+++ b/bessemer/GPUComputingBessemer.rst
@@ -219,6 +219,12 @@ Within your job script(s):
 * Ensure you have ``#SBATCH --partition=gpu-a100-tmp`` near the top of your job script
 * Below that include the three ``module unuse`` / ``module use`` lines shown above before you run any software
 
+
+Compiling for A100 GPUs
+^^^^^^^^^^^^^^^^^^^^^^^
+
+See :ref:<bessemer_gpu_code_gen_opts>.
+
 More information on using AMD CPUs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/bessemer/GPUComputingBessemer.rst
+++ b/bessemer/GPUComputingBessemer.rst
@@ -122,6 +122,8 @@ GPU-enabled Software
   * :ref:`PGI Compilers_bessemer`
   * :ref:`nvidia_compiler_bessemer`
 
+.. _GPUResources_bessemer_tmp_a100_nodes:
+
 Temporary NVIDIA A100 GPU nodes
 -------------------------------
 
@@ -155,8 +157,34 @@ Specifications per A100 node:
    Attempts to run Intel-optimised software on these nodes
    will often result in *illegal instruction* errors.
 
-   A limited number of software packages have been provided for use on these nodes
-   whilst they are temporarily available in Bessemer.
+   A limited number of software packages have been provided 
+   in a separate area (activate by ``module use``) 
+   for use on these nodes whilst they are temporarily available in Bessemer:
+
+   * Some has been compiled and optimised for the AMD Milan CPUs in these nodes
+   * Other software isn't overly optimised for AMD Milan or Intel 
+     (typically as it's pre-compiled binaries provided by software vendors)
+
+   Many users of these nodes will want to use the 
+   :ref:`Conda <python_conda_bessemer>` package manager 
+   to install software; 
+   most software installed via Conda will work fine on these AMD Milan CPUs *but*
+   the default library used by numpy, pandas etc for linear algebra, the *Intel MKL*, 
+   isn't particularly performant on these CPUs.
+   If you can't offload your linear algebra onto the GPUs in these nodes then you 
+   may want to switch to using an alternative library for linear algebra e.g. ::
+
+      conda create -n my_non_intel_env1 -c anaconda python numpy scipy blas=*=*openblas openblas
+      . activate my_non_intel_env1
+
+   Or you can try using an older version of the Intel MKL instead,
+   where there's a special trick for enabling better performance on AMD CPUs: ::
+
+      conda create -n my_non_intel_env2 -c anaconda python numpy mkl=2019.* blas=*=*mkl
+      . activate my_non_intel_env2
+      conda env config vars set MKL_DEBUG_CPU_TYPE=5
+      deactivate
+      . activate my_non_intel_env2
 
 Interactive usage/access: ::
 

--- a/bessemer/GPUComputingBessemer.rst
+++ b/bessemer/GPUComputingBessemer.rst
@@ -192,7 +192,7 @@ Specifications per A100 node:
 **Interactive usage/access**: ::
 
  # Start an interactive session on the A100 nodes, this case with just one A100 GPU:
- srun --pty --partition=gpu-test --gpus-per-node=1 /bin/bash -i
+ srun --pty --partition=gpu-a100-tmp --gpus-per-node=1 /bin/bash -i
  
  # Activate software that has been optimised for the AMD Milan CPUs in these nodes
  module unuse /usr/local/modulefiles/live/eb/all 
@@ -204,7 +204,7 @@ Specifications per A100 node:
 
 **Batch job usage/access** - within your job script(s):
 
-* Ensure you have ``#SBATCH --partition=gpu-test`` near the top of your job script
+* Ensure you have ``#SBATCH --partition=gpu-a100-tmp`` near the top of your job script
 * Below that include the three ``module unuse`` / ``module use`` lines shown above before you run any software
 
 Training materials

--- a/bessemer/GPUComputingBessemer.rst
+++ b/bessemer/GPUComputingBessemer.rst
@@ -223,12 +223,12 @@ Within your job script(s):
 Compiling for A100 GPUs
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-See :ref:<bessemer_gpu_code_gen_opts>.
+See :ref:`here <bessemer_gpu_code_gen_opts>`.
 
 More information on using AMD CPUs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-More detailed information on building and running software on AMD EPYC CPUs (e.g. AMD Milan)**:
+More detailed information on building and running software on AMD EPYC CPUs (e.g. AMD Milan):
 `PRACE's Best Practice Guide - AMD EYPC <https://prace-ri.eu/wp-content/uploads/Best-Practice-Guide_AMD.pdf>`__.
 
 Training materials

--- a/bessemer/GPUComputingBessemer.rst
+++ b/bessemer/GPUComputingBessemer.rst
@@ -157,13 +157,19 @@ Specifications per A100 node:
    Attempts to run Intel-optimised software on these nodes
    will often result in *illegal instruction* errors.
 
+
+
+
    A limited number of software packages have been provided 
-   in a separate area (activate by ``module use``) 
    for use on these nodes whilst they are temporarily available in Bessemer:
 
-   * Some has been compiled and optimised for the AMD Milan CPUs in these nodes
+   * Some packages have been compiled and optimised for the AMD Milan CPUs in these nodes
    * Other software isn't overly optimised for AMD Milan or Intel 
      (typically as it's pre-compiled binaries provided by software vendors)
+
+   See the example below where we change our modules source from the normal Bessemer software packages modules to
+   AMD-compatible modules by 'unusing' the default modules area and 'using' the alternate ``eb-znver3`` area.
+   Available modules can then be listed with the ``modules avail`` command."
 
    Many users of these nodes will want to use the 
    :ref:`Conda <python_conda_bessemer>` package manager 

--- a/bessemer/groupnodes/dcs-acad-gpu-nodes.rst
+++ b/bessemer/groupnodes/dcs-acad-gpu-nodes.rst
@@ -14,18 +14,23 @@ share two NVIDIA V100 GPU nodes in :ref:`Bessemer <bessemer>`:
    * - Academic
      - Node
      - Slurm Account name
+     - Slurm Partition name
    * - `Carolina Scarton`_
      - ``bessemer-node041``
      - ``dcs-acad1``
+     - (see notes below)
    * - `Chenghua Lin`_
      - ``bessemer-node041``
      - ``dcs-acad2``
+     - (see notes below)
    * - `Matt Ellis`_
      - ``bessemer-node042``
      -  ``dcs-acad3``
+     - (see notes below)
    * - `Po Yang`_
      - ``bessemer-node042``
      - ``dcs-acad4``
+     - (see notes below)
 
 Other academics in the department have **temporary** access to some NVIDIA A100 GPU nodes in Bessemer:
 
@@ -70,10 +75,6 @@ Hardware specifications
    * - Local storage
      - 140 GB of temporary storage under ``/scratch`` (2x SSD RAID1)
 
-.. note::
-
-   Most other GPU nodes in Bessemer have 32GB of GPU memory per GPU.
-
 ``gpu-node017`` and ``gpu-node018`` 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -83,7 +84,7 @@ See the
 Requesting access
 -----------------
 
-Users other than the :ref:`four listed academics <dcs_acad_gpu_node_accounts>`
+Users other than the :ref:`listed academics <dcs_acad_gpu_node_accounts>`
 should contact one of those academics should they want access to these nodes.
 
 That academic can then grant users access to the relevant SLURM Account (e.g. ``dcs-acad1``)

--- a/bessemer/groupnodes/dcs-acad-gpu-nodes.rst
+++ b/bessemer/groupnodes/dcs-acad-gpu-nodes.rst
@@ -4,7 +4,7 @@ GPU nodes for specific Computer Science academics
 =================================================
 
 Four academics in the `Department of Computer Science <https://www.sheffield.ac.uk/dcs>`__ (DCS)
-share two GPU nodes in :ref:`Bessemer <bessemer>`.
+share two NVIDIA V100 GPU nodes in :ref:`Bessemer <bessemer>`:
 
 .. _dcs_acad_gpu_node_accounts:
 
@@ -12,22 +12,47 @@ share two GPU nodes in :ref:`Bessemer <bessemer>`.
    :header-rows: 1
 
    * - Academic
+     - Node
      - Slurm Account name
    * - `Carolina Scarton`_
+     - ``bessemer-node041``
      - ``dcs-acad1``
    * - `Chenghua Lin`_
+     - ``bessemer-node041``
      - ``dcs-acad2``
-   * - Matt Ellis
+   * - `Matt Ellis`_
+     - ``bessemer-node042``
      -  ``dcs-acad3``
    * - `Po Yang`_
-     - ``dcs-acad3``
+     - ``bessemer-node042``
+     - ``dcs-acad4``
+
+Other academics in the department have **temporary** access to some NVIDIA A100 GPU nodes in Bessemer:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Academic(s)
+     - Node
+     - Slurm Account name
+     - Slurm Partition name
+   * - `Heidi Christensen`_ / `Jon Barker`_
+     - ``gpu-node017``
+     - ``dcs-acad5``
+     - ``dcs-acad5``
+   * - `Nafise Sadat Moosavi`_
+     - ``gpu-node018``
+     - ``dcs-acad6``
+     - ``dcs-acad6``
+
 
 .. _dcs_acad_gpu_nodes_hw:
 
 Hardware specifications
 -----------------------
 
-``bessemer-node041`` and ``bessemer-node042`` each have:
+``bessemer-node041`` and ``bessemer-node042``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. list-table::
    :header-rows: 0
@@ -49,6 +74,12 @@ Hardware specifications
 
    Most other GPU nodes in Bessemer have 32GB of GPU memory per GPU.
 
+``gpu-node017`` and ``gpu-node018`` 
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+See the 
+:ref:`specifications of the NVIDIA A100 nodes listed here <GPUResources_bessemer_tmp_a100_nodes>`.
+
 Requesting access
 -----------------
 
@@ -67,12 +98,12 @@ Only certain users have access to a given Account.
 
 .. _dcs_acad_gpu_nodes_non_prempt_access:
 
-1. Non-preemptable access to half a node
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+sharc-node041 and sharc-node042: non-preemptable access to half a node
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Each of the four academics (plus their collaborators) have ring-fenced, on-demand access to the resources of half a node.
+Each of four academics (plus their collaborators) have ring-fenced, on-demand access to the resources of half a node.
 
-To submit a job via this route, you need to :ref:`specify a *Partition* and *Account* <slurm_access_priv_nodes>` when submitting a batch job or starting an interactive session:
+To submit a job via this route, you need to :ref:`specify a Partition and an Account <slurm_access_priv_nodes>` when submitting a batch job or starting an interactive session:
 
 * Partition: ``dcs-acad``
 * Account: ``dcs-acadX`` where ``X`` is 1, 2, 3 or 4 and :ref:`varies between the academics <dcs_acad_gpu_node_accounts>`).
@@ -89,10 +120,10 @@ Resource limits per job:
 .. todo::
    If using cluster-wide values for default and max run time then link to central info re that rather than duplicating here.
 
-2. Preemptable access to both nodes
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+sharc-node041 and sharc-node042: preemptable access to both nodes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If any of the academics (or their collaborators) want to run a larger job that requires
+If any of the four academics (or their collaborators) want to run a larger job that requires
 up to *all* the resources available in *one* of these two nodes
 then they can :ref:`specify a different Partition <slurm_access_priv_nodes>` when submitting a batch job or starting an interactive session:
 
@@ -112,20 +143,31 @@ Resource limits per job:
   i.e. multi-node jobs are not permitted.
 * Same default and maximum run-time (:ref:`as above <dcs_acad_gpu_nodes_non_prempt_access>`).
 
-.. todo::
+gpu-node017 and gpu-node018: access to a node
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-   Re-add the following after setting it up:
+Two sets two academics (plus their collaborators) each have access to one node.
 
-   3. General preemptable access to both nodes
+To submit a job via this route, you need to 
+:ref:`specify a Partition and an Account <slurm_access_priv_nodes>` 
+when submitting a batch job or starting an interactive session:
 
-   Users other than the academics and their collaborators can make use of idle time on these nodes and other nodes by
-   submitting batch jobs and starting interactive sessions using a :ref:`particular partition <slurm_access_priv_nodes>`:
+* Partition: ``dcs-acadX`` where ``X`` is 5 or 6 and :ref:`varies between the academics <dcs_acad_gpu_node_accounts>`).
+* Account: ``dcs-acadX`` where again ``X`` is 5 or 6.
+* QoS: do not specify one i.e. do not use the ``--qos`` parameter.
 
-   * Partition: ``preempt``
+Resource limits per job:
 
-   These jobs can be preempted by jobs submitted to the ``dcs-acad-pre`` and ``dcs-acad`` partitions.
-
+* Default run-time: 8 hours
+* Maximum run-time: 7 days
+* CPU cores: 48
+* GPUs: 4
+* Memory: 512 GB
 
 .. _Carolina Scarton: https://www.sheffield.ac.uk/dcs/people/academic/carolina-scarton
 .. _Chenghua Lin: https://www.sheffield.ac.uk/dcs/people/academic/chenghua-lin
+.. _Heidi Christensen: https://www.sheffield.ac.uk/dcs/people/academic/heidi-christensen
+.. _Jon Barker: https://www.sheffield.ac.uk/dcs/people/academic/jon-barker
+.. _Matt Ellis: https://www.sheffield.ac.uk/dcs/people/academic/matt-ellis
+.. _Nafise Sadat Moosavi: https://www.sheffield.ac.uk/dcs/people/academic/nafise-sadat-moosavi
 .. _Po Yang: https://www.sheffield.ac.uk/dcs/people/academic/po-yang

--- a/bessemer/software/libs/cuda.rst
+++ b/bessemer/software/libs/cuda.rst
@@ -133,6 +133,8 @@ In this demonstration, we create a batch job that
 
 ---------
 
+.. _bessemer_gpu_code_gen_opts:
+
 GPU Code Generation Options
 ---------------------------
 
@@ -146,7 +148,7 @@ allows for 'fatbinary' executables that are optimised for multiple device archit
 Each ``-gencode`` argument requires two values,
 the *virtual architecture* and *real architecture*,
 for use in NVCC's `two-stage compilation <https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#virtual-architectures>`_.
-I.e. ``-gencode=arch=compute_70,code=sm_70`` specifies a virtual architecture of ``compute_70`` and real architecture ``sm_70``.
+For example, ``-gencode=arch=compute_70,code=sm_70`` specifies a virtual architecture of ``compute_70`` and real architecture ``sm_70``.
 
 To support future hardware of higher compute capability,
 an additional ``-gencode`` argument can be used to enable Just in Time (JIT) compilation of embedded intermediate PTX code.
@@ -156,14 +158,25 @@ i.e. ``-gencode=arch=compute_70,code=compute_70``.
 
 The minimum specified virtual architecture must be less than or equal to the `Compute Capability <https://developer.nvidia.com/cuda-gpus>`_ of the GPU used to execute the code.
 
-Public and private GPU nodes in Bessemer contain Tesla V100 GPUs, which are compute capability 70.
+Most public and private GPU nodes in Bessemer contain Tesla V100 GPUs, which are Compute Capability 70.
 To build a CUDA application which targets just the public GPUS nodes, use the following ``-gencode`` arguments:
 
 .. code-block:: sh
 
    nvcc filename.cu \
       -gencode=arch=compute_70,code=sm_70 \
-      -gencode=arch=compute_70,code=compute_70 \
+      -gencode=arch=compute_70,code=compute_70
+
+There are :ref:`(temporarily) also a number of A100 GPU nodes in Bessemer <GPUResources_bessemer_tmp_a100_nodes>`
+which are Compute Capability 80.
+To build a CUDA application which targets just those nodes
+you need CUDA >= 11 and need to supply the following ``-gencode`` arguments:
+
+.. code-block:: sh
+
+   nvcc filename.cu \
+      -gencode=arch=compute_80,code=sm_80 \
+      -gencode=arch=compute_80,code=compute_80
 
 Further details of these compiler flags can be found in the `NVCC Documentation <https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#options-for-steering-gpu-code-generation>`_,
 along with details of the supported `virtual architectures <https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#virtual-architecture-feature-list>`_ and `real architectures <https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#gpu-feature-list>`_.


### PR DESCRIPTION
Pretty terse, but that's in part deliberate because users of these nodes should ideally be already familiar with Bessemer/Slurm.

NB name of the partition these A100 nodes are in wants changing to `gpu-a100-tmp` to match these docs.

Closes #1484