### PR TITLE
Update dependencies and Python version

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Python 3.7
+      - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.10
 
       - name: Upgrade pip and install Tox
         run: |
@@ -24,4 +24,4 @@ jobs:
           python -m pip install tox
 
       - name: Check links
-        run: tox -e py37-linkcheck
+        run: tox -e py310-linkcheck

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: "3.10"
 
       - name: Upgrade pip and install Tox
         run: |

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,3 +1,4 @@
+---
 name: test_docs_build
 on:
   # Trigger on pull requests against the master branch
@@ -10,7 +11,7 @@ jobs:
     strategy:
       # Spawn and run a job for each of two supported Python 3.x versions
       matrix:
-        python: [3.10, 3.11]
+        python: ["3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       # Spawn and run a job for each of two supported Python 3.x versions
       matrix:
-        python: [3.7, 3.9]
+        python: [3.10, 3.11]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       # Spawn and run a job for Python 3.10 version.
       matrix:
-        python: [3.10]
+        python: ["3.10"]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -28,9 +28,9 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     strategy:
-      # Spawn and run a job for Python 3.7 version.
+      # Spawn and run a job for Python 3.10 version.
       matrix:
-        python: [3.7]
+        python: [3.10]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -46,7 +46,7 @@ jobs:
           python -m pip install tox
       # Run build stage - py37 should suffice.
       - name: Build the pages
-        run: tox -e py37
+        run: tox -e py310
       # Match old RTD directories pathing.
       - name: Move built files
         run: |

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ Rendered Documentation
 each push to the ``master`` branch causes the `ReadTheDocs <https://readthedocs.org/>`__ service to
 build and serve the documentation.
 
-The ReadTheDocs build configuration is stored in the ``.readthedocs.yaml`` file with the Python version pinned to 3.7 and the Pip 
+The ReadTheDocs build configuration is stored in the ``.readthedocs.yaml`` file with the Python version pinned to 3.10 and the Pip 
 requirements file. The requirements file is ``requirements.txt``.
 
 Please note that the use of the ``.readthedocs.yaml`` file will also override certain web UI settings set in the ReadTheDocs administrative panel.
@@ -47,25 +47,25 @@ Building the documentation on a local Windows machine
 
 #. Create a new *conda environment* for building the documentation by running the following from this window: ::
 
-    conda create --name sheffield_hpc python=3.7
+    conda create --name sheffield_hpc python=3.10
     conda activate sheffield_hpc	# . activate sheffield_hpc on older versions of conda
     pip install tox
 
 #. To build the HTML documentation run: ::
 
-    tox -e py37
+    tox -e py310
 
 The output should be written to ``./_build/html``.
 
 Building the documentation on a local Linux machine
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-#. Ensure one of Python 3.9 or 3.7 are installed.
+#. Ensure one of Python 3.10 or 3.11 are installed.
 #. Ensure the Tox_ build tool is installed and can be used/seen by your chosen Python interpreter.
 
 #. Run Tox to create an isolated Python virtual environment then build documentation: ::
 
-     tox -e py37  # OR
+     tox -e py310
      tox -e py39
 
 The output should be written to ``./_build/html``.
@@ -77,13 +77,13 @@ Building the documentation on a local Mac machine
 #. Install the Python packages needed to build the HTML documentation.  If you are using (mini)conda create a new *conda environment* for building the documentation by running: ::
 
     export PATH=${HOME}/miniconda3/bin:$PATH
-    conda create -n sheffield_hpc python=3.7
+    conda create -n sheffield_hpc python=3.10
     conda activate sheffield_hpc	# . activate sheffield_hpc on older versions of conda
     pip install tox
 
 #. To build the HTML documentation run::
 
-    tox -e py37
+    tox -e py310
 
 The output should be written to ``./_build/html``.
 
@@ -92,21 +92,21 @@ Check external links
 
 Do this with: ::
 
-   tox -e py37-linkcheck
+   tox -e py310-linkcheck
 
 Continuous build and serve
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Build and serve the site and automatically rebuild when source files change: ::
 
-   tox -e py37-livehtml
+   tox -e py310-livehtml
 
 Testing the building of the documentation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The validity of the reStructuredText in this repo and the ability to convert that to HTML with Sphinx can be tested in three ways:
 
-* Locally by contributors when they run e.g. ``tox -e py37-livehtml``
+* Locally by contributors when they run e.g. ``tox -e py310-livehtml``
 * By a [GitHub Actions](https://github.com/rcgsheffield/sheffield_hpc/actions/) Workflow each time a contributor creates or updates a Pull Request.
 * By `ReadTheDocs <https://readthedocs.org/projects/iceberg/>`__ on each push to the ``master`` branch.
 

--- a/conf.py
+++ b/conf.py
@@ -23,6 +23,8 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
     'sphinx_substitution_extensions',
+    'sphinxcontrib.jquery',
+    'sphinx_rtd_theme',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -38,7 +40,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'Sheffield HPC Documentation'
-copyright = '2022, The University of Sheffield'
+copyright = '2023, The University of Sheffield'
 author = 'The University of Sheffield'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/conf.py
+++ b/conf.py
@@ -85,7 +85,6 @@ html_theme = 'sheffieldhpc'
 html_theme_path = ['themes'] + [sphinx_rtd_theme.get_html_theme_path()]
 html_theme_options = {
     'style_external_links': True,
-    'canonical_url': 'https://docs.hpc.sheffield.ac.uk',
     'navigation_depth': 6,
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ requests==2.28.1
 setuptools <63
 six==1.16.0
 snowballstemmer==2.2.0
-Sphinx==5.1.1
+Sphinx==6.0.0
 sphinx-autobuild==2021.3.14
 sphinx-bootstrap-theme==0.8.1
 sphinxcontrib-applehelp==1.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ requests==2.28.1
 setuptools <63
 six==1.16.0
 snowballstemmer==2.2.0
-Sphinx==4.5.0
+Sphinx==5.1.1
 sphinx-autobuild==2021.3.14
 sphinx-bootstrap-theme==0.8.1
 sphinxcontrib-applehelp==1.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,3 +33,4 @@ tornado==6.2
 Sphinx-Substitution-Extensions==2022.02.16
 urllib3==1.26.12
 watchdog==2.1.9
+sphinxcontrib-jquery==3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ six==1.16.0
 snowballstemmer==2.2.0
 Sphinx==6.0.0
 sphinx-autobuild==2021.3.14
-sphinx-bootstrap-theme==0.8.1
+sphinx_rtd_theme==0.5.1
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-devhelp==1.0.2
 sphinxcontrib-htmlhelp==2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ argh==0.26.2
 Babel==2.10.3
 certifi==2022.12.7
 chardet==4.0.0
-docutils==0.17.1
+docutils==0.19
 idna==3.3
 imagesize==1.4.1
 Jinja2==3.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ sphinxcontrib-htmlhelp==2.0.0
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
-tornado==6.1
+tornado==6.2
 Sphinx-Substitution-Extensions==2022.02.16
 urllib3==1.26.12
 watchdog==2.1.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ alabaster==0.7.12
 argh==0.26.2
 Babel==2.10.3
 certifi==2022.12.7
-chardet==4.0.0
+chardet==5.1.0
 docutils==0.19
 idna==3.3
 imagesize==1.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ argh==0.26.2
 Babel==2.10.3
 certifi==2022.12.7
 chardet==5.1.0
-docutils==0.19
+docutils==0.17.1
 idna==3.3
 imagesize==1.4.1
 Jinja2==3.1.2
@@ -20,9 +20,9 @@ requests==2.28.1
 setuptools <63
 six==1.16.0
 snowballstemmer==2.2.0
-Sphinx==6.0.0
+Sphinx==5.3.0
 sphinx-autobuild==2021.3.14
-sphinx_rtd_theme==0.5.1
+sphinx_rtd_theme==1.1.1
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-devhelp==1.0.2
 sphinxcontrib-htmlhelp==2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,6 @@ snowballstemmer==2.2.0
 Sphinx==4.5.0
 sphinx-autobuild==2021.3.14
 sphinx-bootstrap-theme==0.8.1
-sphinx-rtd-theme==1.0.0
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-devhelp==1.0.2
 sphinxcontrib-htmlhelp==2.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -10,11 +10,11 @@ allowlist_externals =
 commands =
     make html
 
-[testenv:py{37,39}-linkcheck]
+[testenv:py{310,311}-linkcheck]
 commands =
     make html
     make linkcheck
 
-[testenv:py{37,39}-livehtml]
+[testenv:py{310,311}-livehtml]
 commands =
     make livehtml


### PR DESCRIPTION
Inc 

* `sphinx_rtd_theme` to latest version (1.1.1) plus latest compatible `sphinx` (5.3) and `docutils` (0.17) packages
* minimum Python version from 3.7 to 3.10 (as 3.7 not supported when move to Sphinx 6.x)
* Enable `sphinxcontrib-jquery` plugin as jQuery not bundled with Sphinx once upgrade to Sphinx 6.x

Supersedes:

* #1598
* #1597
* #1537

