### PR TITLE
Update interactive import

### DIFF
--- a/referenceinfo/imports/scheduler/SLURM/common_commands/srun_start_interactive_session_import_stanage.rst
+++ b/referenceinfo/imports/scheduler/SLURM/common_commands/srun_start_interactive_session_import_stanage.rst
@@ -1,2 +1,5 @@
-After connecting to Stanage (see :ref:`ssh`),  start an interactive session with the 
-:code:`srun --pty bash -i` command.
+After connecting to Stanage (see :ref:`ssh`),  start an interactive session with the following command:
+
+.. code-block:: bash
+
+  srun --pty bash -i


### PR DESCRIPTION
Closes the issue #2048.

https://docs.hpc.shef.ac.uk/en/latest/hpc/flight-desktop.html#usage-instructions

In the file `/referenceinfo/imports/scheduler/SLURM/common_commands/srun_start_interactive_session_import_stanage.rst` , the command `srun --pty bash -i` was included as an inline code. It caused inconsistency in the document as all other codes are included as code blocks. This issue appears in multiple locations within the Stanage section.