### PR TITLE
Refactoring connecting section

### DIFF
--- a/hpc/connecting.rst
+++ b/hpc/connecting.rst
@@ -1,42 +1,5 @@
 .. _connecting:
 
-Connecting to a cluster using myApps (web browser)
-==================================================
-
-For easier access to HPC resources,  IT Services runs an instance of Oracle Secure Global desktop called myApps to provide web-based access to CLI terminals and
-text editors within interactive sessions for the Bessemer and Training HPC clusters.
-
-
-.. important:: 
-    
-    The myApps service is only accessible on Bessemer (:underline-bold:`not` Stanage).
-
-In order to access the HPC clusters you must set up a `VPN connection and MFA <https://www.sheffield.ac.uk/it-services/vpn>`_. 
-Also see section **Whether/how you can connect** below. 
-
-The web browser method of access to Bessemer is recommended. This method works well for most browsers on all the common 
-computing platforms (Linux, Windows, Mac), however we recommend Chrome or Firefox.
-
-:underline-bold:`How to login to the myApps service`
-
-
-#. To login to Bessemer click the following link: `Connect via myAPPs Portal <https://myapps.shef.ac.uk/sgd/index.jsp?langSelected=en>`_
-#. If you are logging in for the first time, select Client Options on the myApps Portal page (bottom right) and 
-   then click the HTML5 option to run myApps entirely within your browser.
-
-   * Alternatively you can select option 1 to download and install the client for your system (Windows, Mac, or Linux).
-
-   .. hint::
-    Usernames to connect with all HPC services will be the same as those you use to login to MUSE :underline-bold:`not` the prefix on your email address.
-
-#. Enter your username and password on the myApps Portal login page.
-#. Once you have managed to login, you will see a window with Bessemer applications on the left hand panel.
-
-You can select a HPC interactive job or a HPC terminal.
-The interactive job is equivalent to a ``srun`` session on a worker node.
-The terminal is equivalent to a login node session from which you can use ``srun``.
-
-
 Connecting to a cluster using SSH
 =================================
 
@@ -91,130 +54,63 @@ The authentication requirements per cluster are summarised below:
     On our Stanage cluster: VPN + Password is needed to setup :ref:`TOTP MFA <mfa-totp-reference-info>`.
 
 
-Connecting with a password
---------------------------
+Connecting with a Password or SSH keys
+---------------------------------------
 
-If connecting using your password, MFA will be mandatory. Depending on the cluster, the type of MFA
-may be standard University `DUO MFA <https://sites.google.com/sheffield.ac.uk/mfa/home>`__, or :ref:`TOTP MFA <mfa-totp-reference-info>`.
-
-.. tabs::
-
-  .. group-tab:: Stanage
-
-    On the Stanage cluster, when you connect you will be prompted for your password and a verification code. 
-    Enter your password and the current TOTP code for your verification code. This process should look like the following in a terminal:
-
-    .. code-block:: console
-
-        ssh test@stanage.shef.ac.uk
-        Password: 
-        Verification code: 
-        Last login: Wed Apr 12 17:09:24 2023 from r.x.y.z
-        *****************************************************************************
-        *                           Stanage HPC cluster                             *
-        *                       The University Of Sheffield                         *
-        *                       https://docs.hpc.shef.ac.uk                         *
-        *                                                                           *
-        *               Unauthorised use of this system is prohibited.              *
-        *****************************************************************************
-        [test@login1 [stanage] ~]$
-
-    If you have not setup your Stanage TOTP MFA, please follow the steps published at: :ref:`stanage-totp-setup`
-  
-  .. group-tab:: Bessemer
-
-    On the Bessemer cluster, when you connect you will be prompted to via a push notification to your DUO device to approve access 
-    or must enter a one-time code from your University provided hardware token which is associated with your DUO account.
-
-    If you have not setup your University DUO MFA, please follow the steps published at: https://www.sheffield.ac.uk/it-services/mfa/set-mfa
-
-  
-  In addition, if you do not have MFA enabled on your account then you will not be able to login from off campus without using the VPN.
-
-Connecting with SSH keys
-------------------------
-
-If connecting using SSH public keys, the following policy applies around their use:
-
-    :underline-bold:`Policy on the use of SSH public key authentication:`
+.. tabs:: 
     
-    |br|
-    
-    * All access to TUOS HPC systems via SSH public/private keypairs should use private keys that were encrypted with a 
-      passphrase :underline-bold:`at creation time`.
-    * All SSH private keys used to access TUOS HPC systems must be never be decrypted and stored as plaintext :underline-bold:`on any computer, at any time`.
-    * Public key access should be from single-user machines (not shared machines) without good reason.
-    * SSH agent forwarding should not be used without good reason.
-    * Unencrypted private keys should not be stored on TUOS HPC systems.
+    .. tab:: With a Password 
+        If connecting using your password, MFA will be mandatory. Depending on the cluster, the type of MFA
+        may be standard University `DUO MFA <https://sites.google.com/sheffield.ac.uk/mfa/home>`__, or :ref:`TOTP MFA <mfa-totp-reference-info>`.
 
-To discuss exceptions to this policy please contact research-it@sheffield.ac.uk
+        .. tabs::
 
+            .. group-tab:: Stanage
 
-Suggested SSH clients
----------------------
+                On the Stanage cluster, when you connect you will be prompted for your password and a verification code. 
+                Enter your password and the current TOTP code for your verification code. This process should look like the following in a terminal:
 
-.. _mobaxterm_connecting_profile_setup:
+                .. code-block:: console
 
-SSH client software on Windows
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                    ssh test@stanage.shef.ac.uk
+                    Password: 
+                    Verification code: 
+                    Last login: Wed Apr 12 17:09:24 2023 from r.x.y.z
+                    *****************************************************************************
+                    *                           Stanage HPC cluster                             *
+                    *                       The University Of Sheffield                         *
+                    *                       https://docs.hpc.shef.ac.uk                         *
+                    *                                                                           *
+                    *               Unauthorised use of this system is prohibited.              *
+                    *****************************************************************************
+                    [test@login1 [stanage] ~]$
 
-We recommend the use of MobaXterm on Windows systems and users will find MobaXterm available on the University's managed desktops by default.
-For personal systems you can download and install the *Installer edition* of `MobaXterm <https://mobaxterm.mobatek.net/download-home-edition.html>`_.
+                If you have not setup your Stanage TOTP MFA, please follow the steps published at: :ref:`stanage-totp-setup`
+            
+            .. group-tab:: Bessemer
 
-After starting MobaXterm you should see something like this:
+                On the Bessemer cluster, when you connect you will be prompted to via a push notification to your DUO device to approve access 
+                or must enter a one-time code from your University provided hardware token which is associated with your DUO account.
 
-.. image:: /images/mobaxterm-welcome.png
-   :width: 100%
-   :align: center
+                If you have not setup your University DUO MFA, please follow the steps published at: https://www.sheffield.ac.uk/it-services/mfa/set-mfa
 
+            
+            In addition, if you do not have MFA enabled on your account then you will not be able to login from off campus without using the VPN.
 
-You should create a session profile for your login for each cluster by clicking *Session* in the top left, and then *SSH*. 
+    .. tab::  With SSH keys
 
-#. Enter the details for the cluster in the *Remote host* box, choosing ``stanage.shef.ac.uk`` or ``bessemer.shef.ac.uk``. 
-#. Now click the *Specify Username* checkmark and enter your username.
-#. Please ensure that the checkmark for *X11 Forwarding* is ticked or GUI applications will be unable to open.
-#. Please ensure that that *Use SCP protocol* is also ticked (or depending on MobaXterm version select *SCP (enhanced speed)* option from the *SSH-browser type* dropdown menu) .
-#. Now click *OK* to save your session profile.
+        If connecting using SSH public keys, the following policy applies around their use:
 
-You should add a session for each cluster.
+            :underline-bold:`Policy on the use of SSH public key authentication:`
+                                  
+            * All access to TUOS HPC systems via SSH public/private keypairs should use private keys that were encrypted with a passphrase :underline-bold:`at creation time`.
+            * All SSH private keys used to access TUOS HPC systems must be never be decrypted and stored as plaintext :underline-bold:`on any computer, at any time`.
+            * Public key access should be from single-user machines (not shared machines) without good reason.
+            * SSH agent forwarding should not be used without good reason.
+            * Unencrypted private keys should not be stored on TUOS HPC systems.
 
-.. hint::
-   Alternatively you can use a terminal within MobaXterm for SSHing to remote machines but
-   be warned that this may cause authentication issues when trying to connect to Stanage using MFA.
+        To discuss exceptions to this policy please contact research-it@sheffield.ac.uk
 
-You can now double click on this session profile to start connecting at which point you will be prompted for your username, password 
-and then with a Duo MFA prompt (or a request for your TOTP verification code on Stanage). Please enter these details and your terminal will connect as shown below.
-
-You **may** be asked to submit your username and password with a second MFA prompt in order for the file browser to work correctly. On a successful 
-login you should be presented with a screen like the below:
-
-.. image:: /images/mobaxterm-terminal.png
-   :width: 100%
-   :align: center
-
-|br|
-
-.. note::
-
-    When you login to a cluster you reach one of two login nodes.
-    You **should not** run applications on the login nodes.
-    Running the interactive job command, ``srun --pty bash -i`` (Stanage & Bessemer), gives you an interactive terminal
-    on one of the many worker nodes in the clusters.
-    
-Running commands from a terminal (from the command-line) may initially be
-unfamiliar to Windows users but this is the recommended approach for
-running commands on Sheffield HPC clusters as
-it is the idiomatic way of interfacing with the Linux clusters.
-
-SSH client software on Mac OS/X and Linux
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Linux and macOS (OS X) both typically come with a command-line SSH client pre-installed.
-
-If you are using macOS and want to be able to run graphical applications on the clusters then
-you need to install the latest version of the `XQuartz <https://www.xquartz.org/>`_ *X Windows server*.
-
-Open a terminal (e.g. *Gnome Terminal* on Linux or *Terminal* on macOS) and then go to :ref:`ssh`.
 
 .. _ssh:
 
@@ -227,21 +123,34 @@ Establishing a SSH connection
 
 
 Once you have a terminal open run the following command to
-log in to a cluster: ::
+log in to a cluster:
 
-    ssh -X $USER@$CLUSTER_NAME.shef.ac.uk
+.. tabs::
+
+    .. tab:: Windows/Linux
+
+        .. code-block:: console
+
+            ssh -X $USER@$CLUSTER_NAME.shef.ac.uk
+
+    .. tab:: macOS
+
+        .. code-block:: console
+        
+            ssh -X $USER@$CLUSTER_NAME.shef.ac.uk
+
+        .. note::
+
+            If this fails then:
+
+            * Check that your `XQuartz <https://www.xquartz.org/>`_ is up to date then try again *or*
+            * Try again with ``-Y`` instead of ``-X``
 
 Here you need to:
 
 * replace ``$USER`` with your IT Services username (e.g. ``te1st``)
 * replace ``$CLUSTER_NAME`` with ``stanage`` or ``bessemer``.
 
-.. note::
-
-    **macOS users**: if this fails then:
-
-    * Check that your `XQuartz <https://www.xquartz.org/>`_ is up to date then try again *or*
-    * Try again with ``-Y`` instead of ``-X``
 
 After typing in this command hit enter to start connecting at which point you will be prompted 
 for your username, password and then with a Duo MFA prompt. 
@@ -302,14 +211,38 @@ This should give you a prompt resembling the one below:
         [te1st@bessemer-node001 ~]$ 
 
 
-
-
 .. note::
 
     When you login to a cluster you reach one of two login nodes.
     You **should not** run applications on the login nodes.
     Running the interactive job command, ``srun --pty bash -i`` (Stanage & Bessemer), gives you an interactive terminal
     on one of the many worker nodes in the clusters.
+    
+Running commands from a terminal (from the command-line) may initially be
+unfamiliar to Windows users but this is the recommended approach for
+running commands on Sheffield HPC clusters as
+it is the idiomatic way of interfacing with the Linux clusters.
+
+Suggested SSH clients
+---------------------
+
+SSH client software on Windows
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+We recommend the use of MobaXterm on Windows systems and users will find MobaXterm available on the University's managed desktops by default.
+For personal systems you can download and install the *Installer edition* of `MobaXterm <https://mobaxterm.mobatek.net/download-home-edition.html>`_.
+
+- :ref:`Setting up Profiles in MobaXterm <mobaxterm_connecting_profile_setup>`.
+
+SSH client software on Mac OS/X and Linux
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Linux and macOS (OS X) both typically come with a command-line SSH client pre-installed.
+
+If you are using macOS and want to be able to run graphical applications on the clusters then
+you need to install the latest version of the `XQuartz <https://www.xquartz.org/>`_ *X Windows server*.
+
+Open a terminal (e.g. *Gnome Terminal* on Linux or *Terminal* on macOS) and then go to :ref:`ssh`.
 
 
 ---------

--- a/hpc/index.rst
+++ b/hpc/index.rst
@@ -15,6 +15,7 @@ This guide will get you set up using the University's clusters
 
    what-is-hpc
    accounts
+   myapps
    connecting
    mfa
    filestore

--- a/hpc/myapps.rst
+++ b/hpc/myapps.rst
@@ -1,0 +1,37 @@
+.. _myapps:
+
+Connecting to Bessemer using myApps (web browser)
+==================================================
+
+For easier access to HPC resources,  IT Services runs an instance of Oracle Secure Global desktop called myApps to provide web-based access to CLI terminals and
+text editors within interactive sessions for the Bessemer and Training HPC clusters.
+
+
+.. important:: 
+    
+    The myApps service is only accessible on Bessemer (:underline-bold:`not` Stanage).
+
+In order to access the HPC clusters you must set up a `VPN connection and MFA <https://www.sheffield.ac.uk/it-services/vpn>`_. 
+Also see section **Whether/how you can connect** below. 
+
+The web browser method of access to Bessemer is recommended. This method works well for most browsers on all the common 
+computing platforms (Linux, Windows, Mac), however we recommend Chrome or Firefox.
+
+:underline-bold:`How to login to the myApps service`
+
+
+#. To login to Bessemer click the following link: `Connect via myAPPs Portal <https://myapps.shef.ac.uk/sgd/index.jsp?langSelected=en>`_
+#. If you are logging in for the first time, select Client Options on the myApps Portal page (bottom right) and 
+   then click the HTML5 option to run myApps entirely within your browser.
+
+   * Alternatively you can select option 1 to download and install the client for your system (Windows, Mac, or Linux).
+
+   .. hint::
+    Usernames to connect with all HPC services will be the same as those you use to login to MUSE :underline-bold:`not` the prefix on your email address.
+
+#. Enter your username and password on the myApps Portal login page.
+#. Once you have managed to login, you will see a window with Bessemer applications on the left hand panel.
+
+You can select a HPC interactive job or a HPC terminal.
+The interactive job is equivalent to a ``srun`` session on a worker node.
+The terminal is equivalent to a login node session from which you can use ``srun``.

--- a/referenceinfo/connecting/index.rst
+++ b/referenceinfo/connecting/index.rst
@@ -1,0 +1,13 @@
+
+**********************************
+Connecting Reference Info
+**********************************
+
+This sub-tree contains reference information about connecting to our clusters.
+
+
+.. toctree::
+  :maxdepth: 1
+  :glob:
+
+  mobaxterm

--- a/referenceinfo/connecting/mobaxterm.rst
+++ b/referenceinfo/connecting/mobaxterm.rst
@@ -1,0 +1,39 @@
+.. _mobaxterm_connecting_profile_setup:
+
+Setting up Profiles in MobaXterm
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+We recommend the use of MobaXterm on Windows systems and users will find MobaXterm available on the University's managed desktops by default.
+For personal systems you can download and install the *Installer edition* of `MobaXterm <https://mobaxterm.mobatek.net/download-home-edition.html>`_.
+
+
+After starting MobaXterm you should see something like this:
+
+.. image:: /images/mobaxterm-welcome.png
+   :width: 100%
+   :align: center
+
+
+You should create a session profile for your login for each cluster by clicking *Session* in the top left, and then *SSH*. 
+
+#. Enter the details for the cluster in the *Remote host* box, choosing ``stanage.shef.ac.uk`` or ``bessemer.shef.ac.uk``. 
+#. Now click the *Specify Username* checkmark and enter your username.
+#. Please ensure that the checkmark for *X11 Forwarding* is ticked or GUI applications will be unable to open.
+#. Please ensure that that *Use SCP protocol* is also ticked (or depending on MobaXterm version select *SCP (enhanced speed)* option from the *SSH-browser type* dropdown menu) .
+#. Now click *OK* to save your session profile.
+
+You should add a session for each cluster.
+
+.. hint::
+   Alternatively you can use a terminal within MobaXterm for SSHing to remote machines but
+   be warned that this may cause authentication issues when trying to connect to Stanage using MFA.
+
+You can now double click on this session profile to start connecting at which point you will be prompted for your username, password 
+and then with a Duo MFA prompt (or a request for your TOTP verification code on Stanage). Please enter these details and your terminal will connect as shown below.
+
+You **may** be asked to submit your username and password with a second MFA prompt in order for the file browser to work correctly. On a successful 
+login you should be presented with a screen like the below:
+
+.. image:: /images/mobaxterm-terminal.png
+   :width: 100%
+   :align: center

--- a/referenceinfo/index.rst
+++ b/referenceinfo/index.rst
@@ -18,4 +18,5 @@ This section should be used to look for a quick references to very specific info
   linux-shell/index
   scheduler/index
   computer-architecture/index
+  connecting/index
   mfa/index


### PR DESCRIPTION
Refactors connecting section of docs.

- Moved setting up MobaXterm profiles to reference info and linked.
- Made use of tabs where appropriate.
- Removed some duplication.
- Suggested SSH Clients now comes after Establishing a SSH connection