### PR TITLE
Add attention - Bessemer service at risk

### DIFF
--- a/global.rst
+++ b/global.rst
@@ -11,3 +11,6 @@
 .. role:: underline-bold
     :class: underline-bold
 
+.. attention::
+
+    **SERVICE RISK: Bessemer will be at risk from 9am on 15th July until 5pm on 19th July 2024**


### PR DESCRIPTION
Adds 'Attention' callout to top of all pages. 

**SERVICE RISK: Bessemer will be at risk from 9am on 15th July until 5pm on 19th July 2024**