### PR TITLE
Stanage: switch to using wildcard toctrees for 4x main sw dirs

### DIFF
--- a/stanagepilot/software/apps/index.rst
+++ b/stanagepilot/software/apps/index.rst
@@ -9,13 +9,3 @@ Applications on Stanage
 
     ansys/index
     ./*
-
-..
-    Eventually the above should look like:
-
-    .. toctree::
-        :maxdepth: 1
-        :glob:
-
-        ansys/index
-        ./*

--- a/stanagepilot/software/development/index.rst
+++ b/stanagepilot/software/development/index.rst
@@ -7,17 +7,4 @@ Developing on Stanage
     :maxdepth: 1
     :glob:
     
-    cmake
-    doxygen
-    gcc
-    git
-    icc_ifort
-    toolchains
-..
-    Eventually the above should look like:
-
-    .. toctree::
-        :maxdepth: 1
-        :glob:
-        
-        ./*
+    ./*

--- a/stanagepilot/software/libs/index.rst
+++ b/stanagepilot/software/libs/index.rst
@@ -7,28 +7,4 @@ Libraries on Stanage
     :maxdepth: 1
     :glob:
     
-    blas
-    boost
-    cfitsio
-    fftw
-    gdal
-    geos
-    hdf5
-    imkl
-    libsndfile
-    libunistring
-    openblas
-    proj
-    scalapack
-    udunits
-
-    
-
-..
-    Eventually the above should look like:
-
-    .. toctree::
-        :maxdepth: 1
-        :glob:
-        
-        ./*
+    ./*

--- a/stanagepilot/software/parallel/index.rst
+++ b/stanagepilot/software/parallel/index.rst
@@ -7,15 +7,4 @@ Parallel Systems on Stanage
     :maxdepth: 1
     :glob:
 
-    impi
-    openmpi
-    
-
-..
-    Eventually the above should look like:
-
-    .. toctree::
-        :maxdepth: 1
-        :glob:
-        
-        ./*
+    ./*


### PR DESCRIPTION
Any reason why not?