### PR TITLE
OpenFOAM on Stanage: no explicit PMIX selection needed now

### DIFF
--- a/stanagepilot/software/apps/openfoam.rst
+++ b/stanagepilot/software/apps/openfoam.rst
@@ -93,7 +93,7 @@ The following is an example batch job running the pitzDaily example model on 4 n
     blockMesh
     decomposePar
 
-    srun --mpi=pmix_v4 --export=ALL simpleFoam -parallel
+    srun --export=ALL simpleFoam -parallel
 
 ------------
 


### PR DESCRIPTION
As PMI(X) selection now handled behind the scenes by modulefiles thanks to @jkwmoore.
