### PR TITLE
Intel 2020a and 2020b updates.

### DIFF
--- a/bessemer/software/development/icc_ifort.rst
+++ b/bessemer/software/development/icc_ifort.rst
@@ -7,6 +7,8 @@ Intel has compilers for C (icc), C++ (icpc) and Fortran (ifort).
 
 To activate *both* the C/C++ and Fortran compilers use one of: ::
 
+   module load iccifort/2020.4.304  # subset of intel-2020b EasyBuild toolchain
+   module load iccifort/2020.1.217  # subset of intel-2020a EasyBuild toolchain
    module load iccifort/2019.5.281  # subset of intel-2019b EasyBuild toolchain
    module load iccifort/2019.1.144-GCC-8.2.0-2.31.1  # subset of intel-2019a toolchain
    module load iccifort/2018.3.222-GCC-7.3.0-2.30 # subset of intel-2018b toolchain

--- a/bessemer/software/libs/imkl.rst
+++ b/bessemer/software/libs/imkl.rst
@@ -21,6 +21,8 @@ Usage
 
 The Intel MKL can be activated using one of the following: ::
 
+   module load imkl/2020.4.304-iimpi-2020b  # subset of intel-2020b EasyBuild toolchain
+   module load imkl/2020.1.217-iimpi-2020a  # subset of intel-2020a EasyBuild toolchain
    module load imkl/2019.5.281-iimpi-2019b  # subset of intel-2019b EasyBuild toolchain
    module load imkl/2019.1.144-iimpi-2019a  # subset of intel-2019a EasyBuild toolchain
    module load imkl/2018.3.222-iimpi-2018b  # subset of intel-2018b EasyBuild toolchain

--- a/bessemer/software/parallel/impi.rst
+++ b/bessemer/software/parallel/impi.rst
@@ -16,7 +16,9 @@ Versions
 --------
 
 You can load a specific version using one of the following: ::
-
+    
+   module load impi/2019.9.304-iccifort-2020.4.304  # subset of intel 2020b EasyBuild toolchain
+   module load impi/2019.7.217-iccifort-2020.1.217  # subset of intel 2020a EasyBuild toolchain
    module load impi/2018.5.288-iccifort-2019.5.281  # subset of intel 2019b EasyBuild toolchain
    module load impi/2018.4.274-iccifort-2019.1.144-GCC-8.2.0-2.31.1  # subset of intel 2019a EasyBuild toolchain
    module load impi/2018.3.222-iccifort-2018.3.222-GCC-7.3.0-2.30 # subset of intel 2018b EasyBuild toolchain


### PR DESCRIPTION
Adds modules to each page for IMPI and compilers.