### PR TITLE
Fix typo in FAQ

### DIFF
--- a/FAQs.rst
+++ b/FAQs.rst
@@ -195,9 +195,9 @@ Following are ways to fix too much time requested:
 .. tabs::
 
    .. group-tab:: Stanage
-        The maximum run time for Bessemer is 168 hours.
+        The maximum run time for Stanage is 96 hours.
 
-        You can get an estimate for when your job will run on Bessemer using:
+        You can get an estimate for when your job will run on Stanage using:
 
         .. code-block:: console
 
@@ -215,7 +215,7 @@ Following are ways to fix too much time requested:
 
                 squeue -j <jobid> --long
 
-        Alternatively, delete the job using scancel and re-submit with the new max runtime
+        Alternatively, delete the job using ``scancel`` and re-submit with the new max runtime.
 
    .. group-tab:: Bessemer
 
@@ -239,7 +239,7 @@ Following are ways to fix too much time requested:
 
                 squeue -j <jobid> --long
 
-        Alternatively, delete the job using scancel and re-submit with the new max runtime
+        Alternatively, delete the job using ``scancel`` and re-submit with the new max runtime.
 
 
 ------


### PR DESCRIPTION
Fixed typo in [Frequently Asked Questions — Sheffield HPC Documentation](https://docs.hpc.shef.ac.uk/en/latest/FAQs.html#i-ve-submitted-a-job-but-it-s-not-running). It is referring to Bessemer in the Stanage Tab.