### PR TITLE
Add missing mentions of Stanage

### DIFF
--- a/help.rst
+++ b/help.rst
@@ -22,10 +22,10 @@ General HPC Problems
 --------------------
 
 If you are struggling to get something working on the HPC you should first have a look through our documentation on the technology (e.g. :ref:`parallel_MPI`), 
-software (e.g. :ref:`sharc-software` ) or cluster (e.g. :ref:`Bessemer`) you are using to see if we have already installed the software / addressed your problem.
+software (e.g. :ref:`stanage-software` ) or cluster (e.g. :ref:`Bessemer`) you are using to see if we have already installed the software / addressed your problem.
 
 You should also make sure you look through our :ref:`FAQs` section as it covers many common mistakes. If you are having issues with your jobs failing 
-please have a look through the sections for :ref:`job debugging on ShARC <job_debugging_sharc>`  and :ref:`job debugging on Bessemer <job_debugging_bessemer>` clusters.
+please have a look through the sections for :ref:`job debugging on ShARC <job_debugging_sharc>`  and :ref:`job debugging on Stanage or Bessemer <job_debugging_bessemer>` clusters.
 
 .. note::
 

--- a/hpc/accounts.rst
+++ b/hpc/accounts.rst
@@ -4,7 +4,7 @@ Getting an Account
 ==================
 
 Before you can start using the clusters you must first request HPC access. HPC access allows usage
-of all of our clusters (:ref:`Bessemer <bessemer>` and :ref:`ShARC <sharc>`).
+of all of our clusters (:ref:`Stanage <stanage>`,:ref:`Bessemer <bessemer>` and :ref:`ShARC <sharc>`).
 
 --------
 

--- a/hpc/modules.rst
+++ b/hpc/modules.rst
@@ -311,7 +311,8 @@ You may therefore want to use them to manage software installed in
 * your home directory
 * a directory shared by your research group
 
-If you want your own Modules, you typically need to create a hierarchy of directories and files.  Within a base directory the relative path to a given module file determines the name you need to use to load it.  See the ``/usr/local/modulefiles`` directories on Bessemer and ShARC to:
+If you want your own Modules, you typically need to create a hierarchy of directories and files.  Within a base directory the relative path to a given module file determines the name you need to use to load it.  
+See the /opt/apps/testapps/el7/modules/ directory on Stanage, or the /usr/local/modulefiles directories on Bessemer and ShARC, to:
 
 * see the files that provide all cluster-wide modules and 
 * get an understanding of the (`Tcl <https://www.tcl.tk/>`__) syntax and structure of module files.  

--- a/hpc/modules.rst
+++ b/hpc/modules.rst
@@ -311,8 +311,9 @@ You may therefore want to use them to manage software installed in
 * your home directory
 * a directory shared by your research group
 
-If you want your own Modules, you typically need to create a hierarchy of directories and files.  Within a base directory the relative path to a given module file determines the name you need to use to load it.  
-See the /opt/apps/testapps/el7/modules/ directory on Stanage, or the /usr/local/modulefiles directories on Bessemer and ShARC, to:
+If you want your own Modules, you typically need to create a hierarchy of directories and files.  
+Within a base directory the relative path to a given module file determines the name you need to use to load it.  
+Access the directories stored in the variable $MODULEPATH to:
 
 * see the files that provide all cluster-wide modules and 
 * get an understanding of the (`Tcl <https://www.tcl.tk/>`__) syntax and structure of module files.  


### PR DESCRIPTION
Not sure if we should wait to make the change to modules.rst

Maybe we need to duplicate the Bessemer debugging section in the Stanage section too and link accordingly from help.rst