### PR TITLE
Unify Fluent spawn command.

### DIFF
--- a/stanagepilot/software/apps/ansys/fluent.rst
+++ b/stanagepilot/software/apps/ansys/fluent.rst
@@ -81,7 +81,10 @@ The script requests 4 cores using the OpenMP parallel environment with a runtime
     #SBATCH --mail-user=a.person@sheffield.ac.uk
     #SBATCH --mail-type=ALL
     module load ANSYS/2022R2
-    fluent 2ddp -t$SLURM_NTASKS -g -driver null -sifile=./"$SLURM_JOBID"_fluent_server_info.txt -i test.jou
+
+    srun hostname -s > hosts.$SLURM_JOB_ID
+
+    fluent 2ddp -t$SLURM_NTASKS -mpi=intel -ssh -cnf=hosts.$SLURM_JOB_ID -g -driver null  -pib.infinipath -sifile=./"$SLURM_JOBID"_fluent_server_info.txt -i test.jou
 
 
 The job is submitted to the queue by typing:

--- a/stanagepilot/software/apps/ansys/fluent.rst
+++ b/stanagepilot/software/apps/ansys/fluent.rst
@@ -59,13 +59,19 @@ Sample SMP Fluent Scheduler Job Script
 """""""""""""""""""""""""""""""""""""""""""
 
 The following is an example batch submission script, ``cfd_job.sh``, to run the executable ``fluent`` with input journal file ``test.jou``, and carry out a 2D double precision CFD simulation.
-The script requests 4 cores using the OpenMP parallel environment with a runtime of 60 mins and 8 GB of real memory per node.
+The script requests 4 cores with a runtime of 60 mins and 8 GB of real memory per node.
 
 .. hint::
 
     * The ``2ddp`` argument is used to specify a 2D double precision simulation. Valid values include: ``2d``, ``2ddp``, ``3d`` and ``3ddp``.
-    * The argument ``$SLURM_NTASKS`` is a SLURM scheduler variable which will return the requested number of tasks.
+    * The ``#SBATCH --nodes=1`` asks the scheduler for 1 node.
+    * The ``#SBATCH --ntasks-per-node=4`` asks the scheduler for 4 tasks per node.
+    * The ``#SBATCH --cpus-per-task=1`` asks the scheduler for 1 core in each task.
+    * The ``srun hostname -s > hosts.$SLURM_JOB_ID`` section sets up the hostlist which is required for correct MPI task spawning in conjunction with the ``-cnf=hosts.$SLURM_JOB_ID`` argument.
+    * The argument ``-mpi=intel`` instructs Fluent to use the Intel MPI communcation method. Consult Fluent documentation for OpenMPI instructions if applicable.
+    * The argument ``-ssh``  instructs Fluent to use SSH to implement the task spawning.
     * The arguments ``-g`` and ``-driver null`` instruct Fluent that it will be running with no GUI to avoid errors caused by plot / figure export.
+    * The argument ``-pib.infinipath`` instructs Fluent to use the high performance Omnipath networking. 
     * The argument ``-sifile=./"$SLURM_JOBID"_fluent_server_info.txt`` tells Fluent to create a file in the working directory with the remote visualization server info.
 
 
@@ -74,6 +80,7 @@ The script requests 4 cores using the OpenMP parallel environment with a runtime
     #!/bin/bash
     #SBATCH --nodes=1
     #SBATCH --ntasks-per-node=4
+    #SBATCH --cpus-per-task=1
     #SBATCH --mem=8000
     #SBATCH --job-name=name_fluent_smp_4
     #SBATCH --output=output_fluent_smp_4
@@ -85,6 +92,11 @@ The script requests 4 cores using the OpenMP parallel environment with a runtime
     srun hostname -s > hosts.$SLURM_JOB_ID
 
     fluent 2ddp -t$SLURM_NTASKS -mpi=intel -ssh -cnf=hosts.$SLURM_JOB_ID -g -driver null  -pib.infinipath -sifile=./"$SLURM_JOBID"_fluent_server_info.txt -i test.jou
+
+.. tip::
+
+    You may have noted that this SMP job uses the same arguments as the MPI jobs below. This is intended due to how Fluent spawns SMP jobs. The distinguishing factor in SMP jobs is 
+    the choice of a single node.
 
 
 The job is submitted to the queue by typing:


### PR DESCRIPTION
As the conventional fully specified (explicitly telling Fluent where to spawn tasks) MPI spawn command for Fluent has proved the most reliable and performant even for SMP this is amended as such.