### PR TITLE
Req-sphinxcontrib-applehelp-removed.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,6 @@ snowballstemmer==2.2.0
 Sphinx==5.3.0
 sphinx-autobuild==2021.3.14
 sphinx_rtd_theme==1.1.1
-sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-devhelp==1.0.2
 sphinxcontrib-htmlhelp==2.0.1
 sphinxcontrib-jsmath==1.0.1


### PR DESCRIPTION
Remove a dependency that is not required.

Also closes: https://github.com/rcgsheffield/sheffield_hpc/pull/1636