### PR TITLE
Remove mailto links

### DIFF
--- a/bessemer/software/apps/ansys/fluent.rst
+++ b/bessemer/software/apps/ansys/fluent.rst
@@ -111,7 +111,7 @@ ANSYS Fluent training and help resources
 
 .. important::
 
-  Academic support requests should be directed to the `IT Services' Research and Innovation team <mailto:research-it@sheffield.ac.uk>`_  or 
+  Academic support requests should be directed to ``research-it@sheffield.ac.uk`` or 
   the `ANSYS Learning Forum <https://forum.ansys.com/>`_ (**ensure you register with your University email for priority support**).
 
 ANSYS provides numerous academic training and help resources including tutorials, video lectures and examples for computational fluid dynamics products.

--- a/bessemer/software/apps/ansys/index.rst
+++ b/bessemer/software/apps/ansys/index.rst
@@ -52,7 +52,7 @@ ANSYS training and help resources
 
 .. important::
 
-  Academic support requests should be directed to the `IT Services' Research and Innovation team <mailto:research-it@sheffield.ac.uk>`_  or 
+  Academic support requests should be directed to ``research-it@sheffield.ac.uk`` or 
   the `ANSYS Learning Forum <https://forum.ansys.com/>`_ (**ensure you register with your University email for priority support**).
 
 ANSYS provides numerous academic training and help resources including tutorials, video lectures and examples. 

--- a/bessemer/software/apps/ansys/ls-dyna.rst
+++ b/bessemer/software/apps/ansys/ls-dyna.rst
@@ -141,7 +141,7 @@ ANSYS LS-DYNA training and help resources
 
 .. important::
 
-  Academic support requests should be directed to the `IT Services' Research and Innovation team <mailto:research-it@sheffield.ac.uk>`_  or 
+  Academic support requests should be directed to ``research-it@sheffield.ac.uk`` or 
   the `ANSYS Learning Forum <https://forum.ansys.com/>`_ (**ensure you register with your University email for priority support**).
 
 ANSYS provides numerous academic training and help resources including tutorials, video lectures and examples. 

--- a/bessemer/software/apps/ansys/mechanical.rst
+++ b/bessemer/software/apps/ansys/mechanical.rst
@@ -85,7 +85,7 @@ ANSYS Mechnical training and help resources
 
 .. important::
 
-  Academic support requests should be directed to the `IT Services' Research and Innovation team <mailto:research-it@sheffield.ac.uk>`_  or 
+  Academic support requests should be directed to ``research-it@sheffield.ac.uk`` or 
   the `ANSYS Learning Forum <https://forum.ansys.com/>`_ (**ensure you register with your University email for priority support**).
 
 ANSYS provides numerous academic training and help resources including tutorials, video lectures and examples for structural and mechnical products. 

--- a/bessemer/software/index.rst
+++ b/bessemer/software/index.rst
@@ -8,7 +8,7 @@ Software on Bessemer
     The latest changes and newly installed software on our clusters can be found at the `HPC Changelog <http://changelog.hpc.shef.ac.uk/>`_ microsite.
 
 These pages list the software available on Bessemer. If you notice an error or
-an omission, or wish to request new software submit a request to `research-it@sheffield.ac.uk <mailto:research-it@sheffield.ac.uk?subject=Bessemer HPC Software installation request>`_ .
+an omission, or wish to request new software submit a request to ``research-it@sheffield.ac.uk``.
 
 
 .. toctree::

--- a/help.rst
+++ b/help.rst
@@ -32,7 +32,7 @@ please have a look through the sections for :ref:`job debugging on ShARC <job_de
     Please make sure you check through our resources prior to contacting us as we are a small team with limited resources.
 
 If you are still having issues or need specific advice e.g. how to best parallelise your workflow, please contact 
-`IT Services' Research and Innovation team <mailto:research-it@sheffield.ac.uk>`_ or if you have more specific queries about programming / coding for HPC clusters e.g. CUDA programming please contact
+`IT Services' Research and Innovation team (``research-it@sheffield.ac.uk``) or if you have more specific queries about programming / coding for HPC clusters e.g. CUDA programming please contact
 the `Research Software Engineering team <https://rse.shef.ac.uk/contact/>`_.
 
 ------

--- a/referenceinfo/imports/stanage/ssh-host-keys.rst
+++ b/referenceinfo/imports/stanage/ssh-host-keys.rst
@@ -10,4 +10,4 @@ Your SSH client will show one of these fingerprints by default. If any one of th
 .. warning::
 
     If none of these fingerprints matches the fingerprint shown in your terminal please 
-    contact the `IT Services' Research and Innovation team <mailto:research-it@sheffield.ac.uk>`_ .
+    contact ``research-it@sheffield.ac.uk``.

--- a/sharc/sharc-decommissioning.rst
+++ b/sharc/sharc-decommissioning.rst
@@ -10,7 +10,7 @@ Once ShARC has been decommissioned and all data securely deleted the system is t
 
 We recommend users move to the :ref:`Stanage<stanage>` cluster which is a new, much larger system than previous TUOS clusters with drastically larger numbers of CPU cores, numbers of cores per node, memory per node (especially with Stanage's 1TB and 2TB nodes) and a large number of GPUs.
 
-Please get in touch with us if you have any concerns regarding this announcement via HPC drop-in sessions (every Friday) or `research-it@sheffield.ac.uk. <mailto:research-it@sheffield.ac.uk?subject=ShARC%20HPC%20decommissioning>`_
+Please get in touch with us if you have any concerns regarding this announcement via HPC drop-in sessions (every Friday) or ``research-it@sheffield.ac.uk``.
 
 .. hint::
 
@@ -61,6 +61,6 @@ User installed software may require recompiling
 
 If you have compiled and installed your own applications on ShARC you should recompile your applications on the newer clusters when migrating your workloads in order to ensure compatibility and potentially significant performance increases. 
 
-If you currently use IT Services-managed applications on ShARC which are not currently available on Stanage or Bessemer then you can submit a request to `research-it@sheffield.ac.uk <mailto:research-it@sheffield.ac.uk?subject=HPC%20Software%20installation%20request>`_.
+If you currently use IT Services-managed applications on ShARC which are not currently available on Stanage or Bessemer then you can submit a request to ``research-it@sheffield.ac.uk``.
 
 

--- a/sharc/software/apps/ansys/fluent.rst
+++ b/sharc/software/apps/ansys/fluent.rst
@@ -162,7 +162,7 @@ ANSYS Fluent training and help resources
 
 .. important::
 
-  Academic support requests should be directed to the `IT Services' Research and Innovation team <mailto:research-it@sheffield.ac.uk>`_  or 
+  Academic support requests should be directed to ``research-it@sheffield.ac.uk`` or 
   the `ANSYS Learning Forum <https://forum.ansys.com/>`_ (**ensure you register with your University email for priority support**).
 
 ANSYS provides numerous academic training and help resources including tutorials, video lectures and examples for computational fluid dynamics products.

--- a/sharc/software/apps/ansys/index.rst
+++ b/sharc/software/apps/ansys/index.rst
@@ -49,7 +49,7 @@ ANSYS training and help resources
 
 .. important::
 
-  Academic support requests should be directed to the `IT Services' Research and Innovation team <mailto:research-it@sheffield.ac.uk>`_  or 
+  Academic support requests should be directed to ``research-it@sheffield.ac.uk`` or 
   the `ANSYS Learning Forum <https://forum.ansys.com/>`_ (**ensure you register with your University email for priority support**).
 
 ANSYS provides numerous academic training and help resources including tutorials, video lectures and examples. 

--- a/sharc/software/apps/ansys/ls-dyna.rst
+++ b/sharc/software/apps/ansys/ls-dyna.rst
@@ -199,7 +199,7 @@ ANSYS LS-DYNA training and help resources
 
 .. important::
 
-  Academic support requests should be directed to the `IT Services' Research and Innovation team <mailto:research-it@sheffield.ac.uk>`_  or 
+  Academic support requests should be directed to ``mailto:research-it@sheffield.ac.uk`` or 
   the `ANSYS Learning Forum <https://forum.ansys.com/>`_ (**ensure you register with your University email for priority support**).
 
 ANSYS provides numerous academic training and help resources including tutorials, video lectures and examples. 

--- a/sharc/software/apps/ansys/mechanical.rst
+++ b/sharc/software/apps/ansys/mechanical.rst
@@ -135,7 +135,7 @@ ANSYS Mechnical training and help resources
 
 .. important::
 
-  Academic support requests should be directed to the `IT Services' Research and Innovation team <mailto:research-it@sheffield.ac.uk>`_  or 
+  Academic support requests should be directed to ``research-it@sheffield.ac.uk`` or 
   the `ANSYS Learning Forum <https://forum.ansys.com/>`_ (**ensure you register with your University email for priority support**).
 
 ANSYS provides numerous academic training and help resources including tutorials, video lectures and examples for for structural and mechnical products.

--- a/sharc/software/index.rst
+++ b/sharc/software/index.rst
@@ -8,7 +8,7 @@ Software on ShARC
     The latest changes and newly installed software on our clusters can be found at the `HPC Changelog <http://changelog.hpc.shef.ac.uk/>`_ microsite.
 
 These pages list the software available on ShARC. If you notice an error or
-an omission, or wish to request new software submit a request to `research-it@sheffield.ac.uk <mailto:research-it@sheffield.ac.uk?subject=ShARC HPC Software installation request>`_ .
+an omission, or wish to request new software submit a request to ``research-it@sheffield.ac.uk``.
 
 
 .. toctree::

--- a/stanage/software/apps/ansys/fluent.rst
+++ b/stanage/software/apps/ansys/fluent.rst
@@ -197,7 +197,7 @@ ANSYS Fluent training and help resources
 
 .. important::
 
-  Academic support requests should be directed to the `IT Services' Research and Innovation team <mailto:research-it@sheffield.ac.uk>`_  or 
+  Academic support requests should be directed to ``research-it@sheffield.ac.uk`` or 
   the `ANSYS Learning Forum <https://forum.ansys.com/>`_ (**ensure you register with your University email for priority support**).
 
 ANSYS provides numerous academic training and help resources including tutorials, video lectures and examples for computational fluid dynamics products.

--- a/stanage/software/apps/ansys/index.rst
+++ b/stanage/software/apps/ansys/index.rst
@@ -49,7 +49,7 @@ ANSYS training and help resources
 
 .. important::
 
-  Academic support requests should be directed to the `IT Services' Research and Innovation team <mailto:research-it@sheffield.ac.uk>`_  or 
+  Academic support requests should be directed to ``research-it@sheffield.ac.uk``  or 
   the `ANSYS Learning Forum <https://forum.ansys.com/>`_ (**ensure you register with your University email for priority support**).
 
 ANSYS provides numerous academic training and help resources including tutorials, video lectures and examples. 

--- a/stanage/software/index.rst
+++ b/stanage/software/index.rst
@@ -10,7 +10,7 @@ Software on Stanage
 
 These pages list the software available on the Stanage cluster. If you notice an error or
 an omission, or wish to request new software submit a request to
-`research-it@sheffield.ac.uk <mailto:research-it@sheffield.ac.uk?subject=HPC Software installation request>`_ .
+``research-it@sheffield.ac.uk``.
 
 .. toctree::
     :maxdepth: 1

--- a/stanage/software/libs/cuda.rst
+++ b/stanage/software/libs/cuda.rst
@@ -230,7 +230,7 @@ A common use-case for using Nsight Compute is to capture all available profiling
 .. note::
 
    If you want to perform CUDA kernel profiling on this cluster 
-   you need to explicitly request (via `research-it@sheffield.ac.uk <mailto:research-it@sheffield.ac.uk>`_) for 
+   you need to explicitly request (via ``research-it@sheffield.ac.uk``) for 
    that to be enabled for you for a certain number of GPUs over a certain time period, 
    otherwise attempts to use tools like Nsight Compute will result in permissions errors (``ERR_NVGPUCTRPERM``).
 


### PR DESCRIPTION
In the age of web-based mail clients they're perhaps much less useful than they used to be.  I'd argue that email addresses as visible plain text are preferable.   