### PR TITLE
Add custom css code-block

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -85,3 +85,8 @@
   }
 
 .boldtext { font-weight: bold; }
+
+/* Add transparency to green code blocks */
+div.highlight pre {
+  background-color: rgba(238, 255, 204);
+}


### PR DESCRIPTION
code-blocks will have same transparency as other call outs etc
![image](https://github.com/rcgsheffield/sheffield_hpc/assets/116731613/63854315-8ce2-4dda-be79-4434c3136f3e)
