### PR TITLE
Update PETSc EL9 doc

### DIFF
--- a/stanage/software/libs/PETSc.rst
+++ b/stanage/software/libs/PETSc.rst
@@ -1,5 +1,5 @@
 .. |softwarename| replace:: PETSc
-.. |currentver| replace:: 3.20.1
+.. |currentver| replace:: 3.19.2
 
 .. _petsc_stanage: 
 
@@ -8,9 +8,9 @@ PETSc
 
 .. sidebar::  |softwarename|
 
-   :Versions: |currentver|
-   :URL: https://petsc.org/release/
-   :Documentation: https://petsc.org/release/manual/
+    :Versions: |currentver|
+    :URL: https://petsc.org/release/
+    :Documentation: https://petsc.org/release/manual/
 
 The Portable, Extensible Toolkit for Scientific Computation (PETSc, pronounced PET-see; the S is silent) is a toolkit for Scientific Computation, is a suite of data structures and routines for the scalable (parallel) solution of scientific applications modeled by partial differential equations. It supports MPI, and GPUs through CUDA, HIP or OpenCL, as well as hybrid MPI-GPU parallelism; it also supports the NEC-SX Tsubasa Vector Engine. PETSc (sometimes called PETSc/TAO) also contains the TAO, the Toolkit for Advanced Optimization, software library.PETSc is developed as open-source, requests and contributions are welcome.
 
@@ -22,8 +22,8 @@ PETSc can be activated using one of:
 
 .. code-block:: bash
 
-   module load PETSc/3.20.1-foss-2022b
-   module load PETSc/3.17.4-foss-2022b
+    module load PETSc/3.19.2-foss-2022b
+    module load PETSc/3.17.4-foss-2022a
 
 
 
@@ -34,25 +34,25 @@ These are primarily for system administrators.
 Version 3.17.4
 ^^^^^^^^^^^^^^^
 
-The none GPU installation was done using the custom easybuild ``PETSc-3.17.4-foss-2022b.eb``. This will also be submited to the official easybuild config github.
+The non-GPU installation was done using the custom easybuild ``PETSc/3.17.4-foss-2022a.eb``. This will also be submited to the official easybuild config GitHub.
 
 Version 3.20.1
 ^^^^^^^^^^^^^^^
 
-The none GPU installation was done using the custom easybuild ``PETSc-3.20.1-foss-2022b.eb``. This will also be submited to the official easybuild config github.
+The non-GPU installation was done using the custom easybuild ``PETSc/3.19.2-foss-2022b.eb``. This will also be submited to the official easybuild config GitHub.
 
 
 Testing
 -------
 
-Version 3.20.1 && 3.17.4
-^^^^^^^^^^^^^^^^^^^^^^^^
+Version 3.19.2 & 3.17.4
+^^^^^^^^^^^^^^^^^^^^^^^
 
 Load the desired PETSc module.
 
 Create a file called example.c
 
-.. code-block:: bash
+.. code-block:: c
 
     static char help[] = "Simple PETSc example demonstrating vector operations.\n\n";
 


### PR DESCRIPTION
Since the number of available versions has been updated from 4 to 2 in R9, the [PETSc](https://docs.hpc.shef.ac.uk/en/latest/stanage/software/libs/PETSc.html#petsc) section in docs should be updated accordingly.

Details are as follow:
```shell
# old
PETSc/3.14.4-foss-2020b
PETSc/3.17.4-foss-2022a
PETSc/3.17.4-foss-2022b
PETSc/3.20.1-foss-2022b

# new
PETSc/3.17.4-foss-2022a
PETSc/3.19.2-foss-2022b
```