### PR TITLE
Remove most references to old gpucomputing site and point at new home for CUDA training material

### DIFF
--- a/bessemer/GPUComputingBessemer.rst
+++ b/bessemer/GPUComputingBessemer.rst
@@ -150,5 +150,5 @@ Specifications per A100 node:
 Training materials
 ------------------
 
-* `Introduction to CUDA by the Research Software Engineering (RSE) team <https://rse.shef.ac.uk/training/com4521>`_
-
+* The Research Software Engineering team have developed an undergraduate teaching module on CUDA;
+`lecture notes and lecture recordings for that module are accessible here <https://rse.shef.ac.uk/training/com4521>`_ for anyone with a University account.

--- a/bessemer/GPUComputingBessemer.rst
+++ b/bessemer/GPUComputingBessemer.rst
@@ -150,5 +150,5 @@ Specifications per A100 node:
 Training materials
 ------------------
 
-* `Introduction to CUDA by GPUComputing@Sheffield <https://gpucomputing.shef.ac.uk/education/cuda/>`_
+* `Introduction to CUDA by the Research Software Engineering (RSE) team <https://rse.shef.ac.uk/training/com4521>`_
 

--- a/bessemer/GPUComputingBessemer.rst
+++ b/bessemer/GPUComputingBessemer.rst
@@ -151,4 +151,4 @@ Training materials
 ------------------
 
 * The Research Software Engineering team have developed an undergraduate teaching module on CUDA;
-`lecture notes and lecture recordings for that module are accessible here <https://rse.shef.ac.uk/training/com4521>`_ for anyone with a University account.
+  `lecture notes and lecture recordings for that module are accessible here <https://rse.shef.ac.uk/training/com4521>`_ for anyone with a University account.

--- a/bessemer/software/apps/pytorch.rst
+++ b/bessemer/software/apps/pytorch.rst
@@ -22,11 +22,6 @@ The use of Anaconda (:ref:`python_conda_bessemer`) is recommended as
 it is able to create a virtual environment in your home directory,
 allowing for the installation of new Python packages without needing admin permission.
 
-This software and documentation is maintained by the `RSES group <https://rse.shef.ac.uk/>`_
-and `GPUComputing@Sheffield <http://gpucomputing.shef.ac.uk/>`_.
-For feature requests or if you encounter any problems,
-please raise an issue on the `GPU Computing repository <https://github.com/RSE-Sheffield/GPUComputing/issues>`_.
-
 Installation in Home Directory
 ------------------------------
 

--- a/bessemer/software/apps/tensorflow.rst
+++ b/bessemer/software/apps/tensorflow.rst
@@ -31,11 +31,6 @@ The use of Anaconda (:ref:`python_conda_bessemer`) is recommended as
 it is able to create a virtual environment in your home directory,
 allowing the installation of new Python packages without needing admin permissions.
 
-This software and documentation is maintained by the `RSES group <https://rse.shef.ac.uk/>`_
-and `GPUComputing@Sheffield <http://gpucomputing.shef.ac.uk/>`_.
-For feature requests or if you encounter any problems,
-please raise an issue on the `GPU Computing repository <https://github.com/RSE-Sheffield/GPUComputing/issues>`_.
-
 Installation in Home Directory - CPU Version
 --------------------------------------------
 
@@ -149,3 +144,8 @@ based on the `tested build configurations <https://www.tensorflow.org/install/so
 .. _tensorflow_cudnn_compat_bess:
 
 .. include:: /referenceinfo/imports/software/tensorflow/compat-table-import.rst
+
+Training
+--------
+
+The Research Software Engineering team has an `introductory workshop on deep learning with the TensorFlow Keras framework <https://rses-dl-course.github.io/>__`.

--- a/bessemer/software/libs/cuda.rst
+++ b/bessemer/software/libs/cuda.rst
@@ -252,8 +252,8 @@ but file locking was not previously enabled on the (`Lustre <http://lustre.org/>
 CUDA Training
 -------------
 
-The Research Software Engineering team provide
-a self-paced `introduction to CUDA <https://rse.shef.ac.uk/training/com4521>`_ training course.
+The Research Software Engineering team have developed an undergraduate teaching module on CUDA;
+`lecture notes and lecture recordings for that module are accessible here <https://rse.shef.ac.uk/training/com4521>`_ for anyone with a University account. 
 
 ---------
 

--- a/bessemer/software/libs/cuda.rst
+++ b/bessemer/software/libs/cuda.rst
@@ -252,8 +252,8 @@ but file locking was not previously enabled on the (`Lustre <http://lustre.org/>
 CUDA Training
 -------------
 
-`GPUComputing@sheffield <http://gpucomputing.shef.ac.uk>`_ provides
-a self-paced `introduction to CUDA <http://gpucomputing.shef.ac.uk/education/cuda/>`_ training course.
+The Research Software Engineering team provide
+a self-paced `introduction to CUDA <https://rse.shef.ac.uk/training/com4521>`_ training course.
 
 ---------
 

--- a/parallel/GPUComputing.rst
+++ b/parallel/GPUComputing.rst
@@ -34,7 +34,7 @@ please join the `GPUComputing google group <https://groups.google.com/a/sheffiel
 Requesting access to GPU facilities
 -----------------------------------
 
-**Public GPU nodes are available to in Bessemer and ShARC. These can be be used without acquiring extra permission.**
+**Public GPU nodes are available to in Stanage, Bessemer and ShARC. These can be be used without acquiring extra permission.**
 
 Research groups also have an option to purchase and add nodes to the cluster to be managed by IT Services.
 For these nodes (e.g. :ref:`dcs_gpu_nodes_bessemer`),
@@ -52,5 +52,6 @@ Using GPUs on the different clusters
 Hardware, software and ways to access GPUs differ between the clusters.
 Instructions specific to each cluster can be found below:
 
+* :ref:`gpu_computing_stanage`
 * :ref:`GPUComputing_bessemer`
 * :ref:`GPUComputing_sharc`

--- a/sharc/DeepLearningShARC.rst
+++ b/sharc/DeepLearningShARC.rst
@@ -21,7 +21,7 @@ The following are the list of currently supported Deep Learning frameworks avail
 * :ref:`theano_sharc`
 * :ref:`torch_sharc`
 
-Deep Learning framworks often have a complex set of software requirements. With the introduction of Apptainer/Singularity on ShARC, a containerisation technology similar to Docker, it is now possible for you to create a software stack that exactly fits your needs and will run on both your local development machine and the ShARC cluster (see :ref:`apptainer_sharc`).
+Deep Learning frameworks often have a complex set of software requirements. With the introduction of Apptainer/Singularity on ShARC, a containerisation technology similar to Docker, it is now possible for you to create a software stack that exactly fits your needs and will run on both your local development machine and the ShARC cluster (see :ref:`apptainer_sharc`).
 
 Use of GPUs for training Neural Networks
 ----------------------------------------
@@ -38,4 +38,4 @@ The Nvidia DGX-1 is the world's first Deep Learning supercomputer. It is availab
 Training Materials
 ------------------
 
-* `Introducting to Deep Learning using Caffe on ShARC's DGX-1 by GPUComputing@Sheffield <https://rse.shef.ac.uk/training/com4521//>`_
+The Research Software Engineering team has an `introductory workshop on deep learning with the TensorFlow Keras framework <https://rses-dl-course.github.io/>__`.

--- a/sharc/DeepLearningShARC.rst
+++ b/sharc/DeepLearningShARC.rst
@@ -38,4 +38,4 @@ The Nvidia DGX-1 is the world's first Deep Learning supercomputer. It is availab
 Training Materials
 ------------------
 
-* `Introducting to Deep Learning using Caffe on ShARC's DGX-1 by GPUComputing@Sheffield <http://gpucomputing.shef.ac.uk/education/cuda/>`_
+* `Introducting to Deep Learning using Caffe on ShARC's DGX-1 by GPUComputing@Sheffield <https://rse.shef.ac.uk/training/com4521//>`_

--- a/sharc/GPUComputingShARC.rst
+++ b/sharc/GPUComputingShARC.rst
@@ -124,4 +124,4 @@ Training materials
 ^^^^^^^^^^^^^^^^^^
 
 * The Research Software Engineering team have developed an undergraduate teaching module on CUDA;
-`lecture notes and lecture recordings for that module are accessible here <https://rse.shef.ac.uk/training/com4521>`_ for anyone with a University account.
+  `lecture notes and lecture recordings for that module are accessible here <https://rse.shef.ac.uk/training/com4521>`_ for anyone with a University account.

--- a/sharc/GPUComputingShARC.rst
+++ b/sharc/GPUComputingShARC.rst
@@ -123,5 +123,4 @@ GPU-enabled Software
 Training materials
 ^^^^^^^^^^^^^^^^^^
 
-* `Introduction to CUDA by GPUComputing@Sheffield <http://gpucomputing.shef.ac.uk/education/cuda/>`_
-* `Introducting to Deep Learning using Caffe on ShARC's DGX-1 by GPUComputing@Sheffield <http://gpucomputing.shef.ac.uk/education/cuda/>`_
+* `Introduction to CUDA by the Research Software Engineering (RSE) team <https://rse.shef.ac.uk/training/com4521>`_

--- a/sharc/GPUComputingShARC.rst
+++ b/sharc/GPUComputingShARC.rst
@@ -123,4 +123,5 @@ GPU-enabled Software
 Training materials
 ^^^^^^^^^^^^^^^^^^
 
-* `Introduction to CUDA by the Research Software Engineering (RSE) team <https://rse.shef.ac.uk/training/com4521>`_
+* The Research Software Engineering team have developed an undergraduate teaching module on CUDA;
+`lecture notes and lecture recordings for that module are accessible here <https://rse.shef.ac.uk/training/com4521>`_ for anyone with a University account.

--- a/sharc/software/apps/caffe.rst
+++ b/sharc/software/apps/caffe.rst
@@ -16,8 +16,6 @@ About Caffe on ShARC
 
 Caffe is available on ShARC as both Apptainer/Singularity images and as a module.
 
-This software and documentation is maintained by the `RSES group <https://rse.shef.ac.uk/>`_ and GPUComputing@Sheffield_. For feature requests or if you encounter any problems, please raise an issue on the `GPU Computing repository <https://github.com/RSE-Sheffield/GPUComputing/issues>`_.
-
 
 Caffe Apptainer/Singularity Images
 ----------------------------------
@@ -110,7 +108,8 @@ If you created a virtual python environment, you must activate it at every new s
 Caffe Training
 --------------
 
-GPUComputing@Sheffield_ provides training materials on the `use of Caffe on the DGX-1 and ShARC cluster <http://gpucomputing.shef.ac.uk/education/intro_dl_sharc_dgx1/>`_.
+The Research Software Engineering team provide
+training materials on the `use of Caffe on the DGX-1 and ShARC cluster <http://gpucomputing.shef.ac.uk/education/intro_dl_sharc_dgx1/>`_.
 
 Installation Notes
 ------------------
@@ -148,6 +147,3 @@ And comes with the following libraries:
   * libpng
   * libtiff
   * opencv 3.2.0
-
-
-.. _GPUComputing@Sheffield: http://gpucomputing.shef.ac.uk

--- a/sharc/software/apps/caffe.rst
+++ b/sharc/software/apps/caffe.rst
@@ -12,7 +12,11 @@ Caffe
 About Caffe on ShARC
 --------------------
 
-**A GPU-enabled worker node must be requested in order to use the GPU version of this software. See** :ref:`GPUComputing_sharc` **for more information.**
+.. note::
+
+   The use of Caffe is no longer recommended; the last release of Caffe was in 2017.
+
+A GPU-enabled worker node must be requested in order to use the GPU version of this software. See :ref:`GPUComputing_sharc` for more information.
 
 Caffe is available on ShARC as both Apptainer/Singularity images and as a module.
 

--- a/sharc/software/apps/caffe.rst
+++ b/sharc/software/apps/caffe.rst
@@ -104,13 +104,6 @@ If you created a virtual python environment, you must activate it at every new s
   #Activation below is only needed if you've installed your on python modules
   source activate caffe
 
-
-Caffe Training
---------------
-
-The Research Software Engineering team provide
-training materials on the `use of Caffe on the DGX-1 and ShARC cluster <http://gpucomputing.shef.ac.uk/education/intro_dl_sharc_dgx1/>`_.
-
 Installation Notes
 ------------------
 

--- a/sharc/software/apps/pytorch.rst
+++ b/sharc/software/apps/pytorch.rst
@@ -25,10 +25,6 @@ About PyTorch on ShARC
 
 As PyTorch and all its dependencies are written in Python, it can be installed locally in your home directory. The use of Anaconda (:ref:`sharc-python-conda`) is recommended as it is able to create a virtual environment in your home directory, allowing the installation of new Python packages without admin permission.
 
-This software and documentation is maintained by the `RSES group <https://rse.shef.ac.uk/>`_ and `GPUComputing@Sheffield <http://gpucomputing.shef.ac.uk/>`_. For feature requests or if you encounter any problems, please raise an issue on the `GPU Computing repository <https://github.com/RSE-Sheffield/GPUComputing/issues>`_.
-
-
-
 Installation in Home Directory
 ------------------------------
 

--- a/sharc/software/apps/tensorflow.rst
+++ b/sharc/software/apps/tensorflow.rst
@@ -18,10 +18,6 @@ Tensorflow is available on ShARC as both Apptainer (previously known as Singular
 
 As Tensorflow and all its dependencies are written in Python, it can be installed locally in your home directory. The use of Anaconda (:ref:`sharc-python-conda`) is recommended as it is able to create a virtual environment in your home directory, allowing the installation of new Python packages without admin permission.
 
-This software and documentation is maintained by the `RSES group <https://rse.shef.ac.uk/>`_ and `GPUComputing@Sheffield <http://gpucomputing.shef.ac.uk/>`_. For feature requests or if you encounter any problems, please raise an issue on the `GPU Computing repository <https://github.com/RSE-Sheffield/GPUComputing/issues>`_.
-
-
-
 Installation in Home Directory - CPU Version
 --------------------------------------------
 
@@ -169,6 +165,10 @@ The following table shows which module to load for the various versions of Tenso
 | >= 1.0.0   | 8.0  | 5.1    | ``libs/cudnn/5.1/binary-cuda-8.0.44``        |
 +------------+------+--------+----------------------------------------------+
 
+Training
+--------
+
+The Research Software Engineering team has an `introductory workshop on deep learning with the TensorFlow Keras framework <https://rses-dl-course.github.io/>__`.
 
 Tensorflow Apptainer/Singularity Images
 ---------------------------------------

--- a/sharc/software/apps/theano.rst
+++ b/sharc/software/apps/theano.rst
@@ -18,10 +18,6 @@ Theano is available on ShARC as both Apptainer/Singularity images and by local i
 
 As Theano and all its dependencies are written in Python. An Apptainer (previously known as Singularity) image is available for instant usage and it can also be installed locally in your home directory. For local installation, the use of Anaconda (:ref:`sharc-python-conda`) is recommended as it is able to create a virtual environment in your home directory, allowing the installation of new Python packages without admin permission.
 
-This software and documentation is maintained by the `RSES group <https://rse.shef.ac.uk/>`_ and `GPUComputing@Sheffield <http://gpucomputing.shef.ac.uk/>`_. For feature requests or if you encounter any problems, please raise an issue on the `GPU Computing repository <https://github.com/RSE-Sheffield/GPUComputing/issues>`_.
-
-
-
 Local Installation
 ------------------
 

--- a/sharc/software/apps/torch.rst
+++ b/sharc/software/apps/torch.rst
@@ -27,9 +27,6 @@ About Torch on ShARC
 
 Torch is available on ShARC as both Apptainer/Singularity images and as a module.
 
-This software and documentation is maintained by the `RSES group <https://rse.shef.ac.uk/>`_ and `GPUComputing@Sheffield <http://gpucomputing.shef.ac.uk/>`_. For feature requests or if you encounter any problems, please raise an issue on the `GPU Computing repository <https://github.com/RSE-Sheffield/GPUComputing/issues>`_.
-
-
 Torch Apptainer/Singularity Images
 ----------------------------------
 

--- a/sharc/software/libs/cuda.rst
+++ b/sharc/software/libs/cuda.rst
@@ -155,8 +155,8 @@ but file locking was not previously enabled on the (`Lustre <http://lustre.org/>
 CUDA Training
 -------------
 
-The Research Software Engineering team provide
-a self-paced `introduction to CUDA <https://rse.shef.ac.uk/training/com4521>`_ training course.
+The Research Software Engineering team have developed an undergraduate teaching module on CUDA;
+`lecture notes and lecture recordings for that module are accessible here <https://rse.shef.ac.uk/training/com4521>`_ for anyone with a University account. 
 
 Determining the NVIDIA Driver version
 -------------------------------------

--- a/sharc/software/libs/cuda.rst
+++ b/sharc/software/libs/cuda.rst
@@ -155,8 +155,8 @@ but file locking was not previously enabled on the (`Lustre <http://lustre.org/>
 CUDA Training
 -------------
 
-`GPUComputing@sheffield <http://gpucomputing.shef.ac.uk>`_ provides 
-a self-paced `introduction to CUDA <http://gpucomputing.shef.ac.uk/education/cuda/>`_ training course.
+The Research Software Engineering team provide
+a self-paced `introduction to CUDA <https://rse.shef.ac.uk/training/com4521>`_ training course.
 
 Determining the NVIDIA Driver version
 -------------------------------------

--- a/stanage/GPUComputingStanage.rst
+++ b/stanage/GPUComputingStanage.rst
@@ -103,4 +103,4 @@ Training materials
 ------------------
 
 * The Research Software Engineering team have developed an undergraduate teaching module on CUDA;
-`lecture notes and lecture recordings for that module are accessible here <https://rse.shef.ac.uk/training/com4521>`_ for anyone with a University account.
+  `lecture notes and lecture recordings for that module are accessible here <https://rse.shef.ac.uk/training/com4521>`_ for anyone with a University account.

--- a/stanage/GPUComputingStanage.rst
+++ b/stanage/GPUComputingStanage.rst
@@ -102,4 +102,5 @@ GPU-enabled Software
 Training materials
 ------------------
 
-* `Introduction to CUDA by the Research Software Engineering (RSE) team <https://rse.shef.ac.uk/training/com4521>`_
+* The Research Software Engineering team have developed an undergraduate teaching module on CUDA;
+`lecture notes and lecture recordings for that module are accessible here <https://rse.shef.ac.uk/training/com4521>`_ for anyone with a University account.

--- a/stanage/GPUComputingStanage.rst
+++ b/stanage/GPUComputingStanage.rst
@@ -102,4 +102,4 @@ GPU-enabled Software
 Training materials
 ------------------
 
-`Introduction to CUDA by GPUComputing@Sheffield <https://gpucomputing.shef.ac.uk/education/cuda/>`_
+* `Introduction to CUDA by the Research Software Engineering (RSE) team <https://rse.shef.ac.uk/training/com4521>`_

--- a/stanage/software/apps/pytorch.rst
+++ b/stanage/software/apps/pytorch.rst
@@ -22,11 +22,6 @@ The use of Anaconda (:ref:`python_stanage`) is recommended as
 it is able to create a virtual environment in your home directory,
 allowing for the installation of new Python packages without needing admin permission.
 
-This software and documentation is maintained by the `RSES group <https://rse.shef.ac.uk/>`_
-and `GPUComputing@Sheffield <http://gpucomputing.shef.ac.uk/>`_.
-For feature requests or if you encounter any problems,
-please raise an issue on the `GPU Computing repository <https://github.com/RSE-Sheffield/GPUComputing/issues>`_.
-
 Installation in Home Directory
 ------------------------------
 

--- a/stanage/software/apps/tensorflow.rst
+++ b/stanage/software/apps/tensorflow.rst
@@ -31,11 +31,6 @@ The use of Anaconda (:ref:`python_stanage`) is recommended as
 it is able to create a virtual environment in your home directory,
 allowing the installation of new Python packages without needing admin permissions.
 
-This software and documentation is maintained by the `RSES group <https://rse.shef.ac.uk/>`_
-and `GPUComputing@Sheffield <http://gpucomputing.shef.ac.uk/>`_.
-For feature requests or if you encounter any problems,
-please raise an issue on the `GPU Computing repository <https://github.com/RSE-Sheffield/GPUComputing/issues>`_.
-
 Installation in Home Directory - CPU Version
 --------------------------------------------
 
@@ -149,3 +144,8 @@ based on the `tested build configurations <https://www.tensorflow.org/install/so
 .. _tensorflow_cudnn_compat_stanage:
 
 .. include:: /referenceinfo/imports/software/tensorflow/compat-table-import.rst
+
+Training
+--------
+
+The Research Software Engineering team has an `introductory workshop on deep learning with the TensorFlow Keras framework <https://rses-dl-course.github.io/>__`.

--- a/stanage/software/libs/cuda.rst
+++ b/stanage/software/libs/cuda.rst
@@ -246,8 +246,8 @@ please use Nsight Systems and Nsight Compute instead.
 CUDA Training
 -------------
 
-`GPUComputing@sheffield <http://gpucomputing.shef.ac.uk>`_ provides
-a self-paced `introduction to CUDA <http://gpucomputing.shef.ac.uk/education/cuda/>`_ training course.
+The Research Software Engineering team provide
+a self-paced `introduction to CUDA <https://rse.shef.ac.uk/training/com4521>`_ training course.
 
 ---------
 

--- a/stanage/software/libs/cuda.rst
+++ b/stanage/software/libs/cuda.rst
@@ -246,8 +246,8 @@ please use Nsight Systems and Nsight Compute instead.
 CUDA Training
 -------------
 
-The Research Software Engineering team provide
-a self-paced `introduction to CUDA <https://rse.shef.ac.uk/training/com4521>`_ training course.
+The Research Software Engineering team have developed an undergraduate teaching module on CUDA;
+`lecture notes and lecture recordings for that module are accessible here <https://rse.shef.ac.uk/training/com4521>`_ for anyone with a University account. 
 
 ---------
 


### PR DESCRIPTION
Also, RSE team not necessarily want to be first point of contact for GPU-related support queries and for maintaining centrally-provided software stacks (RSE folks inc @robadob: let me know if you disagree!)