### PR TITLE
Add robots.txt to webroot.

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -60,6 +60,9 @@ jobs:
       - name: Add Google Search console site verification
         run: |
           cp gsv/google92a5d9499987ed3e.html _build/html/google92a5d9499987ed3e.html
+      - name: Add robots.txt
+        run: |
+          cp robots-txt/robots.txt _build/html/robots.txt
       - name: Setup Pages
         uses: actions/configure-pages@v2
       # Make the artifact which is used to deploy.

--- a/robots-txt/robots.txt
+++ b/robots-txt/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://docs.hpc.shef.ac.uk/en/latest/sitemap.xml


### PR DESCRIPTION
As above. This should ensure other search engines find the sitemap.