### PR TITLE
Amend --user=$USER to --me where appropriate.

### DIFF
--- a/hpc/scheduler/index.rst
+++ b/hpc/scheduler/index.rst
@@ -211,7 +211,7 @@ Example:
 
 .. code-block:: console
 
-    [te1st@bessemer-login1 ~]$ squeue -u $USER
+    [te1st@bessemer-login1 ~]$ squeue --me
             JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)
             833300 interacti     bash   te1st  R      31:22      1 node001
     [te1st@bessemer-login1 ~]$ sattach 833300.0 
@@ -542,7 +542,7 @@ Example:
 
 .. code-block:: console
 
-    [te1st@login1 [stanage] ~]$ squeue -u $USER
+    [te1st@login1 [stanage] ~]$ squeue --me
             JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)
             833300 interacti     bash   te1st  R      31:22      1 node001
     [te1st@login1 [stanage] ~]$ sattach 833300.0 

--- a/referenceinfo/imports/scheduler/SLURM/common_commands/squeue_usage_import.rst
+++ b/referenceinfo/imports/scheduler/SLURM/common_commands/squeue_usage_import.rst
@@ -14,25 +14,31 @@ To limit this command to only display a single user's jobs the ``--user`` flag c
 
   $ squeue --user=$USER
 
+To limit this command to only display your own jobs, the ``--me`` flag can be used: 
+
+.. code-block:: console
+
+  $ squeue --me
+
 Further information without abbreviation can be shown by using the ``--long`` flag: 
 
 .. code-block:: console
 
-  $ squeue --user=$USER --long
+  $ squeue --me --long
 
 The ``squeue`` command also provides a method to calculate the estimated start time for a job by 
 using the ``--start`` flag: 
 
 .. code-block:: console
 
-  $ squeue --user=$USER --start
+  $ squeue --me --start
 
 When checking the status of a job you may wish to check for updates at a time interval. This can 
 be achieved by using the ``--iterate`` flag and a number of seconds: 
 
 .. code-block:: console
 
-  $ squeue --user=$USER --start --iterate=n_seconds
+  $ squeue --me --start --iterate=n_seconds
 
 You can stop this command by pressing ``Ctrl + C``.
 


### PR DESCRIPTION
I omitted doing the same changes for sacct as by default, sacct will only return the current user's info.