### PR TITLE
Remove Bessemer warning, add Stanage maintenance warning.

### DIFF
--- a/global.rst
+++ b/global.rst
@@ -13,6 +13,6 @@
 
 .. attention::
 
-    **SERVICE RISK: The Bessemer HPC cluster will be at risk from 9am on July 15th until 5pm on July 19th 2024**
+    **WARNING: From 9am on 19th August until 5pm on 2nd September there will be no access to the Stanage HPC cluster.**
 
-    For further detail, please :ref:`click this link <bessemer_maintenance_2024_06_27>`.
+    We will send an email to notify you when Stanage is back online and available for job submission.


### PR DESCRIPTION
As titled.^ Updates the global warning to remove Bessemer warning, add Stanage maintenance warning.