### PR TITLE
Correct RIT HPC course labels

### DIFF
--- a/help.rst
+++ b/help.rst
@@ -43,8 +43,8 @@ HPC training?
 IT Services' Research and Innovation courses
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If you are new to the cluster, have never used Linux or HPC before you should attend the RIT 101 (Introduction to Linux), 
-102 (Linux Shell Scripting Tutorial) and 103 (Introduction to Running Software on the HPC) courses.
+If you are new to the cluster, have never used Linux or HPC before you should attend the RIT 101 (Introduction to Linux)
+and RIT 102 (High-Performance Computing) courses.
 
 These courses are very popular and run through both semesters. You can find details and how to register at the website: https://sites.google.com/sheffield.ac.uk/research-training/ (Only accessible with the VPN turned on.)
 

--- a/hpc/what-is-hpc.rst
+++ b/hpc/what-is-hpc.rst
@@ -255,6 +255,6 @@ https://www.sheffield.ac.uk/it-services/codeofpractice/core
 How do I get started?
 ---------------------
 
-Potential users should first register and attend training courses RIT 101 to 103 on
+Potential users should first register and attend training courses RIT 101 and RIT 102 on
 `IT Services' Research and Innovation course details and registration information website <https://sites.google.com/sheffield.ac.uk/research-training/>`_
 (VPN must be turned on) and should then :ref:`request an account <accounts>`.


### PR DESCRIPTION
Remove references to RIT 103 and correct RIT 102 course name

#2009 