### PR TITLE
Remove invalid LS-DYNA licence warning.

### DIFF
--- a/bessemer/software/apps/ansys/ls-dyna.rst
+++ b/bessemer/software/apps/ansys/ls-dyna.rst
@@ -17,14 +17,6 @@ ANSYS LS-DYNA can make use of built in :ref:`MPI <parallel_MPI>` to utilize mult
 CPU and can scale to hundreds of cores.
 
 
-.. warning::
-
-    For the academic year 2021-2022 a total of 12 MPP (multicore) licenses are available. 
-    
-    For any given job you will use ``X-1`` ANSYS LS-DYNA MPP licenses where ``X`` is your chosen 
-    number of cores.
-
-
 ----------------
 
 .. include:: ../ansys/module-load-list.rst

--- a/sharc/software/apps/ansys/ls-dyna.rst
+++ b/sharc/software/apps/ansys/ls-dyna.rst
@@ -16,13 +16,6 @@ like drop tests, impact and penetration, smashes and crashes, occupant safety, a
 ANSYS LS-DYNA can make use of built in :ref:`MPI <parallel_MPI>` to utilize multiple cross 
 node CPU and can scale to hundreds of cores.
 
-.. warning::
-
-    For the academic year 2021-2022 a total of 12 MPP(multicore) licenses are available. 
-    
-    For any given MPI or SMP job you will use ``X-1`` ANSYS LS-DYNA MPP licenses where ``X`` is your 
-    chosen number of cores.
-
 
 ----------------
 


### PR DESCRIPTION
As of 2022 academic year and onward, LS-DYNA licences are now numerous and available in our base multiphysics licence.

Thus the warnings are no longer valid.