### PR TITLE
A100 GPU nodes to be removed from Bessemer and migrated to new HPC system

### DIFF
--- a/bessemer/GPUComputingBessemer.rst
+++ b/bessemer/GPUComputingBessemer.rst
@@ -130,13 +130,11 @@ Temporary NVIDIA A100 GPU nodes
 Prior to May 2022 the Bessemer cluster only featured :ref:`one 'public' GPU node <bessemer-gpu-specs>` containing NVIDIA V100 GPUs
 (although private GPU nodes could be accessed using :ref:`preemptable jobs, for those whose workflows could tolerate preemption<preemptable_jobs_bessemer>`).
 
-As of May 2022, 16 addtional GPUs nodes are (temporarily) available to all users of Bessemer.  
-These feature **NVIDIA A100 GPUs, which may be quite a bit faster than the (older generation) V100 GPUs** available elsewhere in Bessemer.
+Between May and December 2022, 16 addtional GPUs nodes were (temporarily) available to all users of Bessemer.  
+These featured **NVIDIA A100 GPUs, which were quite a bit faster than the (older generation) V100 GPUs** in Bessemer.
 
-.. warning::
-   These nodes are being made available to Bessemer's users on a temporary basis
-   as they will be migrated to the University's new cluster
-   when that comes online in summer 2022.
+.. note::
+   These nodes were removed from Bessemer in December 2022 and will be available in the University's new HPC cluster, Stanage, early in 2023.
 
 Specifications per A100 node:
 
@@ -148,87 +146,6 @@ Specifications per A100 node:
 
   * High-bandwidth, low-latency `NVLink <https://www.nvidia.com/en-gb/design-visualization/nvlink-bridges/>`__ GPU interconnects
   * 80GB memory (HBM2e)
-
-.. warning::
-
-   Much of the :ref:`existing centrally-provided software on Bessemer <bessemer-software>` won't work on
-   the AMD CPUs in these nodes as it has been heavily optimised for Intel CPUs.
-
-   Attempts to run Intel-optimised software on these nodes
-   will often result in *illegal instruction* errors.
-
-   A limited number of software packages have been provided 
-   for use on these nodes whilst they are temporarily available in Bessemer:
-
-   * Some packages have been compiled and optimised for the AMD Milan CPUs in these nodes
-   * Other software isn't overly optimised for AMD Milan or Intel 
-     (typically as it's pre-compiled binaries provided by software vendors)
-
-   See the example below where we change our modules source from the normal Bessemer software packages modules to
-   AMD-compatible modules by 'unusing' the default modules area and 'using' the alternate ``eb-znver3`` area.
-   Available modules can then be listed with the ``modules avail`` command."
-
-   Note that if you've compiled any software in your :ref:`home, fastdata or shared areas <filestore>`
-   using other nodes in Bessemer then this may or may not run on these AMD nodes
-   depending on the extent to which the compilation process optimised the code for Intel CPUs.
-   You may need to recompile.
-
-   Many users of these nodes will want to use the 
-   :ref:`Conda <python_conda_bessemer>` package manager 
-   to install software; 
-   most software installed via Conda will work fine on these AMD Milan CPUs *but*
-   the default library used by numpy, pandas etc for linear algebra, the *Intel MKL*, 
-   isn't particularly performant on these CPUs.
-   If you can't offload your linear algebra onto the GPUs in these nodes then you 
-   may want to switch to using an alternative library for linear algebra e.g. ::
-
-      conda create -n my_non_intel_env1 -c anaconda python numpy scipy blas=*=*openblas openblas
-      . activate my_non_intel_env1
-
-   Or you can try using an older version of the Intel MKL instead,
-   where there's a special trick for enabling better performance on AMD CPUs: ::
-
-      conda create -n my_non_intel_env2 -c anaconda python numpy mkl=2019.* blas=*=*mkl
-      . activate my_non_intel_env2
-      conda env config vars set MKL_DEBUG_CPU_TYPE=5
-      deactivate
-      . activate my_non_intel_env2
-
-Interactive usage/access
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-Start an interactive session on the A100 nodes (in this case with just one A100 GPU): ::
-
-   srun --pty --partition=gpu-a100-tmp --qos=gpu --gpus-per-node=1 /bin/bash -i
- 
-Activate software that has been optimised for the AMD Milan CPUs in these nodes: ::
-
-   module unuse /usr/local/modulefiles/live/eb/all 
-   module unuse /usr/local/modulefiles/live/noeb
-   module use /usr/local/modulefiles/staging/eb-znver3/all/
-
-List software available for use on these nodes: ::
-
-   module avail
-
-Batch job usage/access
-^^^^^^^^^^^^^^^^^^^^^^
-
-Within your job script(s):
-
-* Ensure you include the ``#SBATCH`` lines in :ref:`GPUJobs_bessemer` but change ``--partition`` from ``gpu`` to ``gpu-a100-tmp``;
-* Below that include the three ``module unuse`` / ``module use`` lines shown above before you run any software.
-
-Compiling for A100 GPUs
-^^^^^^^^^^^^^^^^^^^^^^^
-
-See :ref:`here <bessemer_gpu_code_gen_opts>`.
-
-More information on using AMD CPUs
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-More detailed information on building and running software on AMD EPYC CPUs (e.g. AMD Milan):
-`PRACE's Best Practice Guide - AMD EYPC <https://prace-ri.eu/wp-content/uploads/Best-Practice-Guide_AMD.pdf>`__.
 
 Training materials
 ------------------

--- a/bessemer/groupnodes/dcs-acad-gpu-nodes.rst
+++ b/bessemer/groupnodes/dcs-acad-gpu-nodes.rst
@@ -32,25 +32,6 @@ share two NVIDIA V100 GPU nodes in :ref:`Bessemer <bessemer>`:
      - ``dcs-acad4``
      - (see notes below)
 
-Other academics in the department have **temporary** access to some NVIDIA A100 GPU nodes in Bessemer:
-
-.. list-table::
-   :header-rows: 1
-
-   * - Academic(s)
-     - Node
-     - Slurm Account name
-     - Slurm Partition name
-   * - `Heidi Christensen`_ / `Jon Barker`_
-     - ``gpu-node017``
-     - ``dcs-acad5``
-     - ``dcs-acad5``
-   * - `Nafise Sadat Moosavi`_
-     - ``gpu-node018``
-     - ``dcs-acad6``
-     - ``dcs-acad6``
-
-
 .. _dcs_acad_gpu_nodes_hw:
 
 Hardware specifications
@@ -74,12 +55,6 @@ Hardware specifications
      - 25 Gbps Ethernet
    * - Local storage
      - 140 GB of temporary storage under ``/scratch`` (2x SSD RAID1)
-
-``gpu-node017`` and ``gpu-node018`` 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-See the 
-:ref:`specifications of the NVIDIA A100 nodes listed here <GPUResources_bessemer_tmp_a100_nodes>`.
 
 Requesting access
 -----------------
@@ -144,31 +119,7 @@ Resource limits per job:
   i.e. multi-node jobs are not permitted.
 * Same default and maximum run-time (:ref:`as above <dcs_acad_gpu_nodes_non_prempt_access>`).
 
-gpu-node017 and gpu-node018: access to a node
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Two sets two academics (plus their collaborators) each have access to one node.
-
-To submit a job via this route, you need to 
-:ref:`specify a Partition and an Account <slurm_access_priv_nodes>` 
-when submitting a batch job or starting an interactive session:
-
-* Partition: ``dcs-acadX`` where ``X`` is 5 or 6 and :ref:`varies between the academics <dcs_acad_gpu_node_accounts>`).
-* Account: ``dcs-acadX`` where again ``X`` is 5 or 6.
-* QoS: do not specify one i.e. do not use the ``--qos`` parameter.
-
-Resource limits per job:
-
-* Default run-time: 8 hours
-* Maximum run-time: 7 days
-* CPU cores: 48
-* GPUs: 4
-* Memory: 512 GB
-
 .. _Carolina Scarton: https://www.sheffield.ac.uk/dcs/people/academic/carolina-scarton
 .. _Chenghua Lin: https://www.sheffield.ac.uk/dcs/people/academic/chenghua-lin
-.. _Heidi Christensen: https://www.sheffield.ac.uk/dcs/people/academic/heidi-christensen
-.. _Jon Barker: https://www.sheffield.ac.uk/dcs/people/academic/jon-barker
 .. _Matt Ellis: https://www.sheffield.ac.uk/dcs/people/academic/matt-ellis
-.. _Nafise Sadat Moosavi: https://www.sheffield.ac.uk/dcs/people/academic/nafise-sadat-moosavi
 .. _Po Yang: https://www.sheffield.ac.uk/dcs/people/academic/po-yang

--- a/bessemer/software/libs/cuda.rst
+++ b/bessemer/software/libs/cuda.rst
@@ -167,8 +167,6 @@ To build a CUDA application which targets just the public GPUS nodes, use the fo
       -gencode=arch=compute_70,code=sm_70 \
       -gencode=arch=compute_70,code=compute_70
 
-There are :ref:`(temporarily) also a number of A100 GPU nodes in Bessemer <GPUResources_bessemer_tmp_a100_nodes>`
-which are Compute Capability 80.
 To build a CUDA application which targets just those nodes
 you need CUDA >= 11 and need to supply the following ``-gencode`` arguments:
 


### PR DESCRIPTION
I've removed some content that can be re-added once Stanage is online and have reworded other content to note that the A100 nodes are to very shortly transition between clusters with some downtime. 