### PR TITLE
Public permissions warning

### DIFF
--- a/hpc/filestore.rst
+++ b/hpc/filestore.rst
@@ -174,7 +174,15 @@ There are separate ``fastdata`` areas on each cluster:
         chmod 755 /mnt/parscratch/users/$USER/public
         chmod 700 /mnt/parscratch/users/$USER/private
 
-   Note however that the ``public`` folder in this instance will be readable to **all users**!
+    Note however that the ``public`` folder in this instance will be readable to **all users**!
+
+..
+  Comment: There is a need for 755 on a truely public directory here rather than 705 due to the nature of the inherited effective permissions.
+  These effective permissions are determined based on the first class the user falls within in the order of user, group then others. Thus 705 would 
+  have the group's "0" at a higher priority than the other's "5" resulting in blocked access.
+
+  Selecting 705 would allow everyone but the chosen group access.
+  Selecting 755 would allow everyone access including the chosen group.
 
     :underline-bold:`Fastdata filestore backups and snapshots details`
 

--- a/hpc/filestore.rst
+++ b/hpc/filestore.rst
@@ -161,17 +161,20 @@ There are separate ``fastdata`` areas on each cluster:
 
     We recommend users create their own personal folder in the ``/fastdata`` area.  As this doesn't exist by default, you can create it with safe permissions by running the command: ::
 
-        mkdir -m 0700 /mnt/parscratch/users/$USER
+        mkdir /mnt/parscratch/users/$USER
+        chmod 700 /mnt/parscratch/users/$USER
 
-    By running the command above, your area will only be accessible to you. If desired, you could have a more sophisticated sharing scheme with private and public directories ::
+    By running the command above, your area will only be accessible to you. If desired, you could have a more sophisticated sharing scheme with private and fully public directories: ::
 
-        mkdir -m 0755 /mnt/parscratch/users/$USER
+        mkdir /mnt/parscratch/users/$USER
         mkdir /mnt/parscratch/users/$USER/public
         mkdir /mnt/parscratch/users/$USER/private
 
         chmod 755 /mnt/parscratch/users/$USER
         chmod 755 /mnt/parscratch/users/$USER/public
         chmod 700 /mnt/parscratch/users/$USER/private
+
+   Note however that the ``public`` folder in this instance will be readable to **all users**!
 
     :underline-bold:`Fastdata filestore backups and snapshots details`
 

--- a/hpc/filestore.rst
+++ b/hpc/filestore.rst
@@ -176,13 +176,13 @@ There are separate ``fastdata`` areas on each cluster:
 
     Note however that the ``public`` folder in this instance will be readable to **all users**!
 
-..
-  Comment: There is a need for 755 on a truely public directory here rather than 705 due to the nature of the inherited effective permissions.
-  These effective permissions are determined based on the first class the user falls within in the order of user, group then others. Thus 705 would 
-  have the group's "0" at a higher priority than the other's "5" resulting in blocked access.
+    ..
+      Comment: There is a need for 755 on a truely public directory here rather than 705 due to the nature of the inherited effective permissions.
+      These effective permissions are determined based on the first class the user falls within in the order of user, group then others. Thus 705 would 
+      have the group's "0" at a higher priority than the other's "5" resulting in blocked access.
 
-  Selecting 705 would allow everyone but the chosen group access.
-  Selecting 755 would allow everyone access including the chosen group.
+      Selecting 705 would allow everyone but the chosen group access.
+      Selecting 755 would allow everyone access including the chosen group.
 
     :underline-bold:`Fastdata filestore backups and snapshots details`
 

--- a/referenceinfo/imports/filestores/shared-areas/sharc-bessemer-fastdata-managing-import.rst
+++ b/referenceinfo/imports/filestores/shared-areas/sharc-bessemer-fastdata-managing-import.rst
@@ -17,6 +17,14 @@ By running the command above, your area will only be accessible to you. If desir
 
 Note however that the ``public`` folder in this instance will be readable to **all users**!
 
+..
+    Comment: There is a need for 755 on a truely public directory here rather than 705 due to the nature of the inherited effective permissions.
+    These effective permissions are determined based on the first class the user falls within in the order of user, group then others. Thus 705 would 
+    have the group's "0" at a higher priority than the other's "5" resulting in blocked access.
+
+    Selecting 705 would allow everyone but the chosen group access.
+    Selecting 755 would allow everyone access including the chosen group.
+
 :underline-bold:`Fastdata filestore backups and snapshots details`
 
 .. warning:: 

--- a/referenceinfo/imports/filestores/shared-areas/sharc-bessemer-fastdata-managing-import.rst
+++ b/referenceinfo/imports/filestores/shared-areas/sharc-bessemer-fastdata-managing-import.rst
@@ -2,17 +2,20 @@
 
 We recommend users create their own personal folder in the ``/fastdata`` area.  As this doesn't exist by default, you can create it with safe permissions by running the command: ::
 
-    mkdir -m 0700 /fastdata/$USER
+    mkdir /fastdata/$USER
+    chmod 700 /fastdata/$USER
 
-By running the command above, your area will only be accessible to you. If desired, you could have a more sophisticated sharing scheme with private and public directories ::
+By running the command above, your area will only be accessible to you. If desired, you could have a more sophisticated sharing scheme with private and fully public directories: ::
 
-    mkdir -m 0755 /fastdata/$USER
+    mkdir /fastdata/$USER
     mkdir /fastdata/$USER/public
     mkdir /fastdata/$USER/private
 
     chmod 755 /fastdata/$USER
     chmod 755 /fastdata/$USER/public
     chmod 700 /fastdata/$USER/private
+
+Note however that the ``public`` folder in this instance will be readable to **all users**!
 
 :underline-bold:`Fastdata filestore backups and snapshots details`
 


### PR DESCRIPTION
Add a little note to the docs about how setting up a public shared area on par scratch really is public.
Some tidying of formatting.