### PR TITLE
Stanage default memory correction.

### DIFF
--- a/referenceinfo/imports/scheduler/memory_allocation_limits_table_import.rst
+++ b/referenceinfo/imports/scheduler/memory_allocation_limits_table_import.rst
@@ -15,9 +15,9 @@
      - 251 GB
      - 1007 GB 
      - 2014 GB
-     - 2 GB / 251 GB
-     - 2 GB / 251 GB (SMP) ~74404 GB (MPI)
-     - **Per job basis** ``--mem=<nn>``
+     - 4 GB / 251 GB
+     - 4 GB / 251 GB (SMP) ~74404 GB (MPI)
+     - **Per node basis** ``--mem=<nn>``
 
    * - SLURM (Bessemer)
      - 192 GB
@@ -25,7 +25,7 @@
      - N/A
      - 2 GB / 192 GB
      - 2 GB / 192 GB
-     - **Per job basis** ``--mem=<nn>``
+     - **Per node (job) basis** ``--mem=<nn>``
 
    * - SGE (ShARC)
      - 64 GB

--- a/referenceinfo/imports/scheduler/memory_allocation_limits_table_import.rst
+++ b/referenceinfo/imports/scheduler/memory_allocation_limits_table_import.rst
@@ -15,8 +15,8 @@
      - 251 GB
      - 1007 GB 
      - 2014 GB
-     - 4 GB / 251 GB
-     - 4 GB / 251 GB (SMP) ~74404 GB (MPI)
+     - 4016 MB / 251 GB
+     - 4016 MB / 251 GB (SMP) ~74404 GB (MPI)
      - **Per node basis** ``--mem=<nn>``
 
    * - SLURM (Bessemer)


### PR DESCRIPTION
Also includes a minor clarification on Bessemer given Stanage can do SMP and MPI vs Bessemer's SMP only.