### PR TITLE
Bump requirements and remove pathtools from requirements.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,15 @@
 alabaster==0.7.16
 argh==0.31.2
 Babel==2.15.0
-certifi==2024.2.2
+certifi==2024.7.4
 chardet==5.2.0
 docutils==0.18.1
 idna==3.7
 imagesize==1.4.1
 Jinja2==3.1.4
-livereload==2.6.3
+livereload==2.7.0
 MarkupSafe==2.1.5
 packaging==21.3
-pathtools==0.1.2
 port-for==0.7.2
 Pygments==2.17.2
 pyparsing==3.1.2
@@ -30,7 +29,7 @@ sphinxcontrib-qthelp==1.0.7
 sphinxcontrib-serializinghtml==1.1.10
 tornado==6.4.1
 Sphinx-Substitution-Extensions==2022.02.16
-urllib3==2.2.1
+urllib3==2.2.2
 watchdog==4.0.0
 sphinxcontrib-jquery==4.1
 sphinx-copybutton==0.5.2


### PR DESCRIPTION
Updated requirements are an amalgamation of several dependabot PRs.

pathtools is incompatible with Python 3.12 and doesn't seem to be needed in this project any more.