### PR TITLE
Remove OpenMPI-4.1.1 and related toolchains

### DIFF
--- a/stanagepilot/software/libs/fftw.rst
+++ b/stanagepilot/software/libs/fftw.rst
@@ -23,14 +23,11 @@ To make this library available, run one the following: ::
       module load FFTW/3.3.8-gompi-2019b
       module load FFTW/3.3.8-gompi-2020a
       module load FFTW/3.3.8-gompi-2020b
-      module load FFTW/3.3.9-gompi-2021a
       module load FFTW/3.3.10-GCC-11.3.0
       module load FFTW/3.3.10-GCC-12.2.0
-      module load FFTW/3.3.10-gompi-2021b
       module load FFTW.MPI/3.3.10-gompi-2022a
       module load FFTW.MPI/3.3.10-gompi-2022b
 
-.. include:: /referenceinfo/imports/stanage/openmpi_4.1.1_import.rst
 
 - `gompi` versions are a subset of the :ref:`foss toolchain <stanage_eb_toolchains>`
   and also load GCC and OpenMPI

--- a/stanagepilot/software/libs/gdal.rst
+++ b/stanagepilot/software/libs/gdal.rst
@@ -18,18 +18,15 @@ Source license by the `Open Source Geospatial Foundation <http://www.osgeo.org/>
 Usage
 -----
 
-Load by running one of the following ::
+Load by running ::
 
     module load GDAL/3.2.1-foss-2020b
-    module load GDAL/3.3.2-foss-2021b
-
+    
 This will:
 
 * add several GDAL programs to your ``PATH`` environment variable
 * allow other programs to make use of (dynamically link against) the GDAL library
 * activate the modules associated with the specific :ref:`foss toolchain <stanage_eb_toolchains>`
-
-.. include:: /referenceinfo/imports/stanage/openmpi_4.1.1_import.rst
 
 You can run ``gdal-config --version`` to test that you are running the required version ::
 

--- a/stanagepilot/software/libs/scalapack.rst
+++ b/stanagepilot/software/libs/scalapack.rst
@@ -32,14 +32,9 @@ ScaLAPACK can be activated using one of: ::
    module load ScaLAPACK/2.0.2-gompi-2019b
    module load ScaLAPACK/2.1.0-gompi-2020a
    module load ScaLAPACK/2.1.0-gompi-2020b
-   module load ScaLAPACK/2.1.0-gompi-2021a-fb
-   module load ScaLAPACK/2.1.0-gompi-2021b-fb
    module load ScaLAPACK/2.2.0-gompi-2022a-fb
    module load ScaLAPACK/2.2.0-gompi-2022b-fb
 
    
 Note that all load OpenBLAS, despite the change in the module naming convention for more recent toolchains.
-
-
-.. include:: /referenceinfo/imports/stanage/openmpi_4.1.1_import.rst
 

--- a/stanagepilot/software/parallel/openmpi.rst
+++ b/stanagepilot/software/parallel/openmpi.rst
@@ -20,8 +20,6 @@ You can load a specific version using one of the following: ::
     module load OpenMPI/4.0.3-GCC-9.3.0   # part of the foss-2020a toolchain
     module load OpenMPI/4.0.5-GCC-9.3.0   # part of the foss-2020a toolchain
     module load OpenMPI/4.0.5-GCC-10.2.0  # part of the foss-2020b toolchain
-    module load OpenMPI/4.1.1-GCC-10.3.0  # part of the foss-2021a toolchain
-    module load OpenMPI/4.1.1-GCC-11.2.0  # part of the foss-2021b toolchain
     module load OpenMPI/4.1.4-GCC-11.3.0  # part of the foss-2022a toolchain
     module load OpenMPI/4.1.4-GCC-12.2.0  # part of the foss-2022b toolchain
 


### PR DESCRIPTION
Removes module loads for OpenMPI 4.1.1, related toolchains and warnings

clusterusers read permissions have been removed for those modules/packages