### PR TITLE
Stanage MPI builds: document compile + runtime tweaks via EasyBuild hooks

### DIFF
--- a/stanagepilot/software/parallel/impi.rst
+++ b/stanagepilot/software/parallel/impi.rst
@@ -16,7 +16,7 @@ Versions
 --------
 
 You can load a specific version using one of the following: ::
-    
+
     module load impi/2019.7.217-iccifort-2020.1.217     # subset of the intel 2020a toolchain
     module load impi/2019.9.304-iccifort-2020.4.304     # subset of the intel 2020b toolchain
     module load impi/2021.2.0-intel-compilers-2021.2.0  # subset of the intel 2021a toolchain
@@ -31,14 +31,14 @@ which implicitly load versions of icc, ifort (and GCC).
 Examples
 --------
 
-Two examples are given below, the first assessing the MPI performance and the second demonstrating the use 
+Two examples are given below, the first assessing the MPI performance and the second demonstrating the use
 of the Intel MPI compilers.
 
 Example: MPI Performance testing
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-A simple test of these modules can be performed by running the built in performance benchmark tests 
-supplied by Intel. An example of this using 2 cores on one node is given below: 
+A simple test of these modules can be performed by running the built in performance benchmark tests
+supplied by Intel. An example of this using 2 cores on one node is given below:
 
 .. code-block:: bash
 
@@ -93,7 +93,7 @@ This is followed by a series of test benchmark results for each of the many test
 Example: Using the Intel MPI compilers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Another simple test of these modules can be performed by compiling and running the example executable 
+Another simple test of these modules can be performed by compiling and running the example executable
 provided by Intel. An example of this using 2 cores is given below:
 
 .. code-block:: bash
@@ -106,7 +106,7 @@ provided by Intel. An example of this using 2 cores is given below:
 
     # Show which nodes you have been allocated CPU cores on
     echo -e "\nShow node core allocation:\n"
-    
+
     echo "SLURM_JOB_NODELIST=${SLURM_JOB_NODELIST}"
     echo "SLURM_NNODES=${SLURM_NNODES}"
     echo "SLURM_NTASKS_PER_NODE=${SLURM_NTASKS_PER_NODE-1}"
@@ -137,3 +137,20 @@ This will generate output of the form:
 
     Hello world: rank 0 of 2 running on node051.pri.stanage.alces.network
     Hello world: rank 1 of 2 running on node051.pri.stanage.alces.network
+
+Installation notes
+------------------
+
+This section is primarily for administrators of the system. Intel MPI has been installed using the default Easybuild config files but with the following tweaks made via EasyBuild hooks:
+
+* Module files are patched so that
+
+   * they instruct Slurm at runtime
+     (via ``SLURM_MPI_TYPE=pmi2``) that
+     the PMI2 API is to be used for launching remote processes using ``srun``,
+     as Intel MPI currently works better with PMI2 than the newer PMIx APIs.
+   * for versions greater than 19.0.0
+     ``I_MPI_PMI_LIBRARY`` is set to the absolute path to ``libpmi2.so`` (required by ``srun``)
+
+* ``mpirun`` is patched so that ``I_MPI_PMI_LIBRARY`` is explicitly *unset* at execution time,
+  as ``I_MPI_PMI_LIBRARY`` can only be used with ``srun``.

--- a/stanagepilot/software/parallel/impi.rst
+++ b/stanagepilot/software/parallel/impi.rst
@@ -144,13 +144,7 @@ Installation notes
 This section is primarily for administrators of the system. Intel MPI has been installed using the default Easybuild config files but with the following tweaks made via EasyBuild hooks:
 
 * Module files are patched so that
-
-   * they instruct Slurm at runtime
-     (via ``SLURM_MPI_TYPE=pmi2``) that
-     the PMI2 API is to be used for launching remote processes using ``srun``,
-     as Intel MPI currently works better with PMI2 than the newer PMIx APIs.
-   * for versions greater than 19.0.0
-     ``I_MPI_PMI_LIBRARY`` is set to the absolute path to ``libpmi2.so`` (required by ``srun``)
-
-* ``mpirun`` is patched so that ``I_MPI_PMI_LIBRARY`` is explicitly *unset* at execution time,
-  as ``I_MPI_PMI_LIBRARY`` can only be used with ``srun``.
+    * they instruct Slurm at runtime (via ``SLURM_MPI_TYPE=pmi2``) that the PMI2 API is to be used for launching remote processes using ``srun``,
+      as Intel MPI currently works better with PMI2 than the newer PMIx APIs.
+    * for versions greater than 19.0.0 ``I_MPI_PMI_LIBRARY`` is set to the absolute path to ``libpmi2.so`` (required by ``srun``)
+* The ``mpirun`` executable is patched so that ``I_MPI_PMI_LIBRARY`` is explicitly *unset* at execution time, as ``I_MPI_PMI_LIBRARY`` can only be used with ``srun``.

--- a/stanagepilot/software/parallel/impi.rst
+++ b/stanagepilot/software/parallel/impi.rst
@@ -146,5 +146,5 @@ This section is primarily for administrators of the system. Intel MPI has been i
 * Module files are patched so that
     * they instruct Slurm at runtime (via ``SLURM_MPI_TYPE=pmi2``) that the PMI2 API is to be used for launching remote processes using ``srun``,
       as Intel MPI currently works better with PMI2 than the newer PMIx APIs.
-    * for versions greater than 19.0.0 ``I_MPI_PMI_LIBRARY`` is set to the absolute path to ``libpmi2.so`` (required by ``srun``)
+    * for versions greater than 19.0.0 ``I_MPI_PMI_LIBRARY`` is set to the absolute path to ``libpmi2.so`` (required by ``srun``).
 * The ``mpirun`` executable is patched so that ``I_MPI_PMI_LIBRARY`` is explicitly *unset* at execution time, as ``I_MPI_PMI_LIBRARY`` can only be used with ``srun``.

--- a/stanagepilot/software/parallel/openmpi.rst
+++ b/stanagepilot/software/parallel/openmpi.rst
@@ -139,7 +139,36 @@ Your output would be something like: ::
 Installation notes
 ------------------
 
-This section is primarily for administrators of the system. OpenMPI has been installed using the default Easybuild config files.
+This section is primarily for administrators of the system. OpenMPI has been installed using the default Easybuild config files but with the following tweaks made via EasyBuild hooks:
+
+* Compile-time options set so that:
+
+   * All versions compiled with Slurm and PMIx support enabled.
+   * Versions older than 4.1.0 are compiled with support for the PSM2 library for 
+     efficient inter-process communication inc via Omni-Path 
+     (but OpenMPI only actually uses PSM2 at runtime for versions <= 4.0.0).
+
+* Module files are patched so that at runtime:
+
+   * When OpenMPI is loaded, 
+     it instructs Slurm at runtime 
+     (via an environment variable - ``SLURM_MPI_TYPE=pmix_v4``) that 
+     PMIx version 4 is to be used for launching remote processes using ``srun``.
+   * Versions greater than 4.0.0 are configured at runtime to use 
+     LibFabric (OFI) for inter-process communications, which in turn is 
+     configured at runtime via environment variables to use the PSM2 OFI provider 
+     for efficient OmniPath support.  
+     
+     OFI is used instead of PSM2 as 
+     the older PSM2 library on CentOS 7 is incompatible with newer versions of OpenMPI, 
+     plus OFI is now the preferred way of doing comms over Omni-Path fabrics with MPI implementations.
+
+     Key variables set in OpenMPI module files:
+
+      * ``OMPI_MCA_pml=cm``
+      * ``OMPI_MCA_mtl=ofi``
+      * ``OMPI_MCA_mtl_ofi_provider_include=psm2``
+      * ``PMIX_MCA_psec=native``
 
 Build logs and test reports can be found in $EBROOTOPENMPI/easybuild with a given module loaded.
 

--- a/stanagepilot/software/parallel/openmpi.rst
+++ b/stanagepilot/software/parallel/openmpi.rst
@@ -142,14 +142,12 @@ Installation notes
 This section is primarily for administrators of the system. OpenMPI has been installed using the default Easybuild config files but with the following tweaks made via EasyBuild hooks:
 
 * Compile-time options set so that:
-
    * All versions compiled with Slurm and PMIx support enabled.
    * Versions older than 4.1.0 are compiled with support for the PSM2 library for 
      efficient inter-process communication inc via Omni-Path 
      (but OpenMPI only actually uses PSM2 at runtime for versions <= 4.0.0).
 
 * Module files are patched so that at runtime:
-
    * When OpenMPI is loaded, 
      it instructs Slurm at runtime 
      (via an environment variable - ``SLURM_MPI_TYPE=pmix_v4``) that 
@@ -164,13 +162,12 @@ This section is primarily for administrators of the system. OpenMPI has been ins
      plus OFI is now the preferred way of doing comms over Omni-Path fabrics with MPI implementations.
 
      Key variables set in OpenMPI module files:
-
       * ``OMPI_MCA_pml=cm``
       * ``OMPI_MCA_mtl=ofi``
       * ``OMPI_MCA_mtl_ofi_provider_include=psm2``
       * ``PMIX_MCA_psec=native``
 
-Build logs and test reports can be found in $EBROOTOPENMPI/easybuild with a given module loaded.
+Build logs and test reports can be found in ``$EBROOTOPENMPI/easybuild`` with a given module loaded.
 
 
 


### PR DESCRIPTION
I like the idea of this info being public.  Can make it public via other means if/when we publish our EB `hooks.py` file (inc explanatory comments).