### PR TITLE
tox: use allowlist_externals, not whitelist_externals

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ isolated_build = True
 [testenv]
 deps =
     -r requirements.txt
-whitelist_externals =
+allowlist_externals =
     make
     echo
 commands =


### PR DESCRIPTION
`whitelist_externals` deprecated with newer versions of tox.

Closes #1593