### PR TITLE
SSH public key auth policy

### DIFF
--- a/hpc/connecting.rst
+++ b/hpc/connecting.rst
@@ -95,6 +95,15 @@ including *MobaXTerm*.
 | ShARC    | Password + MFA **or** public key      | Not permitted (unless using the :ref:`HPC SSH gateway service <hpcgw_summary>`)                   |
 +----------+---------------------------------------+---------------------------------------------------------------------------------------------------+
 
+.. note::
+   Policy on the use of SSH public key authentication:
+
+   * All access to TUOS HPC systems via SSH public/private keypairs should use private keys that were encrypted with a passphrase at creation time.
+   * Public key access should be from single-user machines (not shared machines) without good reason.
+   * SSH agent forwarding should not be used without good reason.
+   * Unencrypted private keys should not be stored on TUOS HPC systems.
+
+   To discuss exceptions to this policy please contact research-it@sheffield.ac.uk
 
 .. _mobaxterm_connecting_profile_setup:
 

--- a/hpc/connecting.rst
+++ b/hpc/connecting.rst
@@ -98,7 +98,7 @@ including *MobaXTerm*.
 .. note::
    Policy on the use of SSH public key authentication:
 
-   * All access to TUOS HPC systems via SSH public/private keypairs should use private keys that were encrypted with a passphrase at creation time.
+   * All access to TUOS HPC systems via SSH public/private keypairs should use private keys that were encrypted with a passphrase :underline-bold:`at creation time`.
    * Public key access should be from single-user machines (not shared machines) without good reason.
    * SSH agent forwarding should not be used without good reason.
    * Unencrypted private keys should not be stored on TUOS HPC systems.


### PR DESCRIPTION
We should have one to a) encourage good practices, b) to encourage users who want to do non-standard things with SSH pub key auth to get in touch and start a conversation, and c) to dissuade users with very limited understanding of SSH pub/priv key auth from using it (which is the reason the first draft of this policy is concise and technical).    