### PR TITLE
Add git 2.39.1 to both clusters.

### DIFF
--- a/bessemer/software/development/git.rst
+++ b/bessemer/software/development/git.rst
@@ -1,0 +1,30 @@
+git
+===
+
+.. sidebar:: git
+
+   :Latest version: 2.39.1
+   :Dependancies: None
+   :URL: https://git-scm.com/
+
+Git is a free and open source distributed version control system designed to handle everything from small to very large projects with speed and efficiency.
+
+Usage
+-----
+Two version of git are available - an older version that is provided by the operating system and is available on both the login nodes and worker nodes: ::
+
+    $ git --version
+    git version 1.8.3.1
+
+And a newer version that can be activated by loading a module file and is only available on the worker nodes: ::
+
+   $ module load git/2.39.1-GCCcore-10.3.0-nodocs 
+   $ git --version
+   git version 2.39.1
+
+
+Installation notes
+------------------
+
+The git module has been installed using Easybuild 4.4.0 and a custom made git-2.39.1-GCCcore-10.3.0-nodocs.eb which can be found on system in the installation 
+directory: ``/usr/local/packages/live/eb/git/2.39.1-GCCcore-10.3.0-nodocs/easybuild``

--- a/bessemer/software/development/git.rst
+++ b/bessemer/software/development/git.rst
@@ -23,6 +23,9 @@ And a newer version that can be activated by loading a module file and is only a
    git version 2.39.1
 
 
+.. include:: /referenceinfo/imports/software/git/git-training-help-resources.rst
+
+
 Installation notes
 ------------------
 

--- a/referenceinfo/imports/software/git/git-training-help-resources.rst
+++ b/referenceinfo/imports/software/git/git-training-help-resources.rst
@@ -1,0 +1,6 @@
+Git training and help resources
+-------------------------------
+
+* The `software carpentry project <https://software-carpentry.org/>`_ offers numerous lessons including "`Version Control with Git <https://swcarpentry.github.io/git-novice/>`_".
+* The `University of Sheffield Research Software Engineers <https://rse.shef.ac.uk>`_ regularly run a 
+  "`git & GitHub through GitKraken - from Zero to Hero! <https://rse.shef.ac.uk/pages/training/courses/git_Hero.html>`_" course.

--- a/sharc/software/development/git.rst
+++ b/sharc/software/development/git.rst
@@ -3,7 +3,7 @@ git
 
 .. sidebar:: git
 
-   :Latest version: 2.35.2
+   :Latest version: 2.39.1
    :Dependancies: None
    :URL: https://git-scm.com/
 
@@ -20,13 +20,21 @@ And a newer version that can be activated by loading a module file and is only a
 
    $ module load dev/git/2.35.2/gcc-4.9.4 
    $ git --version
-   git version 2.35.2
+   git version 2.39.1
 
 Installation notes
 ------------------
 
+2.39.1
+^^^^^^
+
+* :download:`Install script </sharc/software/install_scripts/dev/git/2.39.1/gcc-4.9.4/install_git.sh>`
+* :download:`Module file </sharc/software/modulefiles/dev/git/2.39.1/gcc-4.9.4>`, located on the system at ``/usr/local/modulefiles/dev/git/2.39.1/gcc-4.9.4``
+
 2.35.2
 ^^^^^^
+
+Retired due to CVE-2022-41903 and CVE-2022-23521.
 
 * :download:`Install script </sharc/software/install_scripts/dev/git/2.35.2/gcc-4.9.4/install.sh>`
 * :download:`Module file </sharc/software/modulefiles/dev/git/2.35.2/gcc-4.9.4>`, located on the system at ``/usr/local/modulefiles/dev/git/2.35.2/gcc-4.9.4``

--- a/sharc/software/development/git.rst
+++ b/sharc/software/development/git.rst
@@ -22,6 +22,11 @@ And a newer version that can be activated by loading a module file and is only a
    $ git --version
    git version 2.39.1
 
+
+
+.. include:: /referenceinfo/imports/software/git/git-training-help-resources.rst
+
+
 Installation notes
 ------------------
 

--- a/sharc/software/development/git.rst
+++ b/sharc/software/development/git.rst
@@ -18,7 +18,7 @@ Two version of git are available - an older version that is provided by the oper
 
 And a newer version that can be activated by loading a module file and is only available on the worker nodes: ::
 
-   $ module load dev/git/2.35.2/gcc-4.9.4 
+   $ module load dev/git/2.39.1/gcc-4.9.4
    $ git --version
    git version 2.39.1
 

--- a/sharc/software/install_scripts/dev/git/2.39.1/gcc-4.9.4/install_git.sh
+++ b/sharc/software/install_scripts/dev/git/2.39.1/gcc-4.9.4/install_git.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+set -eu
+
+GIT_VERS="2.39.1"
+GIT_SRC_TARBALL="git-${GIT_VERS}.tar.xz"
+GIT_SRC_TARBALL_SHA256="40a38a0847b30c371b35873b3afcf123885dd41ea3ecbbf510efa97f3ce5c161"
+GIT_SRC_TARBALL_URL="https://mirrors.edge.kernel.org/pub/software/scm/git/${GIT_SRC_TARBALL}"
+GIT_MAN_TARBALL="git-manpages-${GIT_VERS}.tar.xz"
+GIT_MAN_TARBALL_SHA256="b522a58e963fd5137f660802ec5a93283abfa3eaa0f069ebb6e7f00e529cc775"
+GIT_MAN_TARBALL_URL="https://mirrors.edge.kernel.org/pub/software/scm/git/${GIT_MAN_TARBALL}"
+
+COMPILER="gcc"
+COMPILER_VERS="4.9.4"  # system compiler
+
+PREFIX="/usr/local/packages/dev/git/${GIT_VERS}/${COMPILER}-${COMPILER_VERS}"
+MODULEFILE="/usr/local/modulefiles/dev/git/${GIT_VERS}/${COMPILER}-${COMPILER_VERS}"
+
+# Signal handling for failure
+handle_error () {
+    errcode=$? # save the exit code as the first thing done in the trap function 
+    echo "Error: $errcode" 
+    echo "Command: $BASH_COMMAND" 
+    echo "Line: ${BASH_LINENO[0]}"
+    exit $errcode  # or use some other value or do return instead 
+}
+trap handle_error ERR
+
+# Download and unpack src tarball
+[[ -f $GIT_SRC_TARBALL ]] || wget -L $GIT_SRC_TARBALL_URL
+sha256sum ${GIT_SRC_TARBALL} | grep -q $GIT_SRC_TARBALL_SHA256
+if ! [[ -f .git_src_tarball_unpacked ]]; then
+    tar -Jxf ${GIT_SRC_TARBALL}
+    touch .git_src_tarball_unpacked
+fi
+
+# Create install and modulefile dirs
+for d in $PREFIX $(dirname $MODULEFILE); do
+    mkdir -m 2775 -p $d
+done
+
+# Ensure clean environment
+module purge
+
+# Build from src and install 
+pushd git-${GIT_VERS}
+./configure --prefix="$PREFIX"
+make
+make install
+popd
+
+# Download and unpack manpage tarball
+[[ -f $GIT_MAN_TARBALL ]] || wget -L $GIT_MAN_TARBALL_URL
+sha256sum ${GIT_MAN_TARBALL} | grep -q $GIT_MAN_TARBALL_SHA256
+mkdir -m 2775 -p ${PREFIX}/man
+if ! [[ -f .git_man_tarball_unpacked ]]; then
+    tar -Jxf ${GIT_MAN_TARBALL} -C ${PREFIX}/man
+    touch .git_man_tarball_unpacked
+fi
+
+# Set permissions and ownership
+for d in $PREFIX $(dirname $MODULEFILE); do
+    chmod -R g+w $d
+    chgrp -R hpc_app-admins $d
+done

--- a/sharc/software/modulefiles/dev/git/2.39.1/gcc-4.9.4
+++ b/sharc/software/modulefiles/dev/git/2.39.1/gcc-4.9.4
@@ -1,0 +1,20 @@
+#%Module1.0#####################################################################
+# Git 2.39.1 module file
+
+# Module file logging
+source /usr/local/etc/module_logging.tcl
+
+proc ModulesHelp {} {
+    local $vers
+    puts stderr "Makes git $vers available"
+}
+
+set vers 2.39.1
+set compiler gcc
+set compilervers 4.9.4
+set GIT_DIR /usr/local/packages/dev/git/$vers/$compiler-$compilervers/
+
+module-whatis   "Makes git $vers available"
+
+prepend-path PATH $GIT_DIR/bin
+prepend-path MANPATH $GIT_DIR/man


### PR DESCRIPTION
This is still a draft as installations are still in need of completion on Bessemer as well as the removal of the vulnerable versions.

Another PR for the changelog also required but not pending yet.