### PR TITLE
El9 ansys dr

### DIFF
--- a/referenceinfo/ANSYS/typical_executable_paths.rst
+++ b/referenceinfo/ANSYS/typical_executable_paths.rst
@@ -4,12 +4,12 @@
 ANSYS Packages File Paths
 -------------------------
 
-This page contains a copy of the typical file paths for major ANSYS packages where ``$VERSION`` refers to an ANSYS version, e.g. 202, 190 etc... and ``$DOT_VER`` refers to the same version but with the dot structure e.g. 20.2 19.0 .
+This page contains a copy of the typical file paths for major ANSYS packages where ``$VERSION`` refers to an ANSYS version, e.g. 2023R2, 2023R1 190 etc... and ``$DOT_VER`` refers to the same version but with the dot structure e.g. 232, 231, etc .
 
 The ANSYS directories on the clusters are as follows:
 
   * Bessemer: ``/usr/local/packages/live/noeb/ANSYS/``
-  * Stanage: ``/opt/apps/testapps/el7/software/staging/ANSYS/``
+  * Stanage: ``/opt/apps/tuos/common/software/live/ANSYS/``
 
 
 .. list-table:: Common ANSYS Executable Paths

--- a/referenceinfo/imports/software/ansys/module-load-list-stanage.rst
+++ b/referenceinfo/imports/software/ansys/module-load-list-stanage.rst
@@ -11,3 +11,5 @@ After connecting to Stanage (see :ref:`ssh`),  you can start an :ref:`interactiv
    module load ANSYS/2022R2
    module load ANSYS/2023R1
    module load ANSYS/2023R2
+
+Note that to use the ANSYS GUI you will need to be in a :ref:`flight graphical session on Stanage <flight-desktop>`.

--- a/referenceinfo/imports/software/ansys/module-load-list-stanage.rst
+++ b/referenceinfo/imports/software/ansys/module-load-list-stanage.rst
@@ -8,7 +8,6 @@ Module loading
 
 After connecting to Stanage (see :ref:`ssh`),  you can start an :ref:`interactive session <submit_interactive_stanage>` or submit a batch job using ANSYS programs activating them and making them available with one of the module load commands below: ::
 
-   module load ANSYS/19.2
    module load ANSYS/2022R2
    module load ANSYS/2023R1
    module load ANSYS/2023R2

--- a/referenceinfo/imports/software/ansys/stanage-sidebar.rst
+++ b/referenceinfo/imports/software/ansys/stanage-sidebar.rst
@@ -7,6 +7,6 @@
 
 .. sidebar:: ANSYS
 
-   :Versions: 19.2, 2022R2, 2023R1, 2023R2
+   :Versions: 2022R2, 2023R1, 2023R2
    :Dependencies: UDFs / User subroutines will also need either the GCC or Intel C compiler with correct versions.
    :URL: http://www.ansys.com

--- a/stanage/software/apps/ansys/fluent.rst
+++ b/stanage/software/apps/ansys/fluent.rst
@@ -32,8 +32,7 @@ Interactive jobs
 
 .. include:: /referenceinfo/imports/scheduler/SLURM/common_commands/srun_start_interactive_session_import_stanage.rst
 
-If desired, the ANSYS Workbench GUI executable can be launched with the  ``runwb2`` command.
-To use more than a single core, you should write a batch job script and fluent journal file for submission to the batch queues.
+If desired, the ANSYS Workbench GUI executable can be launched with the  ``runwb2`` command. Note that to use the ANSYSEM GUI you will need to be in a :ref:`flight graphical session on Stanage <flight-desktop>`. To use more than a single core, you should write a batch job script and fluent journal file for submission to the batch queues.
 
 --------------------
 

--- a/stanage/software/apps/ansys/index.rst
+++ b/stanage/software/apps/ansys/index.rst
@@ -91,4 +91,4 @@ The following instruction should be inserted at line 2433 (tbc) in ``anssh.ini``
 
 Module files are available below:
 
-- :download:`/opt/apps/testapps/el7/modules/staging/all/ANSYS/2022R2.lua  </stanage/software/modulefiles/ansys/22.2/2022R2.lua>`
+- :download:`/opt/apps/tuos/common/modules/live/all/ANSYS/2022R2.lua  </stanage/software/modulefiles/ansys/22.2/2022R2.lua>`

--- a/stanage/software/apps/ansys/mechanical.rst
+++ b/stanage/software/apps/ansys/mechanical.rst
@@ -32,8 +32,7 @@ Interactive jobs
 
 You can load an ANSYS module above and then start the ANSYS mechanical launcher program by running the ``launcher`` command.
 
-If desired, the ANSYS Workbench GUI executable can be launched with the  ``runwb2`` command.
-To use more than a single core, you should write a batch job script and ANSYS mechanical APDL script file for submission to the batch queues.
+If desired, the ANSYS Workbench GUI executable can be launched with the  ``runwb2`` command. Note that to use the ANSYSEM GUI you will need to be in a :ref:`flight graphical session on Stanage <flight-desktop>`. To use more than a single core, you should write a batch job script and ANSYS mechanical APDL script file for submission to the batch queues.
 
 --------------------
 


### PR DESCRIPTION
Mods to Ansys documentation:

modules available for Rocky9
include flight desktop for interactive sessions for fluent & mech
modify referenceinfo/sidebar
modify referenceinfo/module load