### PR TITLE
Stanage znver3: foss-2022b-compat GCC (12.2.0) and CMake

### DIFF
--- a/stanage/software/development/cmake.rst
+++ b/stanage/software/development/cmake.rst
@@ -29,6 +29,7 @@ CMake can be loaded with one of:
         .. code-block:: console
 
            module load CMake/3.24.3-GCCcore-11.3.0
+           module load CMake/3.24.3-GCCcore-12.2.0
   
 CMake has a run-time dependency on ``libstdc++`` so
 the cmake module files depend on and load particular versions of the :ref:`GCC compiler <gcc_stanage>`,

--- a/stanage/software/development/gcc.rst
+++ b/stanage/software/development/gcc.rst
@@ -38,6 +38,7 @@ by running *one* of the following lines:
         .. code-block:: console
 
            module load GCCcore/11.3.0 
+           module load GCC/12.2.0
 
 Confirm that you've loaded the version of gcc you wanted using ``gcc -v``.
 


### PR DESCRIPTION
Useful for testing with CUDA 12.0.