### PR TITLE
Add parallel EL9-beta build to site.

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -21,11 +21,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Single deploy job since we're just deploying the once to Github Pages.
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+  # Build pages per branch we want!
+  build-latest:
     runs-on: ubuntu-latest
     strategy:
       # Spawn and run a job for Python 3.10 version.
@@ -63,15 +60,97 @@ jobs:
       - name: Add robots.txt
         run: |
           cp robots-txt/robots.txt _build/html/robots.txt
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-      # Make the artifact which is used to deploy.
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          # Make the artifact with the HTML build directory.
+          name: latest
           path: '_build/html'
-      # Now deploy with the artifact.
+
+  build-el9-beta:
+    runs-on: ubuntu-latest
+    strategy:
+      # Spawn and run a job for Python 3.10 version.
+      matrix:
+        python: ["3.10"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: EL9-beta
+      # Install Python.
+      - name: Set up a version of Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+      # Install Tox for build stage.
+      - name: Upgrade pip and install Tox
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install tox
+      # Run build stage - py37 should suffice.
+      - name: Build the pages
+        run: tox -e py310
+      # Match old RTD directories pathing.
+      - name: Move built files
+        run: |
+          mkdir -p _build/html/en/el9-beta
+          cd _build/html/
+          find . -mindepth 1 -maxdepth 1 -not -name en -exec mv -t en/el9-beta {} +
+          cd ../../
+      - name: Add webroot redirect HTML index page.
+        run: |
+          cp rtd-root-redirect.html _build/html/index.html
+      - name: Add Google Search console site verification
+        run: |
+          cp gsv/google92a5d9499987ed3e.html _build/html/google92a5d9499987ed3e.html
+      - name: Add robots.txt
+        run: |
+          cp robots-txt/robots.txt _build/html/robots.txt
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          name: el9-beta
+          path: '_build/html'
+
+  deploy-static-site:
+    # Don't deploy before the previous steps build the pages.
+    needs: [build-latest, build-el9-beta]
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      # Download the previously generated artifacts.
+      - uses: actions/download-artifact@master
+        with:
+          name: latest
+          path: '_build/latest'
+    
+      - uses: actions/download-artifact@master
+        with:
+          name: el9-beta
+          path: '_build/el9-beta'
+
+      - name: Ensure _build/html folder exists
+        run: mkdir -p _build/html
+
+      # Extract the previously generated artifacts.
+      - name: Extract latest build to _build/html
+        run: tar -xf _build/latest/artifact.tar -C _build/html
+
+      - name: Extract el9-beta build to _build/html
+        run: tar -xf _build/el9-beta/artifact.tar -C _build/html
+
+      # Make the GH pages artifact which is used to deploy.
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          # Make the artifact with the HTML build directory we just extracted everything to.
+          name: github-pages
+          path: '_build/html'
+      # Now deploy the GH pages artifact.
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
Amended workflow now builds a beta branch and also makes this available via ``en/el9-beta`` rather than ``en/latest`` assuming I've not fluffed anything.