### PR TITLE
Stanage: first builds of GCC and CMake for znver3

### DIFF
--- a/stanagepilot/software/development/cmake.rst
+++ b/stanagepilot/software/development/cmake.rst
@@ -8,15 +8,27 @@ CMake is a build tool commonly used when compiling other libraries.
 Usage
 -----
 
-CMake can be loaded with one of: ::
+CMake can be loaded with one of:
 
-   module load CMake/3.16.4-GCCcore-9.3.0  # compatible with foss-2021a toolchain   
-   module load CMake/3.18.4-GCCcore-10.2.0 # compatible with foss-2021a toolchain
-   module load CMake/3.20.1-GCCcore-10.3.0 # compatible with foss-2021b toolchain
-   module load CMake/3.21.1-GCCcore-11.2.0 # compatible with foss-2022a toolchain
-   module load CMake/3.22.1-GCCcore-11.2.0 # compatible with foss-2022a toolchain
-   module load CMake/3.23.1-GCCcore-11.3.0 # compatible with foss-2022b toolchain
-   module load CMake/3.24.3-GCCcore-12.2.0 # compatible with foss-2022b toolchain
+.. tabs::
+
+   .. group-tab:: icelake
+
+        .. code-block:: console
+
+           module load CMake/3.16.4-GCCcore-9.3.0   # compatible with foss-2021a toolchain   
+           module load CMake/3.18.4-GCCcore-10.2.0  # compatible with foss-2021a toolchain
+           module load CMake/3.20.1-GCCcore-10.3.0  # compatible with foss-2021b toolchain
+           module load CMake/3.21.1-GCCcore-11.2.0  # compatible with foss-2022a toolchain
+           module load CMake/3.22.1-GCCcore-11.2.0  # compatible with foss-2022a toolchain
+           module load CMake/3.23.1-GCCcore-11.3.0  # compatible with foss-2022b toolchain
+           module load CMake/3.24.3-GCCcore-12.2.0  # compatible with foss-2022b toolchain
+
+   .. group-tab:: znver3
+
+        .. code-block:: console
+
+           module load CMake/3.24.3-GCCcore-11.3.0
   
 CMake has a run-time dependency on ``libstdc++`` so
 the cmake module files depend on and load particular versions of the :ref:`GCC compiler <gcc_stanage>`,

--- a/stanagepilot/software/development/gcc.rst
+++ b/stanagepilot/software/development/gcc.rst
@@ -7,25 +7,37 @@ The GNU Compiler Collection (gcc) is a widely used, free collection of compilers
 for C (gcc), C++ (g++) and Fortran (gfortran).
 
 It is possible to switch versions of the gcc compiler suite using modules.
-After connecting to Stanage,  start an interactive session: :: 
+After connecting to Stanage, start an interactive session: :: 
 
    srun --pty bash -i
 
 then choose the version of the compiler you wish to use
-by running *one* of the following lines: ::
+by running *one* of the following lines:
 
-   module load GCC/8.2.0-2.31.1  #part of the foss-2019a toolchain
-   module load GCC/8.3.0         #part of the foss-2019b toolchain
-   module load GCC/9.2.0         
-   module load GCC/9.3.0         #part of the foss-2020a toolchain
-   module load GCC/9.5.0         
-   module load GCC/10.1.0        
-   module load GCC/10.2.0        #part of the foss-2020b toolchain
-   module load GCC/10.3.0        #part of the foss-2021a toolchain
-   module load GCC/11.1.0        
-   module load GCC/11.2.0        #part of the foss-2021b toolchain
-   module load GCC/11.3.0        #part of the foss-2022a toolchain
-   module load GCC/12.2.0        #part of the foss-2022b toolchain
+.. tabs::
+
+   .. group-tab:: icelake
+
+        .. code-block:: console
+
+           module load GCC/8.2.0-2.31.1  # part of the foss-2019a toolchain
+           module load GCC/8.3.0         # part of the foss-2019b toolchain
+           module load GCC/9.2.0         
+           module load GCC/9.3.0         # part of the foss-2020a toolchain
+           module load GCC/9.5.0         
+           module load GCC/10.1.0        
+           module load GCC/10.2.0        # part of the foss-2020b toolchain
+           module load GCC/10.3.0        # part of the foss-2021a toolchain
+           module load GCC/11.1.0        
+           module load GCC/11.2.0        # part of the foss-2021b toolchain
+           module load GCC/11.3.0        # part of the foss-2022a toolchain
+           module load GCC/12.2.0        # part of the foss-2022b toolchain
+
+   .. group-tab:: znver3
+
+        .. code-block:: console
+
+           module load GCCcore/11.3.0 
 
 Confirm that you've loaded the version of gcc you wanted using ``gcc -v``.
 
@@ -39,7 +51,7 @@ Documentation
 -------------
 
 man pages are available on the system.
-Once you have loaded the required version of `gcc`, type ::
+Once you have loaded the required version of ``gcc``, type ::
 
     man gcc
 


### PR DESCRIPTION
Differentiated from icelake-optimised builds by using Sphinx tabs. 