### PR TITLE
Stanage RAM corrections.

### DIFF
--- a/hpc/Choosing-appropriate-resources.rst
+++ b/hpc/Choosing-appropriate-resources.rst
@@ -39,7 +39,7 @@ We have three cluster choices listed below for you to choose from:
 
 * Stanage (Our newest and most powerful yet, launched in March 2023).
 * Bessemer (Launched in 2018).
-* ShARC (Launched in 2017).
+* ShARC (Launched in 2016).
 
 It is also important to note that the Sheffield HPC clusters have been designed to fulfil different purposes. Stanage and ShARC are for the most part *`capability`* clusters designed to 
 run larger compute jobs that will use multiple nodes. Bessemer is a *`capacity`* cluster designed to run smaller compute jobs which will fit on a single node. 

--- a/hpc/Choosing-appropriate-resources.rst
+++ b/hpc/Choosing-appropriate-resources.rst
@@ -13,15 +13,16 @@ Choosing appropriate resources for your jobs is essential to ensuring your jobs 
 The key resources you need to optimise for are:
 
 
-* :ref:`Cluster-choice <Cluster-choice>`
-* :ref:`Time-allocation <Time-allocation>`
-* :ref:`Cores-allocation <Cores-allocation>`
-* :ref:`Memory-allocation <Memory-allocation>`
-* :ref:`Filestore-limits <Filestore-limits>`
+* :ref:`Cluster-choice. <Cluster-choice>`
+* :ref:`Time-allocation. <Time-allocation>`
+* :ref:`Cores-allocation. <Cores-allocation>`
+* :ref:`Memory-allocation. <Memory-allocation>`
+* :ref:`Filestore-limits. <Filestore-limits>`
 
 
 
-It is important to be aware that the resource requests that you make are not flexible: if your job exceeds what you have requested for it the scheduler will terminate your job abruptly and without any warning. This means that it is safest to over estimate your job's requirements if they cannot be accurately and precisely known in advance.
+It is important to be aware that the resource requests that you make are not flexible: if your job exceeds what you have requested for it the scheduler will terminate your job 
+abruptly and without any warning. This means that it is safest to over estimate your job's requirements if they cannot be accurately and precisely known in advance.
 
 This does not mean that you can set extremely large values for these resource requests for several reasons, the most important being:
 
@@ -36,14 +37,17 @@ Cluster choice
 
 We have three cluster choices listed below for you to choose from:
 
-* Stanage (Our newest and most powerful yet, launched in March 2023)
-* Bessemer (Launched in 2018)
-* ShARC (Launched in 2017)
+* Stanage (Our newest and most powerful yet, launched in March 2023).
+* Bessemer (Launched in 2018).
+* ShARC (Launched in 2017).
 
-It is also important to note that the Sheffield HPC clusters have been designed to fulfil different purposes. Stanage and ShARC are for the most part *capability* clusters designed to run larger compute jobs that will use multiple nodes. Bessemer is a *capacity* cluster designed to run smaller compute jobs which will fit on a single node. In addition, Stanage and Bessemer have newer CPUs with more modern features. Bessemer and Stanage do not have a `/data` filestore.
-
+It is also important to note that the Sheffield HPC clusters have been designed to fulfil different purposes. Stanage and ShARC are for the most part *`capability`* clusters designed to 
+run larger compute jobs that will use multiple nodes. Bessemer is a *`capacity`* cluster designed to run smaller compute jobs which will fit on a single node. 
 
 You should prioritize putting smaller core count jobs onto Bessemer and massively parallel jobs onto Stanage or ShARC (while utilizing a form of :ref:`MPI <parallel_MPI>`).
+
+In addition, Stanage and Bessemer have newer CPUs with more modern features. All of the clusters share similar file storage areas, each which are tuned for certain workloads
+although the Bessemer and Stanage clusters do not have a `/data` filestore.
 
 The specifications for each cluster are detailed for Stanage here :ref:`stanage-specs` , Bessemer here :ref:`bessemer-specs` and ShARC here :ref:`sharc-specs` .
 
@@ -54,34 +58,57 @@ The specifications for each cluster are detailed for Stanage here :ref:`stanage-
 .. include:: ../referenceinfo/scheduler/TimeAllocationLimits.rst
 
 
-The time allocation limits will differ between job types and by cluster - a summary of these differences can be seen above. Time requirements are highly dependent on how many CPU cores your job is using - using more cores may significantly decrease the amount of time the job spends running, depending on how optimally the software you are using supports parallelisation. Further details on CPU cores selection can be found in the `CPU cores allocation <#cpu-allocation-limits>`_ section.
+The time allocation limits will differ between job types and by cluster - a summary of these differences can be seen above. Time requirements are highly dependent on 
+how many CPU cores your job is using - using more cores may significantly decrease the amount of time the job spends running, depending on how optimally the software 
+you are using supports parallelisation. Further details on CPU cores selection can be found in the `CPU cores allocation <#cpu-allocation-limits>`_ section.
 
 
 Determining time requirements using timing commands in your script
 --------------------------------------------------------------------
 
-A way of deducing the "wall clock" time used by a job is to use the date or the timeused command within the script file. The date command is part of the Linux operating system whereas the timeused command is specific to our clusters and provides the usage figures directly rather than having to manually calculate it from two subsequent date commands. Here are some examples -
+A way of deducing the "wall clock" time used by a job is to use the ``date`` command within the batch script file. The ``date`` command is part of the Linux operating 
+system. Here is an example:
 
 
-Using the **date** command: ::
+.. tabs::
+
+   .. group-tab:: Stanage
+
+    .. code-block:: shell
+
+        #SBATCH --time=00:10:00
+        date
+        my_program < my_input
+        date        
+
+    When the above script is submitted (via ``sbatch``), the job output file will contain the date and time at each invocation of the date command. You can then calculate the 
+    difference between these date/times to determine the actual time taken.
+
+   .. group-tab:: Bessemer
+
+    .. code-block:: shell
+
+        #SBATCH --time=00:10:00
+        date
+        my_program < my_input
+        date
+
+    When the above script is submitted (via ``sbatch``), the job output file will contain the date and time at each invocation of the date command. You can then calculate the 
+    difference between these date/times to determine the actual time taken.
+
+   .. group-tab:: ShARC
+
+    .. code-block:: shell
 
         #$ -l h_rt=10:00:00
         date
         my_program < my_input
         date
 
-When the above script is submitted (via qsub), the job output file will contain the date and time at each invocation of the date command. You can then calculate the difference between these date/times to determine the actual time taken.
+    When the above script is submitted (via qsub), the job output file will contain the date and time at each invocation of the date command. You can then calculate the 
+    difference between these date/times to determine the actual time taken.
 
 
-Using the **timeused** command: ::
-
-       #$ -l h_rt=10:00:00
-       export TIMECOUNTER=0
-       source timeused
-       my_program < my_input
-       source timeused
-
-When the above script is submitted the first invocation of the timeused command will initialise the timer counter due to the fact that TIMECOUNTER variable is set to 0. The subsequent invocations will report the time in hours,minutes and seconds since the first invocation.
 
 
 -----------------

--- a/referenceinfo/imports/scheduler/memory_allocation_limits_table_import.rst
+++ b/referenceinfo/imports/scheduler/memory_allocation_limits_table_import.rst
@@ -12,11 +12,11 @@
      - Submission Argument
 
    * - SLURM (Stanage)
-     - 256 GB
+     - 251 GB
      - 1TB 
      - 2TB
-     - 2 GB / 256 GB
-     - 2 GB / 256 GB
+     - 2 GB / 251 GB
+     - 2 GB / 251 GB (SMP) ~74404 GB (MPI)
      - **Per job basis** ``--mem=<nn>``
 
    * - SLURM (Bessemer)
@@ -34,3 +34,12 @@
      - 2 GB / 64 GB
      - 2 GB / 64 GB (SMP) ~6144 GB (MPI)
      - **Per core basis** ``-l rmem=<nn>``
+
+..
+   The interactive job max RAM and batch job SMP values are both derived from a normal compute node's total RAM.
+
+   The total MPI memory available above is derived from the total CPU nodes multiplied by the standard node RAM + Large RAM nodes * Large RAM amount and so on. 
+   GPU nodes excluded as these should not be contigously available.
+
+   Values for Stanage are not their total available RAM on the node as a result of Alces configuration for SLURM differing / the node requiring reserved memory
+   for the operating system.

--- a/referenceinfo/imports/scheduler/memory_allocation_limits_table_import.rst
+++ b/referenceinfo/imports/scheduler/memory_allocation_limits_table_import.rst
@@ -13,8 +13,8 @@
 
    * - SLURM (Stanage)
      - 251 GB
-     - 1TB 
-     - 2TB
+     - 1007 GB 
+     - 2014 GB
      - 2 GB / 251 GB
      - 2 GB / 251 GB (SMP) ~74404 GB (MPI)
      - **Per job basis** ``--mem=<nn>``

--- a/referenceinfo/imports/scheduler/memory_allocation_limits_table_import.rst
+++ b/referenceinfo/imports/scheduler/memory_allocation_limits_table_import.rst
@@ -41,5 +41,5 @@
    The total MPI memory available above is derived from the total CPU nodes multiplied by the standard node RAM + Large RAM nodes * Large RAM amount and so on. 
    GPU nodes excluded as these should not be contiguously available.
 
-   Values for Stanage are not their total available RAM on the node as a result of Alces configuration for SLURM differing / the node requiring reserved memory
+   Note that on Stanage the amount of memory available for Slurm jobs is not a neat multiple of two; this is because Slurm has been configured to not make less memory than the total amount of RAM per node available to jobs so as to ring-fence some memory for use by the operating system.
    for the operating system.

--- a/referenceinfo/imports/scheduler/memory_allocation_limits_table_import.rst
+++ b/referenceinfo/imports/scheduler/memory_allocation_limits_table_import.rst
@@ -39,7 +39,7 @@
    The interactive job max RAM and batch job SMP values are both derived from a normal compute node's total RAM.
 
    The total MPI memory available above is derived from the total CPU nodes multiplied by the standard node RAM + Large RAM nodes * Large RAM amount and so on. 
-   GPU nodes excluded as these should not be contigously available.
+   GPU nodes excluded as these should not be contiguously available.
 
    Values for Stanage are not their total available RAM on the node as a result of Alces configuration for SLURM differing / the node requiring reserved memory
    for the operating system.

--- a/referenceinfo/scheduler/SGE/sge_parallel_environments.rst
+++ b/referenceinfo/scheduler/SGE/sge_parallel_environments.rst
@@ -1,10 +1,10 @@
 
-ShARC Parallel Environments
----------------------------
+ShARC/SGE Parallel Environments
+-------------------------------
 
-The available :ref:`parallel environments <parallel>` for ShARC only (Stanage and Bessemer only have the SMP environment which is set by default) can be found below:
+The available :ref:`SGE parallel environments <parallel>` (for ShARC only) can be found below:
 
-.. list-table:: ShARC Parallel Environments Table
+.. list-table:: ShARC SGE Parallel Environments Table
    :widths: 20 80
    :header-rows: 1
 


### PR DESCRIPTION
Primarily to correct the slightly lower RAM amounts on Stanage but some other minor corrections.

Timeused not being available on the clusters has been removed from the docs.