### PR TITLE
Fix xrefs for h100 related links on stanage pytorch/tensorflow pages

### DIFF
--- a/stanage/software/apps/pytorch.rst
+++ b/stanage/software/apps/pytorch.rst
@@ -23,7 +23,7 @@ it is able to create virtual environment(s) in your home directory,
 allowing for the installation of new Python packages without needing admin permission.
 
 .. note::
-   All 'stable' releases of PyTorch to date (up to and including 2.0.1) are not compatible with Stanage nodes with H100 GPUs (see :ref`Stanage specs <stanage-gpu-specs>`).
+   All 'stable' releases of PyTorch to date (up to and including 2.0.1) are not compatible with Stanage nodes with H100 GPUs (see :ref:`Stanage specs <stanage-gpu-specs>`).
 
    To use PyTorch on the H100 nodes you must install and use a 'nightly' build of PyTorch (see installation instructions below).
 

--- a/stanage/software/apps/tensorflow.rst
+++ b/stanage/software/apps/tensorflow.rst
@@ -35,7 +35,7 @@ allowing the installation of new Python packages without needing admin permissio
 .. note::
    If you are wanting to use TensorFlow with GPUs on Stanage:
    
-   Be aware that official TensorFlow releases don't (yet) come with CUDA code compiled to target the ``sm_90`` NVIDIA Compute Capability (required by H100 GPUs - see :ref`Stanage specs <stanage-gpu-specs>`).
+   Be aware that official TensorFlow releases don't (yet) come with CUDA code compiled to target the ``sm_90`` NVIDIA Compute Capability (required by H100 GPUs - see :ref:`Stanage specs <stanage-gpu-specs>`).
    Attempts to run TensorFlow on H100 nodes will result in GPU-architecture-independent 'PTX' code that is bundled with TensorFlow being compiled on the fly to target the ``sm_90`` NVIDIA Compute Capability.
    Be warned that this process can take up to ~30 minutes.
 


### PR DESCRIPTION
Fixes incorrect rst cross references on the tensorflow and pytorch stanage pages in the h100 notes


e.g. https://docs.hpc.shef.ac.uk/en/latest/stanage/software/apps/pytorch.html


![image](https://github.com/rcgsheffield/sheffield_hpc/assets/628937/1ab80ccc-e14d-41c0-9c7e-897cf9313467)

to

![image](https://github.com/rcgsheffield/sheffield_hpc/assets/628937/7bded863-f9d6-4c5c-9c5f-c9c4f751a9b6)
