### PR TITLE
Stange: Add CUDA 10.x gencode instructions (embed compute_70 PTX)

### DIFF
--- a/stanagepilot/software/libs/cuda.rst
+++ b/stanagepilot/software/libs/cuda.rst
@@ -74,14 +74,6 @@ An example of the use of ``nvcc`` (the CUDA compiler): ::
 
 This will compile the CUDA program contained in the file ``filename.cu``.  
 
-.. TODO: incorporate the following if install CUDA < 11 at some point.
-
-   "'nvcc filename.cu' is correct, but will only work with CUDA >= 11.0 which introdcued SM 80.
-
-   CUDA 11.0 Release Notes: https://docs.nvidia.com/cuda/archive/11.0_GA/cuda-toolkit-release-notes/index.html#cuda-general-new-features
-
-   So may need to add a condition around that (if CUDA 10.x is avialable as suggested in Compiling the sample programs), where embedding PTX for 70 via -gencode=arch=compute_70,code=compute_70 would be the closest fit (but ideally everyone should use CUDA 11.0+ on these nodes).
-
 ---------
 
 Compiling the sample programs
@@ -149,13 +141,27 @@ i.e. ``-gencode=arch=compute_80,code=compute_80``.
 The minimum specified virtual architecture must be less than or equal to the `Compute Capability <https://developer.nvidia.com/cuda-gpus>`_ of the GPU used to execute the code.
 
 At present, all GPUs in Stanage are NVIDIA Tesla A100 GPUs, which are Compute Capability 80.
+
+CUDA 10.x is not aware of Compute Capability 80, so PTX for an older architecture (Compute Capability 70) should be embedded instead.
+
 To build a CUDA application which targets just A100 GPUs, use the following ``-gencode`` arguments:
 
-.. code-block:: sh
+.. tabs::
 
-   nvcc filename.cu \
-      -gencode=arch=compute_80,code=sm_80 \
-      -gencode=arch=compute_80,code=compute_80
+   .. group-tab:: CUDA 11.0+
+
+        .. code-block:: sh
+
+           nvcc filename.cu \
+              -gencode=arch=compute_80,code=sm_80 \
+              -gencode=arch=compute_80,code=compute_80
+
+   .. group-tab:: CUDA 10.x
+
+        .. code-block:: sh
+
+           nvcc filename.cu \
+              -gencode=arch=compute_70,code=compute_70
 
 Further details of these compiler flags can be found in the `NVCC Documentation <https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#options-for-steering-gpu-code-generation>`_,
 along with details of the supported `virtual architectures <https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#virtual-architecture-feature-list>`_ and `real architectures <https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#gpu-feature-list>`_.


### PR DESCRIPTION
CUDA 10.x is not aware of Ampere (Compute capability 80) GPUs, so the gencode documentation needs ammending to cover this use case.

Embedding PTX for Compute Capability 70 (Volta/GV100) should be the closest performance (It should be closer than 75/Turing due to FP64 characteristics). 
There will be some additional time on first run as the PTX is JIT'd to CC 80, but this is unavoidable if using CUDA 10.x on stange)

Default compilation (no gencodes) is fine with both, as it uses the oldest non-deprecated gencode and embeds ptx (i.e. It will run, but will not do SM 80 specific optimisations either way). 
For CUDA 10.x this will be SM 35 (2nd gen kepler, K40) IIRC, while 11.x will be SM 52 (2nd gen consumer maxwell, geforce 9xx).

For (mostly my) future reference I've put together a MWE which can be used to to test the behaviour: https://github.com/ptheywood/cuda-gencodes-demo

![image](https://user-images.githubusercontent.com/628937/231749577-55192b9c-182d-40a0-b131-0c773a73feb3.png)

![image](https://user-images.githubusercontent.com/628937/231749692-5dd59426-2b27-47c8-a11a-7a4f7b132387.png)
