### PR TITLE
Removing sharc mentions part 1

### DIFF
--- a/bessemer/index.rst
+++ b/bessemer/index.rst
@@ -10,7 +10,7 @@ Bessemer
 
 This is the documentation for Bessemer, one of the University of Sheffield's High Performance Computing clusters. Bessemer is a 'capacity' cluster designed 
 to run compute jobs which will fit on a single node.
-Bessemer can support jobs requiring up to 40 cores per job - for larger jobs please use :ref:`stanage`.
+Bessemer can support jobs requiring up to 40 cores per job; for larger jobs please use :ref:`stanage`, which has 64 cores in standard non-GPU nodes and supports multi-node jobs
 
 .. toctree::
   :hidden:

--- a/bessemer/index.rst
+++ b/bessemer/index.rst
@@ -10,7 +10,7 @@ Bessemer
 
 This is the documentation for Bessemer, one of the University of Sheffield's High Performance Computing clusters. Bessemer is a 'capacity' cluster designed 
 to run compute jobs which will fit on a single node.
-Bessemer can support jobs requiring up to 40 cores per job - for larger jobs please use :ref:`stanage` or :ref:`sharc`.
+Bessemer can support jobs requiring up to 40 cores per job - for larger jobs please use :ref:`stanage`.
 
 .. toctree::
   :hidden:

--- a/bessemer/software/parallel/impi.rst
+++ b/bessemer/software/parallel/impi.rst
@@ -27,11 +27,8 @@ which implicitly load versions of icc, ifort (and GCC).
 
 .. warning::
 
-   The Bessemer cluster does not have a high performance interconnect between nodes. As 
-   a result cross-node MPI performance will be sharply limited in comparison to Stanage.
-
-   In addition, cross-node MPI is not normally permitted as these kinds of workloads 
-   should be run on the Stanage cluster for the reason above.
+    Multi-node jobs are (for the most part) not permitted by Slurm on Bessemer; the system has been configured this way as Bessemer,
+    unlike Stanage, doesn't have a very high-bandwidth, low-latency network connecting all worker nodes.
 
 
 Examples

--- a/bessemer/software/parallel/impi.rst
+++ b/bessemer/software/parallel/impi.rst
@@ -28,10 +28,10 @@ which implicitly load versions of icc, ifort (and GCC).
 .. warning::
 
    The Bessemer cluster does not have a high performance interconnect between nodes. As 
-   a result cross-node MPI performance will be sharply limited in comparison to ShARC.
+   a result cross-node MPI performance will be sharply limited in comparison to Stanage.
 
    In addition, cross-node MPI is not normally permitted as these kinds of workloads 
-   should be run on the ShARC cluster for the reason above.
+   should be run on the Stanage cluster for the reason above.
 
 
 Examples

--- a/hpc/connecting.rst
+++ b/hpc/connecting.rst
@@ -3,7 +3,7 @@
 Connecting to a cluster using myApps (web browser)
 ==================================================
 
-For easier access to HPC resources,  IT Services runs an instance of Oracle Secure Global desktop called myApps to provide web based access to CLI terminals,
+For easier access to HPC resources,  IT Services runs an instance of Oracle Secure Global desktop called myApps to provide web-based access to CLI terminals and
 text editors within interactive sessions for the Bessemer and Training HPC clusters.
 
 

--- a/hpc/connecting.rst
+++ b/hpc/connecting.rst
@@ -4,23 +4,23 @@ Connecting to a cluster using myApps (web browser)
 ==================================================
 
 For easier access to HPC resources,  IT Services runs an instance of Oracle Secure Global desktop called myApps to provide web based access to CLI terminals,
-text editors within interactive sessions for the ShARC, Bessemer and Training HPC clusters.
+text editors within interactive sessions for the Bessemer and Training HPC clusters.
 
 
 .. important:: 
     
-    The myApps service is only accessible on Bessmer and ShARC (:underline-bold:`not` Stanage).
+    The myApps service is only accessible on Bessemer (:underline-bold:`not` Stanage).
 
 In order to access the HPC clusters you must set up a `VPN connection and MFA <https://www.sheffield.ac.uk/it-services/vpn>`_. 
 Also see section **Whether/how you can connect** below. 
 
-The web browser method of access to ShARC and Bessemer is recommended. This method works well for most browsers on all the common 
+The web browser method of access to Bessemer is recommended. This method works well for most browsers on all the common 
 computing platforms (Linux, Windows, Mac), however we recommend Chrome or Firefox.
 
 :underline-bold:`How to login to the myApps service`
 
 
-#. To login to ShARC or Bessemer click the following link: `Connect via myAPPs Portal <https://myapps.shef.ac.uk/sgd/index.jsp?langSelected=en>`_
+#. To login to Bessemer click the following link: `Connect via myAPPs Portal <https://myapps.shef.ac.uk/sgd/index.jsp?langSelected=en>`_
 #. If you are logging in for the first time, select Client Options on the myApps Portal page (bottom right) and 
    then click the HTML5 option to run myApps entirely within your browser.
 
@@ -32,11 +32,11 @@ computing platforms (Linux, Windows, Mac), however we recommend Chrome or Firefo
 #. Enter your username and password on the myApps Portal login page.
 #. Once you have managed to login, you will see a window with applications on the left hand panel.
 
-There are icons for ShARC Applications & Bessemer Applications respectively.
+There are icons for Bessemer and ShARC Applications. However, ShARC was decommissioned hence those applications are no longer available.
 
-For each of these you can select a HPC interactive job or a HPC terminal (where HPC choices are ShARC or Bessemer).
-The interactive job is equivalent to a ``qsh``/``qrshx`` or ``srun`` session on a worker node.
-The terminal is equivalent to a login node session from which you can use ``qsh``/``qrshx``, ``qrsh``, ``qsh-vis`` or ``srun`` respectively.
+You can select a HPC interactive job or a HPC terminal.
+The interactive job is equivalent to a ``srun`` session on a worker node.
+The terminal is equivalent to a login node session from which you can use ``srun``.
 
 
 Connecting to a cluster using SSH
@@ -85,8 +85,6 @@ The authentication requirements per cluster are summarised below:
 +==========+======================================================+===================================================================================================+
 | Bessemer | Password + DUO MFA **or** public key                 | Not permitted (unless using the :ref:`HPC SSH gateway service <hpcgw_summary>`)                   |
 +----------+------------------------------------------------------+---------------------------------------------------------------------------------------------------+
-| ShARC    | Password + DUO MFA **or** public key                 | Not permitted (unless using the :ref:`HPC SSH gateway service <hpcgw_summary>`)                   |
-+----------+------------------------------------------------------+---------------------------------------------------------------------------------------------------+
 | Stanage  | Password/public key + TOTP MFA **or** VPN + password | Not permitted (unless using the :ref:`HPC SSH gateway service <hpcgw_summary>`)                   |
 +----------+------------------------------------------------------+---------------------------------------------------------------------------------------------------+
 
@@ -132,14 +130,6 @@ may be standard University `DUO MFA <https://sites.google.com/sheffield.ac.uk/mf
 
     If you have not setup your University DUO MFA, please follow the steps published at: https://www.sheffield.ac.uk/it-services/mfa/set-mfa
 
-  .. group-tab:: ShARC
-
-    On the ShARC cluster, when you connect you will be prompted to via a push notification to your DUO device to approve access 
-    or must enter a one-time code from your University provided hardware token which is associated with your DUO account.
-
-    If you have not setup your University DUO MFA, please follow the steps published at: https://www.sheffield.ac.uk/it-services/mfa/set-mfa
-
-
   
   In addition, if you do not have MFA enabled on your account then you will not be able to login from off campus without using the VPN.
 
@@ -182,7 +172,7 @@ After starting MobaXterm you should see something like this:
 
 You should create a session profile for your login for each cluster by clicking *Session* in the top left, and then *SSH*. 
 
-#. Enter the details for the cluster in the *Remote host* box, choosing ``bessemer.shef.ac.uk``, ``sharc.shef.ac.uk`` or ``stanage.shef.ac.uk``. 
+#. Enter the details for the cluster in the *Remote host* box, choosing ``stanage.shef.ac.uk`` or ``bessemer.shef.ac.uk``. 
 #. Now click the *Specify Username* checkmark and enter your username.
 #. Please ensure that the checkmark for *X11 Forwarding* is ticked or GUI applications will be unable to open.
 #. Please ensure that that *Use SCP protocol* is also ticked (or depending on MobaXterm version select *SCP (enhanced speed)* option from the *SSH-browser type* dropdown menu) .
@@ -210,7 +200,7 @@ login you should be presented with a screen like the below:
 
     When you login to a cluster you reach one of two login nodes.
     You **should not** run applications on the login nodes.
-    Running the interactive job command, ``qrshx`` (ShARC) or ``srun --pty bash -i`` (Bessemer & Stanage), gives you an interactive terminal
+    Running the interactive job command, ``srun --pty bash -i`` (Stanage & Bessemer), gives you an interactive terminal
     on one of the many worker nodes in the clusters.
     
 Running commands from a terminal (from the command-line) may initially be
@@ -246,7 +236,7 @@ log in to a cluster: ::
 Here you need to:
 
 * replace ``$USER`` with your IT Services username (e.g. ``te1st``)
-* replace ``$CLUSTER_NAME`` with ``bessemer``, ``sharc`` or ``stanage``.
+* replace ``$CLUSTER_NAME`` with ``stanage`` or ``bessemer``.
 
 .. note::
 
@@ -314,37 +304,13 @@ This should give you a prompt resembling the one below:
         [te1st@bessemer-node001 ~]$ 
 
 
-  .. group-tab:: ShARC
-
-    .. code-block:: console
-
-        [te1st@sharc-login1 ~]$
-
-    At this prompt if you would like an interactive session you can type: 
-
-    .. code-block:: console
-
-        qrshx
-
-    Like this: 
-
-    .. code-block:: console
-
-        [te1st@sharc-login1 ~]$ qrshx
-
-
-    Which will start an interactive session, which supports graphical applications resembling the below: 
-
-    .. code-block:: console
-
-        [te1st@sharc-node001 ~]$  
 
 
 .. note::
 
     When you login to a cluster you reach one of two login nodes.
     You **should not** run applications on the login nodes.
-    Running the interactive job command, ``qrshx`` (ShARC) or ``srun --pty bash -i`` (Bessemer & Stanage), gives you an interactive terminal
+    Running the interactive job command, ``srun --pty bash -i`` (Stanage & Bessemer), gives you an interactive terminal
     on one of the many worker nodes in the clusters.
 
 
@@ -373,4 +339,4 @@ What Next?
 Now you have connected to a cluster,
 you can look at how to submit jobs on the :ref:`job_submission_control` page or
 look at the software installed on
-:ref:`Bessemer <bessemer-software>`, :ref:`ShARC <sharc-software>` and :ref:`Stanage <stanage-software>`
+:ref:`Stanage <stanage-software>` and :ref:`Bessemer <bessemer-software>`. 

--- a/hpc/connecting.rst
+++ b/hpc/connecting.rst
@@ -30,9 +30,7 @@ computing platforms (Linux, Windows, Mac), however we recommend Chrome or Firefo
     Usernames to connect with all HPC services will be the same as those you use to login to MUSE :underline-bold:`not` the prefix on your email address.
 
 #. Enter your username and password on the myApps Portal login page.
-#. Once you have managed to login, you will see a window with applications on the left hand panel.
-
-There are icons for Bessemer and ShARC Applications. However, ShARC was decommissioned hence those applications are no longer available.
+#. Once you have managed to login, you will see a window with Bessemer applications on the left hand panel.
 
 You can select a HPC interactive job or a HPC terminal.
 The interactive job is equivalent to a ``srun`` session on a worker node.

--- a/hpc/filestore.rst
+++ b/hpc/filestore.rst
@@ -137,7 +137,7 @@ All users have a home directory on each system:
 **Fastdata** areas are **optimised for large file operations**.  
 These areas are `Lustre <https://en.wikipedia.org/wiki/Lustre_(file_system)>`__ filesystems. 
 
-They are are **faster** than :ref:`home_dir` and :ref:`shared_dir` when dealing with larger files but 
+They are **faster** than :ref:`home_dir` and :ref:`shared_dir` when dealing with larger files but 
 are **not performant when reading/writing lots of small files** 
 (:ref:`scratch_dir` are ideal for reading/writing lots of small temporary files within jobs).
 An example of how slow it can be for large numbers of small files is detailed `here <http://www.walkingrandomly.com/?p=6167>`__.

--- a/hpc/filestore.rst
+++ b/hpc/filestore.rst
@@ -3,10 +3,9 @@
 Filestores
 ==========
 
-Every HPC user has access to *up to* six different storage areas:
+Every HPC user has access to *up to* five different storage areas:
 
 * :ref:`home_dir`: per-user :term:`backed-up <Mirrored backups>`, :term:`snapshotted <Snapshotted storage>` storage
-* :ref:`data_dir`: additional per-user snapshotted storage (*not on Bessemer*)
 * :ref:`fastdata_dir`: high-performance shared filesystem for temporary data - optimised for reading/writing large files from multiple nodes and threads simultaneously
 * :ref:`shared_dir`: per-PI shared storage areas (snapshotted and backed-up) for project data - can be accessed from non-HPC machines too
 * :ref:`scratch_dir`: per-node temporary storage - useful for reading/writing lots of small files within *one job*
@@ -90,21 +89,6 @@ All users have a home directory on each system:
 
     .. include:: /referenceinfo/imports/filestores/shared-areas/sharc-bessemer-snapshot-mirror-settings.rst
 
-  .. group-tab:: ShARC
-
-    :underline-bold:`Home filestore area details`
-
-    +------------------------+------+----------------+-----------------------------------------------+-------------------------+
-    | Path                   | Type | Quota per user | Shared between system login and worker nodes? | Shared between systems? |
-    +========================+======+================+===============================================+=========================+
-    |``/home/$USER``         | NFS  | 10GB           | Yes                                           | No                      |
-    +------------------------+------+----------------+-----------------------------------------------+-------------------------+
-
-    Where ``$USER`` is the user's username.
-
-
-    .. include:: /referenceinfo/imports/filestores/shared-areas/sharc-bessemer-snapshot-mirror-settings.rst
-
 
 .. note::
 
@@ -115,10 +99,10 @@ All users have a home directory on each system:
   +===================+========================+
   | Stanage           |``/users/$USER``        |
   +-------------------+------------------------+
-  | Bessemer & ShARC  |``/home/$USER``         |
+  | Bessemer          |``/home/$USER``         |
   +-------------------+------------------------+ 
 
-  To ensure that your code is compatible with all three clusters, we suggest using the symbols "~" or "$HOME" to represent the home directory. This approach ensures that the correct path is used regardless of the cluster you are working on, making your code more portable and agnostic to the specific cluster environment.
+  To ensure that your code is compatible with both clusters, we suggest using the symbols "~" or "$HOME" to represent the home directory. This approach ensures that the correct path is used regardless of the cluster you are working on, making your code more portable and agnostic to the specific cluster environment.
 
   .. tabs::
 
@@ -142,86 +126,8 @@ All users have a home directory on each system:
         $ echo ~
         /home/te1st
 
-   .. group-tab:: ShARC
-      
-      .. code-block:: console
-        :emphasize-lines: 1,3
-
-        $ echo $HOME
-        /home/te1st
-        $ echo ~
-        /home/te1st
 
 ------
-
-.. _data_dir:
-
-*Data* directories
-------------------
-
-ShARC, (:underline-bold:`only`), has access to an additional larger *data* storage area:
-
-.. tabs::
-    
- .. group-tab:: Stanage
-
-    .. warning::
-      
-      There is no ``/data`` area on Stanage.
-
- .. group-tab:: Bessemer
-
-    .. warning::
-      
-      There is no ``/data`` area on Bessemer.
-
- .. group-tab:: ShARC
-      
-    +----------+------------------------+------+----------------+-----------------------------------------------+-------------------------+
-    | System   | Path                   | Type | Quota per user | Shared between system login and worker nodes? | Shared between systems? |
-    +==========+========================+======+================+===============================================+=========================+
-    | ShARC    | ``/data/$USER``        | NFS  | 100GB          | Yes                                           | No                      |
-    +----------+------------------------+------+----------------+-----------------------------------------------+-------------------------+
-
-    Where ``$USER`` is the user's username.
-
-    See also: :ref:`quota_check` and * :ref:`exceed_quota`.
-
-    :underline-bold:`Data filestore backups and snapshots details`
-
-    +---------------------------+--------------------+
-    | Frequency of snapshotting | Snapshots retained |
-    +===========================+====================+
-    | Every 4 hours             | 10 most recent     |
-    +---------------------------+--------------------+
-    | Every night               | Last 7 days        |
-    +---------------------------+--------------------+
-
-    +-------------------------------+------------------+
-    | Frequency of mirrored backups | Backups retained |
-    +===============================+==================+
-    | Every 4 hours                 | 6 most recent    |
-    +-------------------------------+------------------+
-    | Every night                   | 28 most recent   |
-    +-------------------------------+------------------+
-
-    See also: :ref:`recovering_snapshots`.
-
-    :underline-bold:`Automounting`
-
-
-    *Data* directories are **made available to you (mounted) on demand**: 
-    if you list the contents of just ``/data`` after first logging on then your ``/data/te1st`` subdirectory (where ``te1st`` is your username) might not be shown.
-    However, if you list the contents of ``/data/te1st`` itself or change into that directory
-    then its contents will appear.  
-
-    Later on if you list the contents of ``/data`` again 
-    you may find that ``/data/te1st`` has disappeared again, as 
-    it is automatically *unmounted* following a period of inactivity. 
-
-
-
------
 
 .. _fastdata_dir:
 
@@ -305,20 +211,6 @@ There are separate ``fastdata`` areas on each cluster:
 
     .. include:: /referenceinfo/imports/filestores/shared-areas/sharc-bessemer-fastdata-managing-import.rst
 
-   .. group-tab:: ShARC
-
-    :underline-bold:`Fastdata filestore area details`
-
-    +---------------+--------+----------------+---------------------+-------------------------+---------------------------+
-    | Path          | Type   | Quota per user | Filesystem capacity | Shared between systems? | Network bandwith per link |
-    +===============+========+================+=====================+=========================+===========================+
-    | ``/fastdata`` | Lustre | No limits      | 669 TB              | No                      | 100Gb/s (*Omni-Path*)     |
-    +---------------+--------+----------------+---------------------+-------------------------+---------------------------+
-
-    .. include:: /referenceinfo/imports/filestores/shared-areas/sharc-bessemer-fastdata-managing-import.rst
-
-
-
 
 -----
 
@@ -384,16 +276,6 @@ As our HPC cluster are each hosted in different datacentres the policy, configur
       to a Bessemer local shared research area filestore area from a Sheffield based machine will have a similar performance decrease.
 
       If you need to access a ``/shared`` area on Bessemer please contact `research-it@sheffield.ac.uk <research-it@sheffield.ac.uk>`__ to arrange this.
-
-   .. group-tab:: ShARC
-
-      :underline-bold:`Shared research area mount availability`
-
-      On the ShARC cluster shared research areas are available **on all HPC nodes**. This is because the HPC nodes are within the same local network as the shared research area filestores as to give maximum performance.
-
-      :underline-bold:`Shared research area performance`
-
-      As the HPC nodes are within the same local network, local NFS filestorage performance is provided.
 
 
 .. _shared_dir_perms:
@@ -479,30 +361,6 @@ Specifics for each Cluster
     The scheduler will then clean up (delete) ``$TMPDIR`` at the end of your job, 
     ensuring that the space can be used by other users.
 
-   .. group-tab:: ShARC
-
-    The scheduler will automatically create a per-job directory for you under ``/scratch``.
-    The name of this directory is stored in the ``$TMPDIR`` environment variable e.g. 
-    
-    .. code-block:: console
-
-      [te1st@sharc-login1 ~]$ qrshx
-      [te1st@sharc-node003 ~]$ cd $TMPDIR
-      [te1st@sharc-node003 667443.1.all.q]$ pwd
-      /scratch/667443.1.all.q
-
-    The scheduler will then clean up (delete) ``$TMPDIR`` at the end of your job, 
-    ensuring that the space can be used by other users.
-
-    .. warning::
-
-      If using ``qrsh`` on ShARC to start an interactive job then 
-      the ``TMPDIR`` environment variable will unfortunately be undefined
-      so you will need to manually create a directory under ``/scratch`` (named using your username)
-      and this will not be cleaned up when the job ends.
-
-
-
 
 -----
 
@@ -523,11 +381,9 @@ and if their request is granted they will be given write access to this area:
 +----------+--------------------------+------+-----------------------------+-------------------------------------+-----------------------------------------+
 | System   | Path                     | Type | Software install guidelines | Public index of areas               | Notes                                   |
 +==========+==========================+======+=============================+=====================================+=========================================+
-| ShARC    | ``/usr/local/community`` | NFS  | :ref:`sharc-community`      | :ref:`sharc-software-install-guide` | Also available at ``/usr/local/extras`` |
+| Stanage  | N/A                      | N/A  |                             |                                     |                                         |
 +----------+--------------------------+------+-----------------------------+-------------------------------------+-----------------------------------------+
 | Bessemer | ``/usr/local/community`` | NFS  |                             |                                     |                                         |
-+----------+--------------------------+------+-----------------------------+-------------------------------------+-----------------------------------------+
-| Stanage  | N/A                      | N/A  |                             |                                     |                                         |
 +----------+--------------------------+------+-----------------------------+-------------------------------------+-----------------------------------------+
 
 Note that:
@@ -543,7 +399,7 @@ Note that:
 How to check your quota usage
 -----------------------------
 
-To find out your storage quota usage for your :ref:`home directory <home_dir>` and :ref:`data directory <data_dir>` (if on ShARC) 
+To find out your storage quota usage for your :ref:`home directory <home_dir>` 
 you can use the ``quota`` command:
 
 .. tabs::
@@ -580,41 +436,6 @@ you can use the ``quota`` command:
       :ref:`ncdu module on Bessemer <ncdu_bessemer>`. The **ncdu** utility will give you an 
       interactive display of what files/folders are taking up storage in a given directory tree.
 
-   .. group-tab:: ShARC
-
-      .. code-block:: console
-
-            [te1st@sharc-node004 binary]$ quota
-
-            Size  Used Avail Use%  Mounted on
-            10G    10G    0G 100%  /home/te1st
-            100G     0  100G   0%  /data/te1st
-
-      In the above, you can see that the quota was set to 10 gigabytes and all of this is in use which is likely to cause jobs to fail.
-
-      To determine usage in a particular :ref:`shared_dir` you can use the ``df`` command like so: 
-
-      .. code-block:: console
-
-          [te1st@sharc-node004 binary]$ df -h /shared/myproject1
-          Filesystem                        Size  Used Avail Use% Mounted on
-          172.X.X.X:/myproject1/myproject1   10T  9.1T  985G  91% /shared/myproject1
-
-      To assess what is using up your quota within a given directory, you can make use of the 
-      :ref:`ncdu module on ShARC <ncdu_sharc>`. The **ncdu** utility will give you an 
-      interactive display of what files/folders are taking up storage in a given directory tree.
-
-      To determine usage in a particular :ref:`shared_dir` you can use the ``df`` command like so: 
-
-      .. code-block:: console
-
-          [te1st@login1 [stanage] ~]$  df -h /shared/myproject1
-          Filesystem                        Size  Used Avail Use% Mounted on
-          172.X.X.X:/myproject1/myproject1   10T  9.1T  985G  91% /shared/myproject1
-
-      To assess what is using up your quota within a given directory, you can make use of the 
-      :ref:`ncdu module on Stanage <ncdu_stanage>`. The **ncdu** utility will give you an 
-      interactive display of what files/folders are taking up storage in a given directory tree.
 
 -----
 
@@ -627,8 +448,7 @@ If you reach your quota for your :ref:`home directory <home_dir>` then
 many common programs/commands may cease to work as expected or at all and
 you may not be able to log in.
 
-In addition, jobs may fail if you exceed your quota with a job making use of your 
-:ref:`data directory <data_dir>` or a :ref:`Shared (project) directory <shared_dir>`.
+In addition, jobs may fail if you exceed your quota with a job making use of a :ref:`Shared (project) directory <shared_dir>`.
 
 In order to avoid this situation it is strongly recommended that you:
 

--- a/hpc/filestore.rst
+++ b/hpc/filestore.rst
@@ -137,7 +137,7 @@ All users have a home directory on each system:
 **Fastdata** areas are **optimised for large file operations**.  
 These areas are `Lustre <https://en.wikipedia.org/wiki/Lustre_(file_system)>`__ filesystems. 
 
-They are are **faster** than :ref:`home_dir`, :ref:`data_dir` and :ref:`shared_dir` when dealing with larger files but 
+They are are **faster** than :ref:`home_dir` and :ref:`shared_dir` when dealing with larger files but 
 are **not performant when reading/writing lots of small files** 
 (:ref:`scratch_dir` are ideal for reading/writing lots of small temporary files within jobs).
 An example of how slow it can be for large numbers of small files is detailed `here <http://www.walkingrandomly.com/?p=6167>`__.
@@ -226,7 +226,7 @@ See also: :ref:`recovering_snapshots`.
 Automounting
 ^^^^^^^^^^^^
 
-Similar to :ref:`data_dir`, subdirectories beneath ``/shared`` are **mounted on demand** on the HPC systems: 
+Subdirectories beneath ``/shared`` are **mounted on demand** on the HPC systems: 
 they may not be visible if you simply list the contents of the ``/shared`` directory but 
 will be accessible if you ``cd`` (change directory) into a subdirectory e.g. ``cd /shared/my_group_file_share1``.
 
@@ -301,7 +301,7 @@ The documentation for the ``/shared`` storage service includes information on:
 For **jobs that need to read/write lots of small files** the most performant storage will be 
 the temporary storage on each node.
 
-This is because with :ref:`home_dir`, :ref:`data_dir`, :ref:`fastdata_dir` and :ref:`shared_dir`,
+This is because with :ref:`home_dir`, :ref:`fastdata_dir` and :ref:`shared_dir`,
 each time a file is accessed the filesystem needs to request ownership/permissions information from another server
 and for small files these overheads are proportionally high. 
 
@@ -312,7 +312,7 @@ As the local temporary storage areas are node-local storage and files/folders ar
 
 * any data used by the job must be **copied to** the local temporary store when the jobs starts. 
 * any output data stored in the local temporary store must also be **copied off** to another area before the job finishes.
-  (e.g. to :ref:`home_dir` or :ref:`data_dir`).
+  (e.g. to :ref:`home_dir`).
 
 Further conditions also apply:
 

--- a/hpc/installing-software.rst
+++ b/hpc/installing-software.rst
@@ -491,7 +491,7 @@ They do this by adding and removing software to the the ``PATH`` and ``LD_LIBRAR
 variables as well as set any additional required environment varibles, configuration or license files using 
 the ``module load`` or  ``module unload`` functionality.
 
-Module files are written in LUA on Stanage and TCL on Bessemer. To see examples, check the module paths with ``echo $MODULEPATH`` 
+Module files are written in Lua or TCL on Stanage and TCL on Bessemer. To see examples, check the module paths with ``echo $MODULEPATH`` 
 to get an idea of what these should look like.
 
 Further detail on the environment modules system in use on the clusters can be found on the 

--- a/hpc/installing-software.rst
+++ b/hpc/installing-software.rst
@@ -10,7 +10,7 @@ Installing software to the clusters
         :local:
   
 
-As :ref:`Stanage <stanage>`, :ref:`Bessemer <bessemer>` and :ref:`ShARC <sharc>`  are general purpose HPC clusters, 
+As :ref:`Stanage <stanage>` and :ref:`Bessemer <bessemer>` are general purpose HPC clusters, 
 we provide and maintain only the most essential and most popular applications on them.
 
 We are aware of our users' need to run applications that are specific to their own subject 
@@ -19,7 +19,7 @@ and special shared areas on the clusters for public use.
 
 This option should be seen as a service without support as we will expect such users to be able to 
 tackle the problems encountered during installations on their own. We will however help make such 
-software available to other Bessemer and ShARC users by copying/installing scripts to shared locations.
+software available to other Stanage and Bessemer users by copying/installing scripts to shared locations.
 
     :underline-bold:`Policy on user-installed software on University of Sheffield HPC systems`
 
@@ -190,12 +190,12 @@ where it is downloading the RPM from as well as the full name of the file downlo
 .. code-block:: console
     :emphasize-lines: 1
     
-    [user@sharc-node004 yumpackages]$ yumdownloader make
+    [user@node004 [stanage] yumpackages]$ yumdownloader make
     Loaded plugins: fastestmirror, priorities
     Loading mirror speeds from cached hostfile
     * epel: ftp.nluug.nl
     make-3.82-24.el7.x86_64.rpm                                | 421 kB  00:00:00     
-    [user@sharc-node004 yumpackages]$                  
+    [user@node004 [stanage] yumpackages]$                  
 
 This method will automatically check the package integrity and check it also has valid signatures.
 
@@ -227,7 +227,7 @@ This RPM can now be downloaded using the ``wget`` command on the cluster:
 .. code-block:: console
     :emphasize-lines: 1
 
-    [user@sharc-node004 yumpackages]$ wget http://mirror.centos.org/centos/7/os/x86_64/Packages/make-3.82-24.el7.x86_64.rpm
+    [user@node004 [stanage] yumpackages]$ wget http://mirror.centos.org/centos/7/os/x86_64/Packages/make-3.82-24.el7.x86_64.rpm
     --2021-07-15 12:19:18--  http://mirror.centos.org/centos/7/os/x86_64/Packages/make-3.82-24.el7.x86_64.rpm
     Resolving mirror.centos.org (mirror.centos.org)... 85.236.43.108, 2604:1380:2001:d00::3
     Connecting to mirror.centos.org (mirror.centos.org)|85.236.43.108|:80... connected.
@@ -248,7 +248,7 @@ package has been signed as trusted. We can do this with the ``rpm --checksig`` c
 .. code-block:: console
     :emphasize-lines: 1
 
-    [user@sharc-node004 yumpackages]$ rpm --checksig make-3.82-24.el7.x86_64.rpm 
+    [user@node004 [stanage] yumpackages]$ rpm --checksig make-3.82-24.el7.x86_64.rpm 
     make-3.82-24.el7.x86_64.rpm: rsa sha1 (md5) pgp md5 OK
 
 .. hint::
@@ -361,7 +361,7 @@ First clone the project using Git and the ``.git`` URL above as follows:
 .. code-block:: console
     :emphasize-lines: 1
 
-    [user@sharc-login4 make-git]$ git clone https://git.savannah.gnu.org/git/make.git
+    [user@login1 [stanage] make-git]$ git clone https://git.savannah.gnu.org/git/make.git
     Cloning into 'make'...
     remote: Counting objects: 16331, done.
     remote: Compressing objects: 100% (3434/3434), done.
@@ -376,8 +376,8 @@ The available tags and branches will be shown on the source code repository webp
 .. code-block:: console
     :emphasize-lines: 1,2
 
-    [user@sharc-login4 make-git]$ cd make
-    [user@sharc-login4 make]$ git checkout tags/4.3
+    [user@login1 [stanage] make-git]$ cd make
+    [user@login1 [stanage] make]$ git checkout tags/4.3
     Note: checking out 'tags/4.3'.
     
     You are in 'detached HEAD' state. You can look around, make experimental
@@ -410,7 +410,7 @@ With this in mind, the process is very similar for most packages and will requir
 load appropriate versions of GCC and / or CMake, potentially run a specific script (e.g. ./autogen.sh or 
 ./build), configure the build options and then compile the source code.
 
-e.g. compiling a more modern version of the ``make`` program on the ShARC cluster:
+e.g. compiling a more modern version of the ``make`` program on the Stanage cluster:
 
 .. note::
 
@@ -423,13 +423,13 @@ e.g. compiling a more modern version of the ``make`` program on the ShARC cluste
 
 .. code-block:: console
 
-    [user@sharc-login4 make]$ module load dev/gcc/8.2
-    [user@sharc-login4 make]$ cd make
-    [user@sharc-login4 make]$ mkdir ./build && cd ./build
-    [user@sharc-login4 make]$ ../configure --prefix=$HOME/software/installed/make
-    [user@sharc-login4 make]$ make -j $NSLOTS
-    [user@sharc-login4 make]$ make -j $NSLOTS check
-    [user@sharc-login4 make]$ make -j $NSLOTS install
+    [user@node001 [stanage] make]$ cd make
+    [user@node001 [stanage] make]$ mkdir ./build && cd ./build
+    [user@node001 [stanage] make]$ module load GCC/12.2.0
+    [user@node001 [stanage] make]$ ../configure --prefix=$HOME/software/installed/make
+    [user@node001 [stanage] make]$ make -j $NSLOTS
+    [user@node001 [stanage] make]$ make -j $NSLOTS check
+    [user@node001 [stanage] make]$ make -j $NSLOTS install
 
 * A ``build`` directory is made and then used to keep the source files unpolluted.
 * The ``../configure`` script is called from the directory above with the ``--prefix`` option set
@@ -483,7 +483,7 @@ Environment 'Modules' and their purpose
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 ‘Environment Modules’ are the mechanism by which much of the software is made available to the users 
-of the Bessemer and ShARC clusters. You are able to load and unload modules which make specific 
+of the Stanage and Bessemer clusters. You are able to load and unload modules which make specific 
 configurations of software available in a structured way which can avoid conflicts between different 
 versions of the same software.
 
@@ -491,7 +491,7 @@ They do this by adding and removing software to the the ``PATH`` and ``LD_LIBRAR
 variables as well as set any additional required environment varibles, configuration or license files using 
 the ``module load`` or  ``module unload`` functionality.
 
-Module files are written in TCL, please have a look at some of our modules in ``/usr/local/modulefiles/`` 
+Module files are written in LUA on Stanage and TCL on Bessemer. To see examples, check the module paths with ``echo $MODULEPATH`` 
 to get an idea of what these should look like.
 
 Further detail on the environment modules system in use on the clusters can be found on the 

--- a/hpc/transferring-files.rst
+++ b/hpc/transferring-files.rst
@@ -15,7 +15,7 @@ To transfer files to/from the clusters you can:
 * Use a `Research Storage fileshare <https://www.sheffield.ac.uk/it-services/research-storage/>`_ as common storage directly 
   accessible from your own machine and from the clusters.
 * Use a program like ``curl`` or ``wget`` to download files directly to the clusters.
-* Use a :ref:`flight session <flight-desktop>` on Stanage or   to open firefox and interactively download directly to clusters.
+* Open a Firefox browser and interactively download directly to clusters. Using a :ref:`flight session <flight-desktop>` on Stanage or interactive session on Bessemer 
 
 .. hint::
 

--- a/hpc/transferring-files.rst
+++ b/hpc/transferring-files.rst
@@ -15,7 +15,7 @@ To transfer files to/from the clusters you can:
 * Use a `Research Storage fileshare <https://www.sheffield.ac.uk/it-services/research-storage/>`_ as common storage directly 
   accessible from your own machine and from the clusters.
 * Use a program like ``curl`` or ``wget`` to download files directly to the clusters.
-* Open a Firefox browser and interactively download directly to clusters. Using a :ref:`flight session <flight-desktop>` on Stanage or interactive session on Bessemer 
+* Use a :ref:`flight session <flight-desktop>` on Stanage or interactive session on Bessemer, to open a Firefox browser and interactively download directly to clusters. 
 
 .. hint::
 

--- a/hpc/transferring-files.rst
+++ b/hpc/transferring-files.rst
@@ -15,7 +15,7 @@ To transfer files to/from the clusters you can:
 * Use a `Research Storage fileshare <https://www.sheffield.ac.uk/it-services/research-storage/>`_ as common storage directly 
   accessible from your own machine and from the clusters.
 * Use a program like ``curl`` or ``wget`` to download files directly to the clusters.
-* Use a ``qsh-vis`` session to open firefox and interactively download directly to clusters.
+* Use a :ref:`flight session <flight-desktop>` on Stanage or   to open firefox and interactively download directly to clusters.
 
 .. hint::
 

--- a/referenceinfo/environment-modules/creating-custom-modulefiles.rst
+++ b/referenceinfo/environment-modules/creating-custom-modulefiles.rst
@@ -36,7 +36,7 @@ variables with ``prepend-path``.
 
 
 Much like using a ``.bashrc`` file with the export command, we can add the required variables and directives 
-to a custom module file. For example, if called ``CustomModule`` and saved in ``/home/myusername/modules/`` may 
+to a custom module file. For example, if called ``CustomModule`` and saved in ``$HOME/modules/`` may 
 look something like:
 
 .. code-block:: TCL
@@ -58,8 +58,8 @@ look something like:
 
     ## Load any dependencies
     
-    module load dev/gcc/8.2
-    module load dev/cmake/3.17.1/gcc-8.2
+    module load GCC/10.2
+    module load CMake/3.18.4-GCCcore-10.2.0
 
     ## Set a program root directory TCL variable MY_PROGRAM_DIR to simplify prepend-path directives.
     ## **Reminder** setting an environment variable with setenv does not set the equivalent TCL variable!

--- a/referenceinfo/imports/filestores/shared-areas/recovering-from-snapshots.rst
+++ b/referenceinfo/imports/filestores/shared-areas/recovering-from-snapshots.rst
@@ -11,7 +11,7 @@ Recovering files from snapshots
    
    .. group-tab:: Bessemer
 
-    :ref:`home_dir`, :ref:`data_dir` and :ref:`shared_dir` are regularly :term:`snapshotted <Snapshotted storage>`.
+    :ref:`home_dir` and :ref:`shared_dir` are regularly :term:`snapshotted <Snapshotted storage>`.
     See above for details of the snapshot schedules per area.
     A subset of snapshots can be accessed by HPC users from the HPC systems themselves
     by *explicitly* browsing to hidden directories e.g.
@@ -20,8 +20,6 @@ Recovering files from snapshots
     | Storage area                                     | Parent directory of snapshots    |
     +==================================================+==================================+
     | :ref:`Home directory <home_dir>`                 | ``/home/$USER/.snapshot``        |
-    +--------------------------------------------------+----------------------------------+
-    | :ref:`Data directory <data_dir>`                 | ``/data/$USER/.snapshot``        |
     +--------------------------------------------------+----------------------------------+
     | A :ref:`Shared (project) directory <shared_dir>` | ``/shared/myproject1/.snapshot`` |
     +--------------------------------------------------+----------------------------------+
@@ -35,28 +33,3 @@ Recovering files from snapshots
 
     If you need help, please contact `research-it@sheffield.ac.uk <research-it@sheffield.ac.uk>`__.
 
-   .. group-tab:: ShARC
-
-    :ref:`home_dir`, :ref:`data_dir` and :ref:`shared_dir` are regularly :term:`snapshotted <Snapshotted storage>`.
-    See above for details of the snapshot schedules per area.
-    A subset of snapshots can be accessed by HPC users from the HPC systems themselves
-    by *explicitly* browsing to hidden directories e.g.
-
-    +--------------------------------------------------+----------------------------------+
-    | Storage area                                     | Parent directory of snapshots    |
-    +==================================================+==================================+
-    | :ref:`Home directory <home_dir>`                 | ``/home/$USER/.snapshot``        |
-    +--------------------------------------------------+----------------------------------+
-    | :ref:`Data directory <data_dir>`                 | ``/data/$USER/.snapshot``        |
-    +--------------------------------------------------+----------------------------------+
-    | A :ref:`Shared (project) directory <shared_dir>` | ``/shared/myproject1/.snapshot`` |
-    +--------------------------------------------------+----------------------------------+
-
-    From within per-snapshot directories you can access (read-only) copies of files/directories.
-    This allows you to attempt recover any files you might have accidentally modified or deleted recently.
-
-    Note that ``.snapshot`` directories are not visible when listing all hidden items within their parent directories
-    (e.g. using ``ls -a /home/$USER``): 
-    you need to explicitly ``cd`` into ``.snapshot`` directories to see/access them.
-
-    If you need help, please contact `research-it@sheffield.ac.uk <research-it@sheffield.ac.uk>`__.

--- a/referenceinfo/imports/filestores/shared-areas/sharc-bessemer-fastdata-managing-import.rst
+++ b/referenceinfo/imports/filestores/shared-areas/sharc-bessemer-fastdata-managing-import.rst
@@ -34,7 +34,7 @@ By running the command above, your area will only be accessible to you. If desir
     We reserve the right to change this policy without warning in order to ensure efficient running of the service.
 
     It is important to therefore not use *fastdata* areas for long-term storage and 
-    **copy important data** from these areas to areas suitable for longer-term storage (:ref:`home_dir`, :ref:`data_dir` or :ref:`shared_dir`).
+    **copy important data** from these areas to areas suitable for longer-term storage (:ref:`home_dir` or :ref:`shared_dir`).
 
 You can use the ``lfs``  command to find out which files in a *fastdata* directory are older than a certain number of days and hence approaching the time of deletion. 
 For example, if your username is ``te1st`` then you can find files 50 or more days old using: ::

--- a/referenceinfo/linux-shell/making-software-available-with-bashrc.rst
+++ b/referenceinfo/linux-shell/making-software-available-with-bashrc.rst
@@ -8,24 +8,18 @@ Making software available via the .bashrc file
 Software can be made available using your ``.bashrc`` file and adding/editing any 
 relevant environment variables. 
 
-.. warning::
-
-    Using your ``.bashrc`` file to make software available on ShARC will not work correctly in 
-    ``qsub`` batch jobs unless you supply the ``#$ -V`` SGE  argument in your submission script as 
-    non-interactive sessions **do not** source the ``.bashrc`` file.
-
 .. caution::
 
     We do not recommend editing your ``.bashrc`` file as this could result in corrupting your 
     shell environment. If possible make use of the :ref:`modules system <software_installs_modules>`.
 
-Assuming you have installed your software in a folder with the path ``/home/$USER/software/installs/mysoftware`` 
+Assuming you have installed your software in a folder with the path ``$HOME/software/installs/mysoftware`` 
 and the software has added a ``bin`` and ``lib`` folder. You would adjust your file to be:
 
 .. code-block:: bash
 
-    export PATH=/home/$USER/software/installs/mysoftware/bin:$PATH
-    export LD_LIBRARY_PATH=/home/$USER/software/installs/mysoftware/lib:$LD_LIBRARY_PATH
+    export PATH=$HOME/software/installs/mysoftware/bin:$PATH
+    export LD_LIBRARY_PATH=$HOME/software/installs/mysoftware/lib:$LD_LIBRARY_PATH
 
 If you are installing libraries and software that are dependencies, using 64 bit software, 
 need to set a variable for a license server/file etc... you may also need to use other environment 
@@ -33,33 +27,33 @@ variables pointing at different paths e.g.
 
 .. code-block:: bash
 
-    export LD_LIBRARY_PATH=/home/$USER/software/installs/mysoftware/lib:$LD_LIBRARY_PATH
-    export LD_LIBRARY_PATH=/home/$USER/software/installs/mysoftware/lib64:$LD_LIBRARY_PATH
+    export LD_LIBRARY_PATH=$HOME/software/installs/mysoftware/lib:$LD_LIBRARY_PATH
+    export LD_LIBRARY_PATH=$HOME/software/installs/mysoftware/lib64:$LD_LIBRARY_PATH
 
 .. code-block:: bash
 
-    export LIBRARY_PATH=/home/$USER/software/installs/mysoftware/lib:$LIBRARY_PATH
-    export LIBRARY_PATH=/home/$USER/software/installs/mysoftware/lib64:$LIBRARY_PATH
+    export LIBRARY_PATH=$HOME/software/installs/mysoftware/lib:$LIBRARY_PATH
+    export LIBRARY_PATH=$HOME/software/installs/mysoftware/lib64:$LIBRARY_PATH
 
 .. code-block:: bash
 
-    export PKG_CONFIG_PATH=/home/$USER/software/installs/mysoftware/lib/pkgconfig:$PKG_CONFIG_PATH
-    export PKG_CONFIG_PATH=/home/$USER/software/installs/mysoftware/lib64/pkgconfig:$PKG_CONFIG_PATH
-    export PKG_CONFIG_PATH=/home/$USER/software/installs/mysoftware/share/pkgconfig:$PKG_CONFIG_PATH
+    export PKG_CONFIG_PATH=$HOME/software/installs/mysoftware/lib/pkgconfig:$PKG_CONFIG_PATH
+    export PKG_CONFIG_PATH=$HOME/software/installs/mysoftware/lib64/pkgconfig:$PKG_CONFIG_PATH
+    export PKG_CONFIG_PATH=$HOME/software/installs/mysoftware/share/pkgconfig:$PKG_CONFIG_PATH
 
 .. code-block:: bash
 
-    export ACLOCAL_PATH=/home/$USER/software/installs/mysoftware/share/aclocal:$ACLOCAL_PATH
+    export ACLOCAL_PATH=$HOME/software/installs/mysoftware/share/aclocal:$ACLOCAL_PATH
 
 .. code-block:: bash
 
-    export CMAKE_PREFIX_PATH=/home/$USER/software/installs/mysoftware/:$CMAKE_PREFIX_PATH
+    export CMAKE_PREFIX_PATH=$HOME/software/installs/mysoftware/:$CMAKE_PREFIX_PATH
 
 .. code-block:: bash
 
-    export CPLUS_INCLUDE_PATH=/home/$USER/software/installs/mysoftware/include:$CPLUS_INCLUDE_PATH
-    export CPATH=/home/$USER/software/installs/mysoftware/include:$CPATH
+    export CPLUS_INCLUDE_PATH=$HOME/software/installs/mysoftware/include:$CPLUS_INCLUDE_PATH
+    export CPATH=$HOME/software/installs/mysoftware/include:$CPATH
 
 .. code-block:: bash
 
-    export MY_SOFTWARE_LICENSE_PATH=/home/$USER/software/licenses/mysoftware/license.lic
+    export MY_SOFTWARE_LICENSE_PATH=$HOME/software/licenses/mysoftware/license.lic

--- a/referenceinfo/linux-shell/the-bashrc-file.rst
+++ b/referenceinfo/linux-shell/the-bashrc-file.rst
@@ -16,8 +16,7 @@ The .bashrc file and its purpose
     
     If you find your shell environment is behaving oddly, programs are no longer available and 
     you suspect you may have corrupted your shell environment by editing the ``.bashrc`` file you 
-    can reset it with the command ``resetenv`` or ``/usr/local/scripts/resetenv`` then 
-    logging out and back in.
+    can reset it with the command ``resetenv`` then logging out and back in.
 
 
 The ``.bashrc`` file is a hidden script file located in a user's home directory which runs 

--- a/referenceinfo/linux-shell/unpacking-a-tarball.rst
+++ b/referenceinfo/linux-shell/unpacking-a-tarball.rst
@@ -14,12 +14,12 @@ For GZip compression the format of this command is:
 
 .. code-block:: console
 
-    [user@sharc-node004 tarpackages]$ tar -xzf mytarball.tar.gz
+    [user@node004 [stanage] tarpackages]$ tar -xzf mytarball.tar.gz
 
 For BZip compression the format of this command is: 
 
 .. code-block:: console
 
-    [user@sharc-node004 tarpackages]$ tar -xjf mytarball.tar.bz2
+    [user@node004 [stanage] tarpackages]$ tar -xjf mytarball.tar.bz2
 
 No example of this process is shown as the commands do not have terminal output unless there is an error.

--- a/referenceinfo/linux-shell/unpacking-an-rpm.rst
+++ b/referenceinfo/linux-shell/unpacking-an-rpm.rst
@@ -16,7 +16,7 @@ i.e. ``./usr/bin/gmake`` rather than ``/usr/bin/gmake``
     :emphasize-lines: 1
     :caption: The output below has been truncated to save space as indicated by \*SNIP\*.
 
-    [user@sharc-node004 yumpackages]$ rpm2cpio make-3.82-24.el7.x86_64.rpm | cpio -idmv
+    [user@node004 [stanage] yumpackages]$ rpm2cpio make-3.82-24.el7.x86_64.rpm | cpio -idmv
     ./usr/bin/gmake
     ./usr/bin/make
     ./usr/share/doc/make-3.82

--- a/referenceinfo/linux-shell/verifying-software-package-downloads.rst
+++ b/referenceinfo/linux-shell/verifying-software-package-downloads.rst
@@ -16,9 +16,9 @@ An example of checking the integrity of the Make RPM is shown below using the
 .. code-block:: console
     :emphasize-lines: 1,3
 
-    [user@sharc-node004 yumpackages]$ md5sum make-3.82-24.el7.x86_64.rpm 
+    [user@node004 [stanage] yumpackages]$ md5sum make-3.82-24.el7.x86_64.rpm 
     c678cfe499cd64bae54a09b43f600231  make-3.82-24.el7.x86_64.rpm
-    [user@sharc-node004 yumpackages]$ sha256sum make-3.82-24.el7.x86_64.rpm 
+    [user@node004 [stanage] yumpackages]$ sha256sum make-3.82-24.el7.x86_64.rpm 
     d4829aff887b450f0f3bd307f782e062d1067ca4f95fcad5511148679c14a668  make-3.82-24.el7.x86_64.rpm
 
 At this stage if being thorough you should check that any vendor or package maintainer signatures on 
@@ -31,7 +31,7 @@ demonstrated below with the GNU Make project's source tarball:
 .. code-block:: console
     :emphasize-lines: 1,7
     
-    [user@sharc-node004 make]$ gpg --verify make-4.3.tar.gz.sig make-4.3.tar.gz
+    [user@node004 [stanage] make]$ gpg --verify make-4.3.tar.gz.sig make-4.3.tar.gz
     gpg: Signature made Sun 19 Jan 2020 22:24:43 GMT using RSA key ID DB78137A
     gpg: Good signature from "Paul D. Smith <paul@mad-scientist.net>"
     gpg:                 aka "Paul D. Smith <psmith@gnu.org>"


### PR DESCRIPTION
PR to remove mentions of ShARC. 
Other smaller, more manageable PRs will remove or move the remaining ShARC related info to decommissioned section.
