### PR TITLE
nagfor 6.2 modulefile: warn that deprecated

### DIFF
--- a/sharc/software/modulefiles/dev/NAG/6.2
+++ b/sharc/software/modulefiles/dev/NAG/6.2
@@ -18,6 +18,11 @@ set nagroot /usr/local/packages/dev/NAG/$nagvers
 
 module-whatis   "Makes the NAG Fortran Compiler v$nagvers available"
 
+set curMod [module-info name]
+if { [ module-info mode load ] } {
+     puts stderr "Note: '$curMod' is deprecated on this system."
+}
+
 prepend-path PATH $nagroot/bin
 prepend-path MANPATH $nagroot/man
 setenv NAG_KUSARI_FILE /usr/local/packages/dev/NAG/license.lic


### PR DESCRIPTION
No longer supported and licensed by NAG.