### PR TITLE
Update libsndfile command for readability

### DIFF
--- a/stanage/software/libs/libsndfile.rst
+++ b/stanage/software/libs/libsndfile.rst
@@ -61,4 +61,4 @@ Using the command :
 
 .. code-block:: 
 
-    gcc list_formats.c `pkg-config --libs sndfile` -o output
+    gcc list_formats.c $(pkg-config --libs sndfile) -o output


### PR DESCRIPTION
Updated libsndfile command on Stanage to 
```bash
gcc list_formats.c $(pkg-config --libs sndfile) -o output
```

Please refer to Issue #2153 for more details. 