### PR TITLE
Move hw-accel-gfx to decom

### DIFF
--- a/decommissioned/sharc/hw-accel-gfx.rst
+++ b/decommissioned/sharc/hw-accel-gfx.rst
@@ -1,3 +1,6 @@
+.. include:: /referenceinfo/imports/decommissioned/decom_watermark.rst
+.. include:: /referenceinfo/imports/decommissioned/sharc_decom.rst
+
 .. _hw-accel-gfx:
 
 Hardware-accelerated graphics rendering (qsh-vis)

--- a/decommissioned/sharc/index.rst
+++ b/decommissioned/sharc/index.rst
@@ -29,6 +29,7 @@ If greater single-threaded performance or greater numbers of cores are required 
   groupnodes/index
   jupyterhub
   sharc-decommissioning
+  hw-accel-gfx
   FAQ_sharc
 
 * :ref:`sharc-software`

--- a/hpc/index.rst
+++ b/hpc/index.rst
@@ -24,6 +24,5 @@ This guide will get you set up using the University's clusters
    modules
    Choosing-appropriate-resources
    installing-software
-   hw-accel-gfx
    flight-desktop
    hpcgateway


### PR DESCRIPTION
Moving Hardware-accelerated graphics rendering (qsh-vis) to Decommissioned section