### PR TITLE
Bump GitHub Actions versions

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,19 +1,20 @@
+---
 name: periodic_link_check
-on: 
+on:
   workflow_dispatch:
   schedule:
     # * is a special character in YAML so you have to quote this string
-    - cron:  '0 0 1,15 * *'
+    - cron: '0 0 1,15 * *'
 
 jobs:
   link_check:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python 3.7
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.7
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -13,10 +13,10 @@ jobs:
         python: [3.7, 3.9]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up a version of Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
 

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,3 +1,4 @@
+---
 name: Deploy site static content to Github Pages
 
 on:
@@ -35,7 +36,7 @@ jobs:
         uses: actions/checkout@v3
       # Install Python.
       - name: Set up a version of Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
       # Install Tox for build stage.


### PR DESCRIPTION
* actions/setup-python from v2 to v4
* actions/checkout from v2 to v3

We are getting deprecation warnings in GHA logs re the use of `actions/checkout@v2`